### PR TITLE
Fix the move constructor of Option.

### DIFF
--- a/core/src/utils/Option.hpp
+++ b/core/src/utils/Option.hpp
@@ -58,10 +58,11 @@ namespace ledger {
             Option() {};
             Option(const T& value) : _optional(value) {};
             Option(T&& value) : _optional(std::move(value)) {};
-            Option(Option<T>&& other) noexcept = default;
+            Option(Option<T>&& other) noexcept : _optional(std::move(other._optional)) {}
 
             Option(const Option<T>& option) : _optional(option._optional) {};
             Option(const std::experimental::optional<T>& optional) : _optional(optional) {};
+
             Option<T>& operator=(const Option<T>& option) {
                 if (this != &option) {
                     _optional = option._optional;


### PR DESCRIPTION
Some bit of background on this. It looks like (the class is Foo):

    Foo(Foo&&) noexcept = default;

Is not portable as it won’t compile on clang as of today. The single
solution I found was to explicitly implement that constructor
(Option<T>). I’m not sure whether it’s linked to the fact the class is
templated or what.