### PR TITLE
Fix session reference leak

### DIFF
--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeTransactionBuilder.cpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeTransactionBuilder.cpp
@@ -175,7 +175,7 @@ namespace ledger {
         BitcoinLikeTransactionBuilder::createSendScript(const std::string &address) {
             auto a = std::dynamic_pointer_cast<BitcoinLikeAddress>(BitcoinLikeAddress::parse(address, _currency));
             if (a == nullptr) {
-                throw make_exception(api::ErrorCode::RUNTIME_ERROR, "Invalid address {}", address)
+                throw make_exception(api::ErrorCode::RUNTIME_ERROR, "Invalid address {}", address);
             }
             BitcoinLikeScript script;
             if (a->isP2PKH()) {

--- a/core/src/wallet/common/AbstractWallet.cpp
+++ b/core/src/wallet/common/AbstractWallet.cpp
@@ -241,13 +241,9 @@ namespace ledger {
         }
 
         FuturePtr<api::Account> AbstractWallet::getAccount(int32_t index) {
-            soci::session sql(getDatabase()->getPool());
-            return getAccount(sql, index);
-        }
-
-        FuturePtr<api::Account> AbstractWallet::getAccount(soci::session &sql, int32_t index) {
             auto self = shared_from_this();
-            return async<std::shared_ptr<api::Account>>([self, index, &sql] () -> std::shared_ptr<api::Account> {
+            return async<std::shared_ptr<api::Account>>([self, index] () -> std::shared_ptr<api::Account> {
+                soci::session sql(self->getDatabase()->getPool());
                 auto it = self->_accounts.find(index);
                 if (it != self->_accounts.end()) {
                     auto ptr = it->second;
@@ -279,7 +275,7 @@ namespace ledger {
                 soci::session sql(getDatabase()->getPool());
                 AccountDatabaseHelper::getAccountsIndexes(sql, getWalletUid(), offset, count, indexes);
                 for (auto& index : indexes) {
-                    accounts.push_back(getAccount(sql, index));
+                    accounts.push_back(getAccount(index));
                 }
                 return core::async::sequence(getMainExecutionContext(), accounts);
             });

--- a/core/src/wallet/common/AbstractWallet.hpp
+++ b/core/src/wallet/common/AbstractWallet.hpp
@@ -146,8 +146,6 @@ namespace ledger {
             void addAccountInstanceToInstanceCache(const std::shared_ptr<AbstractAccount>& account);
 
         private:
-            FuturePtr<api::Account> getAccount(soci::session &sql, int32_t index);
-
             std::string _name;
             std::string _uid;
             std::shared_ptr<spdlog::logger> _logger;


### PR DESCRIPTION
Fix a leak of sql session in AbstractAccount#getAccount. We used to pass a reference of a session in an asynchronous method and I this point the session is destroyed by RAII. The fact that it's not crashing all the time was a side effect.