### PR TITLE
Fix the TempDir __MINGW__ vs. __clang__ compilation.

### DIFF
--- a/core/test/lib/libledger-test/TempDir.hpp
+++ b/core/test/lib/libledger-test/TempDir.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#ifndef __MINGW32__
-    #include <experimental/filesystem>
-#else
+#if defined(__MINGW32__) || defined(__clang__)
     #include <sys/stat.h>
     #include <sys/types.h>
     #include <unistd.h>
+#else
+    #include <experimental/filesystem>
 #endif // !__MINGW32__
 
 
@@ -15,7 +15,23 @@
 namespace ledger {
     namespace core {
         namespace test {
-#ifndef __MINGW32__
+#if defined(__MINGW32__) || defined (__clang__)
+            static std::string GetTempDirPath() {
+                std::random_device rd;  //Will be used to obtain a seed for the random number engine
+                std::mt19937 gen(rd());
+                return boost::lexical_cast<std::string>(gen());
+            }
+
+            static std::string CreateTempDir() {
+                auto path = GetTempDirPath();
+#ifdef __MINGW32__
+                mkdir(path.c_str());
+#else
+                mkdir(path.c_str(), 0777);
+#endif
+                return path;
+            }
+#else
             static std::string GetTempDirPath() {
                 std::random_device rd;  //Will be used to obtain a seed for the random number engine
                 std::mt19937 gen(rd());
@@ -27,18 +43,6 @@ namespace ledger {
             static std::string CreateTempDir() {
                 auto path = GetTempDirPath();
                 std::experimental::filesystem::create_directory(path);
-                return path;
-            }
-#else
-            static std::string GetTempDirPath() {
-                std::random_device rd;  //Will be used to obtain a seed for the random number engine
-                std::mt19937 gen(rd());
-                return boost::lexical_cast<std::string>(gen());
-            }
-
-            static std::string CreateTempDir() {
-                auto path = GetTempDirPath();
-                mkdir(path.c_str());
                 return path;
             }
 #endif // !__MINGW32__


### PR DESCRIPTION
This is due to the fact that Apple doesn’t provide the experimental
headers for clang…

![](https://media.makeameme.org/created/sad-cat-5b6c0d.jpg)