### PR TITLE
Add persistent UTXO sources.

### DIFF
--- a/.circleci/init_submodules.sh
+++ b/.circleci/init_submodules.sh
@@ -11,12 +11,7 @@ git submodule sync
 
 #Otherwise can't init submodules
 echo "========> Update all submodules "
-#No need for those
-#git submodule update -- djinni || echo "===========Djinni submodule already updated"
-git submodule update -- toolchains/polly || echo "===========Polly submodule already updated"
-#git submodule update -- tools/gyp || echo "===========gyp submodule already updated"
-git submodule update -- core/lib/spdlog || echo "===========spdlog submodule already updated"
-git submodule update -- core/lib/leveldb || echo "===========leveldb submodule already updated"
+git submodule update
 
 #should checkout leveldb bitcoin-fork branch on leveldb submodule
 cd $HOME/lib-ledger-core/core/lib/leveldb && git checkout bitcoin-fork

--- a/core/src/wallet/BlockchainDatabase.hpp
+++ b/core/src/wallet/BlockchainDatabase.hpp
@@ -15,6 +15,7 @@ namespace ledger {
             virtual Future<std::vector<Block>> getBlocks(uint32_t heightFrom, uint32_t heightTo) = 0;
             virtual Future<Option<Block>> getBlock(uint32_t height) = 0;
             virtual Future<Option<std::pair<uint32_t, Block>>> getLastBlock() = 0;
+            virtual Future<Option<uint32_t>> getLastBlockHeight() = 0;
         };
 
         template<typename Block>

--- a/core/src/wallet/bitcoin/Bitcoin.hpp
+++ b/core/src/wallet/bitcoin/Bitcoin.hpp
@@ -18,7 +18,7 @@ namespace ledger {
             };
 
             static auto optionUint64ToBigInt = [](const Option<uint64_t>& value) -> Option<BigInt> {
-                return value.map<BigInt>([](const uint64_t& val) { return BigInt(val); });
+                return value.map<BigInt>([](const uint64_t& val) { return BigInt(static_cast<unsigned long long>(val)); });
             };
 
             struct Block {

--- a/core/src/wallet/bitcoin/PersistentUTXOSource.cpp
+++ b/core/src/wallet/bitcoin/PersistentUTXOSource.cpp
@@ -30,7 +30,7 @@ namespace ledger {
                             // no block in the DB so far; persist the source list
                             auto block = std::vector<uint8_t>();
                             serialization::save(sourceList, block);
-                            self->_db->AddBlock(self->_inMemorySource->currentSynchronizedHeight(), block);
+                            self->_db->AddBlock(inMemHeight, block);
                         }
 
                         return sourceList;

--- a/core/src/wallet/bitcoin/PersistentUTXOSource.cpp
+++ b/core/src/wallet/bitcoin/PersistentUTXOSource.cpp
@@ -18,7 +18,7 @@ namespace ledger {
                     return _db->GetLastBlock().template map<UTXOSourceList>(ctx, [=](const Option<std::pair<uint32_t, db::ReadOnlyBlockchainDB::RawBlock>>& lastBlock) {
                         if (lastBlock.hasValue()) {
                             auto dbHeight = std::get<0>(*lastBlock);
-                            auto inMemHeight = self->_inMemorySource->currentSynchronizedHeight();
+                            auto inMemHeight = sourceList.height;
 
                             if (dbHeight < inMemHeight) {
                                 // the in-memory source has advanced; we must persist the new state

--- a/core/src/wallet/bitcoin/PersistentUTXOSource.cpp
+++ b/core/src/wallet/bitcoin/PersistentUTXOSource.cpp
@@ -16,9 +16,10 @@ namespace ledger {
 
                 return _inMemorySource->getUTXOs(ctx).template flatMap<UTXOSourceList>(ctx, [=](const UTXOSourceList& sourceList) {
                     return _db->GetLastBlock().template map<UTXOSourceList>(ctx, [=](const Option<std::pair<uint32_t, db::ReadOnlyBlockchainDB::RawBlock>>& lastBlock) {
+                        auto inMemHeight = sourceList.height;
+
                         if (lastBlock.hasValue()) {
                             auto dbHeight = std::get<0>(*lastBlock);
-                            auto inMemHeight = sourceList.height;
 
                             if (dbHeight < inMemHeight) {
                                 // the in-memory source has advanced; we must persist the new state

--- a/core/src/wallet/bitcoin/PersistentUTXOSource.cpp
+++ b/core/src/wallet/bitcoin/PersistentUTXOSource.cpp
@@ -1,0 +1,42 @@
+#include <bytes/serialization.hpp>
+#include <wallet/bitcoin/PersistentUTXOSource.hpp>
+#include <database/BlockchainDB.hpp>
+
+namespace ledger {
+    namespace core {
+        namespace bitcoin {
+            PersistentUTXOSource::PersistentUTXOSource(
+                const std::shared_ptr<db::BlockchainDB>& blockchainDB,
+                const std::shared_ptr<UTXOSourceInMemory>& inMemorySource
+            ) : _db(blockchainDB), _inMemorySource(inMemorySource) {
+            }
+
+            Future<UTXOSourceList> PersistentUTXOSource::getUTXOs(std::shared_ptr<api::ExecutionContext> ctx) {
+                auto self = shared_from_this();
+
+                return _inMemorySource->getUTXOs(ctx).template flatMap<UTXOSourceList>(ctx, [=](const UTXOSourceList& sourceList) {
+                    return _db->GetLastBlock().template map<UTXOSourceList>(ctx, [=](const Option<std::pair<uint32_t, db::ReadOnlyBlockchainDB::RawBlock>>& lastBlock) {
+                        if (lastBlock.hasValue()) {
+                            auto dbHeight = std::get<0>(*lastBlock);
+                            auto inMemHeight = self->_inMemorySource->currentSynchronizedHeight();
+
+                            if (dbHeight < inMemHeight) {
+                                // the in-memory source has advanced; we must persist the new state
+                                auto block = std::vector<uint8_t>();
+                                serialization::save(sourceList, block);
+                                self->_db->AddBlock(inMemHeight, block);
+                            }
+                        } else {
+                            // no block in the DB so far; persist the source list
+                            auto block = std::vector<uint8_t>();
+                            serialization::save(sourceList, block);
+                            self->_db->AddBlock(self->_inMemorySource->currentSynchronizedHeight(), block);
+                        }
+
+                        return sourceList;
+                    });
+                });
+            }
+        }
+    }
+}

--- a/core/src/wallet/bitcoin/PersistentUTXOSource.hpp
+++ b/core/src/wallet/bitcoin/PersistentUTXOSource.hpp
@@ -1,9 +1,9 @@
 /*
  *
- * UTXOSource
+ * PersistentUTXOSource
  * ledger-core
  *
- * Created by Dimitri Sabadie on 13/12/2018.
+ * Created by Dimitri Sabadie on 21/12/2018.
  *
  * The MIT License (MIT)
  *
@@ -31,32 +31,28 @@
 
 #pragma once
 
-#include <functional>
-#include <map>
-#include <memory>
-#include <set>
-#include <string>
-#include <utility>
-
-#include <wallet/bitcoin/UTXO.hpp>
 #include <api/ExecutionContext.hpp>
 #include <async/Future.hpp>
+#include <database/BlockchainDB.hpp>
+#include <wallet/bitcoin/UTXOSource.hpp>
+#include <wallet/bitcoin/UTXOSourceInMemory.hpp>
 
 namespace ledger {
     namespace core {
         namespace bitcoin {
-            /// An UTXO source (Bitcoin-like currencies only).
-            ///
-            /// Such a type represents a *source* of UTXO. That is, an abstracted way to get a set of
-            /// UTXOs. It might take the set from a database, from a cache, invent them on the fly, etc.
-            struct UTXOSource {
-                virtual ~UTXOSource() = default;
+            class PersistentUTXOSource: public UTXOSource, public std::enable_shared_from_this<PersistentUTXOSource> {
+                std::shared_ptr<db::BlockchainDB> _db; ///< Database used for UTXOs persistence.
+                std::shared_ptr<UTXOSourceInMemory> _inMemorySource; ///< Memory cache.
 
-                /// Get the list of UTXOs from this source.
-                ///
-                /// The set of string is a list of all known addresses (both input and outputs) that
-                /// were used in past transactions.
-                virtual Future<UTXOSourceList> getUTXOs(std::shared_ptr<api::ExecutionContext> ctx) = 0;
+            public:
+                PersistentUTXOSource(
+                    const std::shared_ptr<db::BlockchainDB>& blockchainDB,
+                    const std::shared_ptr<UTXOSourceInMemory>& inMemorySource
+                );
+
+                ~PersistentUTXOSource() = default;
+
+                Future<UTXOSourceList> getUTXOs(std::shared_ptr<api::ExecutionContext> ctx) override;
             };
         }
     }

--- a/core/src/wallet/bitcoin/UTXO.cpp
+++ b/core/src/wallet/bitcoin/UTXO.cpp
@@ -7,12 +7,12 @@ namespace ledger {
                 : amount(amount), address(address) {
             }
 
-            UTXOSourceList::UTXOSourceList(std::map<UTXOKey, UTXOValue>&& available, std::set<UTXOKey>&& spent)
-                : available(std::move(available)), spent(std::move(spent)) {
+            UTXOSourceList::UTXOSourceList(std::map<UTXOKey, UTXOValue>&& available, std::set<UTXOKey>&& spent, uint32_t height)
+                : available(std::move(available)), spent(std::move(spent)), height(height) {
             }
 
-            UTXOSourceList::UTXOSourceList(const std::map<UTXOKey, UTXOValue>& available, const std::set<UTXOKey>& spent)
-                : available(available), spent(spent) {
+            UTXOSourceList::UTXOSourceList(const std::map<UTXOKey, UTXOValue>& available, const std::set<UTXOKey>& spent, uint32_t height)
+                : available(available), spent(spent), height(height) {
             }
 
         }

--- a/core/src/wallet/bitcoin/UTXO.hpp
+++ b/core/src/wallet/bitcoin/UTXO.hpp
@@ -27,6 +27,11 @@ namespace ledger {
                 std::string address;
 
                 UTXOValue(const BigInt& satoshis, const std::string& address);
+
+                template <class Archive>
+                void serialize(Archive& ar) {
+                    ar(amount, address);
+                }
             };
 
             /// An UTXO source list.
@@ -36,10 +41,18 @@ namespace ledger {
             /// from other sources).
             struct UTXOSourceList {
                 std::map<UTXOKey, UTXOValue> available; ///< Available UTXOs.
-                std::set<UTXOKey> spent; ///< Spent UTXOs we don’t know / can’t resolve (yet).
+                std::set<UTXOKey> spent; ///< Spent UTXOs we donâ€™t know / canâ€™t resolve (yet).
+
                 UTXOSourceList() = default;
+
                 UTXOSourceList(std::map<UTXOKey, UTXOValue>&& available, std::set<UTXOKey>&& spent);
+
                 UTXOSourceList(const std::map<UTXOKey, UTXOValue>& available, const std::set<UTXOKey>& spent);
+
+                template <class Archive>
+                void serialize(Archive& ar) {
+                    ar(available, spent);
+                }
             };
         }
     }

--- a/core/src/wallet/bitcoin/UTXO.hpp
+++ b/core/src/wallet/bitcoin/UTXO.hpp
@@ -23,6 +23,7 @@ namespace ledger {
             struct UTXOValue {
                 /// Amount.
                 BigInt amount;
+
                 /// Address that was used.
                 std::string address;
 
@@ -42,12 +43,13 @@ namespace ledger {
             struct UTXOSourceList {
                 std::map<UTXOKey, UTXOValue> available; ///< Available UTXOs.
                 std::set<UTXOKey> spent; ///< Spent UTXOs we don’t know / can’t resolve (yet).
+                uint32_t height; ///< Block height at which the source was generated for.
 
                 UTXOSourceList() = default;
 
-                UTXOSourceList(std::map<UTXOKey, UTXOValue>&& available, std::set<UTXOKey>&& spent);
+                UTXOSourceList(std::map<UTXOKey, UTXOValue>&& available, std::set<UTXOKey>&& spent, uint32_t height);
 
-                UTXOSourceList(const std::map<UTXOKey, UTXOValue>& available, const std::set<UTXOKey>& spent);
+                UTXOSourceList(const std::map<UTXOKey, UTXOValue>& available, const std::set<UTXOKey>& spent, uint32_t height);
 
                 template <class Archive>
                 void serialize(Archive& ar) {

--- a/core/src/wallet/bitcoin/UTXOSource.hpp
+++ b/core/src/wallet/bitcoin/UTXOSource.hpp
@@ -53,9 +53,6 @@ namespace ledger {
                 virtual ~UTXOSource() = default;
 
                 /// Get the list of UTXOs from this source.
-                ///
-                /// The set of string is a list of all known addresses (both input and outputs) that
-                /// were used in past transactions.
                 virtual Future<UTXOSourceList> getUTXOs(std::shared_ptr<api::ExecutionContext> ctx) = 0;
             };
         }

--- a/core/src/wallet/bitcoin/UTXOSourceInMemory.cpp
+++ b/core/src/wallet/bitcoin/UTXOSourceInMemory.cpp
@@ -26,7 +26,7 @@ namespace ledger {
             return _blockDB->getLastBlockHeight().flatMap<UTXOSourceList>(ctx, [=](const Option<uint32_t>& lastBlockHeight) {
                 // compute the list of blocks we need to retreive
                 if (lastBlockHeight) {
-                    auto currentHeight = lastBlockHeight.getValue();
+                    auto currentHeight = lastBlockHeight.getValue() + 1;
 
                     if (currentHeight > self->_lastHeight) {
                         // there are blocks we don’t know about

--- a/core/src/wallet/bitcoin/UTXOSourceInMemory.cpp
+++ b/core/src/wallet/bitcoin/UTXOSourceInMemory.cpp
@@ -23,10 +23,10 @@ namespace ledger {
             auto self = shared_from_this();
 
             // get the last block height
-            return _blockDB->getLastBlock().map<UTXOSourceList>(ctx, [&](const Option<std::pair<uint32_t, BitcoinLikeNetwork::FilledBlock>>& lastBlockPair) {
+            return _blockDB->getLastBlockHeight().map<UTXOSourceList>(ctx, [&](const Option<uint32_t>& lastBlockHeight) {
                 // compute the list of blocks we need to retreive
-                if (lastBlockPair) {
-                    auto currentHeight = lastBlockPair->first;
+                if (lastBlockHeight) {
+                    auto currentHeight = lastBlockHeight;
                     auto spent = std::set<UTXOKey>();
 
                     if (currentHeight > self->_lastHeight) {

--- a/core/src/wallet/bitcoin/UTXOSourceInMemory.cpp
+++ b/core/src/wallet/bitcoin/UTXOSourceInMemory.cpp
@@ -96,6 +96,10 @@ namespace ledger {
             _cache.clear();
             _lastHeight = _lowestHeight;
         }
+
+        uint32_t UTXOSourceInMemory::currentSynchronizedHeight() {
+            return _lastHeight;
+        }
     }
     }
 }

--- a/core/src/wallet/bitcoin/UTXOSourceInMemory.cpp
+++ b/core/src/wallet/bitcoin/UTXOSourceInMemory.cpp
@@ -77,16 +77,16 @@ namespace ledger {
                             self->_lastHeight = currentHeight;
                         });
                     }
-                    
+
                     // copy the UTXO map and move it in our list
                     auto utxos = self->_cache;
 
                     // create the resulting UTXO source list
-                    auto sourceList = UTXOSourceList(std::move(utxos), std::move(spent));
+                    auto sourceList = UTXOSourceList(std::move(utxos), std::move(spent), currentHeight);
                     return sourceList;
                 } else {
                     // no data, just return nothing
-                    return UTXOSourceList({}, {});
+                    return UTXOSourceList({}, {}, 0);
                 }
             });
         }

--- a/core/src/wallet/bitcoin/UTXOSourceInMemory.hpp
+++ b/core/src/wallet/bitcoin/UTXOSourceInMemory.hpp
@@ -92,6 +92,9 @@ namespace ledger {
 
                 /// Invalidate the UTXO cache.
                 void invalidate();
+
+                /// Get the height we’re currently synchronized to.
+                uint32_t currentSynchronizedHeight();
             };
         }
     }

--- a/core/src/wallet/common/InMemoryBlockchainDatabase.hpp
+++ b/core/src/wallet/common/InMemoryBlockchainDatabase.hpp
@@ -42,6 +42,18 @@ namespace ledger {
                     return Future<Option<std::pair<uint32_t, Block>>>::successful(Option<std::pair<uint32_t, Block>>(*lastIt));
                 }
 
+                Future<Option<uint32_t>> getLastBlockHeight() override {
+                    std::lock_guard<std::mutex> lock(_lock);
+
+                    if (_blocks.empty()) {
+                        return Future<Option<uint32_t>>::successful(Option<uint32_t>());
+                    }
+
+                    auto lastIt = _blocks.end();
+                    lastIt--;
+                    return Future<Option<uint32_t>>::successful(Option<uint32_t>(lastIt->first));
+                }
+
                 void addBlock(uint32_t height, const Block& block) override {
                     std::lock_guard<std::mutex> lock(_lock);
                     _blocks[height] = block;

--- a/core/src/wallet/common/OperationServiceOnDB.hpp
+++ b/core/src/wallet/common/OperationServiceOnDB.hpp
@@ -39,9 +39,9 @@ namespace ledger {
                         _unstableBlocksDB->getBlocks(fromBlock, toBlock),
                         _stableBlocksDB->getBlocks(fromBlock, toBlock)
                     };
-                    auto self = shared_from_this();
+                    auto self = this->shared_from_this();
                     return executeAll(_executionContext, futures)
-                        .map<std::vector<Operation>>(_executionContext, [self](const std::vector<std::vector<FilledBlock>>& vectorBlocks) {
+                        .template map<std::vector<Operation>>(_executionContext, [self](const std::vector<std::vector<FilledBlock>>& vectorBlocks) {
                             std::vector<Operation> res;
                             self->addOperations(vectorBlocks[0], api::TrustLevel::UNTRUSTED, res);
                             self->addOperations(vectorBlocks[1], api::TrustLevel::TRUSTED, res);
@@ -50,9 +50,9 @@ namespace ledger {
                 }
 
                 Future<std::vector<Operation>> getPendingOperations() override {
-                    auto self = shared_from_this();
+                    auto self = this->shared_from_this();
                     return _pendingTransactions->getLastBlock()
-                        .map<std::vector<Operation>>(_executionContext, [self](const Option<std::pair<uint32_t, FilledBlock>>& lastBlock) {
+                        .template map<std::vector<Operation>>(_executionContext, [self](const Option<std::pair<uint32_t, FilledBlock>>& lastBlock) {
                             std::vector<Operation> res;
                             if (!lastBlock.hasValue())
                                 return res;

--- a/core/src/wallet/common/PersistentBlockchainDatabase.hpp
+++ b/core/src/wallet/common/PersistentBlockchainDatabase.hpp
@@ -80,6 +80,15 @@ namespace ledger {
                     });
                 }
 
+                Future<Option<uint32_t>> getLastBlockHeight() override {
+                    return _persistentDB->GetLastBlock()
+                        .map<Option<uint32_t>>(_context, [](const Option<std::pair<uint32_t, RawBlock>>& rawBlock) {
+                        return rawBlock.map<uint32_t>([](const std::pair<uint32_t, RawBlock>& rawBlock) {
+                            return rawBlock.first;
+                        });
+                    });
+                }
+
                 void addBlock(uint32_t height, const Block& block) override {
                     RawBlock rawBlock = serialize<Block>(block);
                     _persistentDB->AddBlock(height, rawBlock);

--- a/core/test/wallet/AccountSynchronizer_test.cpp
+++ b/core/test/wallet/AccountSynchronizer_test.cpp
@@ -109,7 +109,7 @@ TEST_F(AccountSyncTest, NoStableBlocksInBlockchain) {
     {
         BL{ 1, "block 1",
         {
-            TR{ { "X" },{ { "0", 10000 } } }
+            TR{ { { "X", 0 } }, { { "0", 10000 } } }
         } }
     };
     setBlockchain(bch);

--- a/core/test/wallet/AccountSynchronizer_test.cpp
+++ b/core/test/wallet/AccountSynchronizer_test.cpp
@@ -130,7 +130,7 @@ TEST_F(AccountSyncTest, HappyPath) {
     setupFakeDatabases();
     std::vector<BL> bch;
     for (uint32_t i = 1; i <= 5; ++i)
-        bch.push_back(BL{ i, "block " + boost::lexical_cast<std::string>(i),{ TR{ { "X" },{ { "0", 10000 } } } } });
+        bch.push_back(BL{ i, "block " + boost::lexical_cast<std::string>(i),{ TR{ { { "X", 0 } }, { { "0", 10000 } } } } });
     setBlockchain(bch);
     {
         testing::Sequence s;
@@ -158,7 +158,7 @@ TEST_F(AccountSyncTest, NoUpdatesNeeded) {
     fakeStableDB.addBlock(2, toFilledBlock(BL{ 2, "block 2", {} }));
     std::vector<BL> bch;
     for (uint32_t i = 1; i <= 5; ++i)
-        bch.push_back(BL{ i, "block " + boost::lexical_cast<std::string>(i),{ TR{ { "X" },{ { "0", 10000 } } } } });
+        bch.push_back(BL{ i, "block " + boost::lexical_cast<std::string>(i),{ TR{ { { "X", 0 } }, { { "0", 10000 } } } } });
     EXPECT_CALL(*stableBlocksDBMock, addBlock(_, _)).Times(1);
     setBlockchain(bch);
     {

--- a/core/test/wallet/BlocksSynchronizer_test.cpp
+++ b/core/test/wallet/BlocksSynchronizer_test.cpp
@@ -73,7 +73,7 @@ namespace ledger {
                 {
                     BL{ 1, "block 1",
                     {
-                        TR{ { "X" },{ { "0", 10000 } } }
+                        TR{ { { "X", 0 } },{ { "0", 10000 } } }
                     }}
                 };
                 setBlockchain(bch);
@@ -91,8 +91,8 @@ namespace ledger {
                 {
                     BL{ 1, "block 1",
                     {
-                        TR{ { "X" },{ { "0", 10000 } } },
-                        TR{ { "Y" },{ { "0", 10000 } } }
+                        TR{ { { "X", 0 } },{ { "0", 10000 } } },
+                        TR{ { { "Y", 0 } },{ { "0", 10000 } } }
                     } }
                 };
                 setBlockchain(bch);
@@ -110,11 +110,11 @@ namespace ledger {
                 {
                     BL{ 1, "block 1",
                     {
-                        TR{ { "X" },{ { "0", 10000 } } },
+                        TR{ { { "X", 0 } }, { { "0", 10000 } } },
                     } },
                     BL{ 2, "block 2",
                     {
-                        TR{ { "X" },{ { "0", 10000 } } },
+                        TR{ { { "X", 0 } }, { { "0", 10000 } } },
                     } },
                 };
                 setBlockchain(bch);
@@ -136,11 +136,11 @@ namespace ledger {
                 {
                     BL{ 1, "block 1",
                     {
-                        TR{ { "X" },{ { "0", 10000 } } },
+                        TR{ { { "X", 0 } }, { { "0", 10000 } } },
                     } },
                     BL{ 2, "block 2",
                     {
-                        TR{ { "X" },{ { "Y", 10000 } } },
+                        TR{ { { "X", 0 } }, { { "Y", 10000 } } },
                     } },
                 };
                 setBlockchain(bch);
@@ -160,11 +160,11 @@ namespace ledger {
                 {
                     BL{ 1, "block 1",
                     {
-                        TR{ { "X" },{ { "0", 10000 } } },
+                        TR{ { { "X", 0 } }, { { "0", 10000 } } },
                     } },
                     BL{ 2, "block 2",
                     {
-                        TR{ { "X" },{ { "0", 10000 } } },
+                        TR{ { { "X", 0 } }, { { "0", 10000 } } },
                     } },
                 };
                 setBlockchain(bch);
@@ -184,11 +184,11 @@ namespace ledger {
                 {
                     BL{ 1, "block 1",
                     {
-                        TR{ { "X" },{ { "0", 10000 } } },
-                        TR{ { "X" },{ { "1", 10000 } } },
-                        TR{ { "X" },{ { "2", 10000 } } },
-                        TR{ { "X" },{ { "3", 10000 } } },
-                        TR{ { "X" },{ { "4", 10000 } } },
+                        TR{ { { "X", 0 } }, { { "0", 10000 } } },
+                        TR{ { { "X", 0 } }, { { "1", 10000 } } },
+                        TR{ { { "X", 0 } }, { { "2", 10000 } } },
+                        TR{ { { "X", 0 } }, { { "3", 10000 } } },
+                        TR{ { { "X", 0 } }, { { "4", 10000 } } },
                     } },
                 };
                 setBlockchain(bch);
@@ -212,19 +212,19 @@ namespace ledger {
                 {
                     BL{ 1, "block 1",
                     {
-                        TR{ { "X" },{ { "0", 10000 } } }
+                        TR{ { { "X", 0 } }, { { "0", 10000 } } }
                     }},
                     BL{ 2, "block 2",
                     {
-                        TR{ { "X" },{ { "1", 10000 } } }
+                        TR{ { { "X", 0 } }, { { "1", 10000 } } }
                     } },
                     BL{ 3, "block 3",
                     {
-                        TR{ { "X" },{ { "2", 10000 } } }
+                        TR{ { { "X", 0 } }, { { "2", 10000 } } }
                     } },
                     BL{ 4, "block 4",
                     {
-                        TR{ { "X" },{ { "3", 10000 } } }
+                        TR{ { { "X", 0 } }, { { "3", 10000 } } }
                     } }
                 };
                 setBlockchain(bch);
@@ -255,7 +255,7 @@ namespace ledger {
                 {
                     ::testing::Sequence s;
                     for (uint32_t i = 1; i <= 300; ++i) {
-                        auto b = BL{ i, "block " + boost::lexical_cast<std::string>(i),{ TR{ { "X" },{ { "0", 10000 } } } } };
+                        auto b = BL{ i, "block " + boost::lexical_cast<std::string>(i), { TR{ { { "X", 0 } }, { { "0", 10000 } } } } };
                         bch.push_back(b);
                         EXPECT_CALL(*blocksDBMock, addBlock(b.height, Truly(Same(b))));
                     }
@@ -282,10 +282,10 @@ namespace ledger {
                 setupFakeKeychains();
                 std::vector<BL> bch;
                 for (uint32_t i = 1; i <= 200; ++i) {
-                    auto b = BL{ 1, "block 1",{ TR{ { "X" + boost::lexical_cast<std::string>(i) },{ { "0", 10000 } } } } };
+                    auto b = BL{ 1, "block 1",{ TR{ { { "X" + boost::lexical_cast<std::string>(i), 0 } }, { { "0", 10000 } } } } };
                     bch.push_back(b);
                 }
-                bch.push_back(BL{ 2, "block 2",{ TR{ { "X" },{ { "0", 10000 } } } } });
+                bch.push_back(BL{ 2, "block 2",{ TR{ { { "X", 0 } },{ { "0", 10000 } } } } });
                 setBlockchain(bch);
 
                 EXPECT_CALL(*blocksDBMock, addBlock(_, _)).Times(0);
@@ -305,7 +305,7 @@ namespace ledger {
                 {
                     ::testing::Sequence s;
                     for (uint32_t i = 1; i <= LAST_BLOCK; i += 500) {
-                        auto b = BL{ i, "block " + boost::lexical_cast<std::string>(i),{ TR{ { "X" },{ { boost::lexical_cast<std::string>((i / 500) % 500), 10000 } } } } };
+                        auto b = BL{ i, "block " + boost::lexical_cast<std::string>(i) ,{ TR{ { { "X", 0 } } ,{ { boost::lexical_cast<std::string>((i / 500) % 500), 10000 } } } } };
                         bch.push_back(b);
                         EXPECT_CALL(*blocksDBMock, addBlock(b.height, Truly(Same(b)))).Times(1);
                     }

--- a/core/test/wallet/CMakeLists.txt
+++ b/core/test/wallet/CMakeLists.txt
@@ -10,6 +10,7 @@ endif (APPLE)
 
 add_executable(ledger-core-wallet-tests
     main.cpp
+    CommonFixtureFunctions.cpp
     InMemoryPartialBlocksDB_test.cpp
     BlocksSynchronizer_test.cpp
     Helpers.cpp

--- a/core/test/wallet/CMakeLists.txt
+++ b/core/test/wallet/CMakeLists.txt
@@ -8,20 +8,20 @@ if (APPLE)
     add_definitions(-D__GLIBCXX__)
 endif (APPLE)
 
-add_executable(ledger-core-wallet-tests 
-main.cpp 
-InMemoryPartialBlocksDB_test.cpp 
-BlocksSynchronizer_test.cpp
-Helpers.cpp
-CommonFixtureFunctions.cpp
-ChangeKeychain_test.cpp
-PersistentBlockchainDatabase_test.cpp
-AccountSynchronizer_test.cpp
-InMemoryBlockchainDatabase_test.cpp
-UTXOServiceSourceBased_test.cpp
-BalanceServiceUTXOBased_test.cpp
-OperationServiceOnDB_test.cpp
-OperationFromBitcoinTransaction_test.cpp
+add_executable(ledger-core-wallet-tests
+    main.cpp
+    InMemoryPartialBlocksDB_test.cpp
+    BlocksSynchronizer_test.cpp
+    Helpers.cpp
+    ChangeKeychain_test.cpp
+    PersistentBlockchainDatabase_test.cpp
+    AccountSynchronizer_test.cpp
+    InMemoryBlockchainDatabase_test.cpp
+    UTXOServiceSourceBased_test.cpp
+    BalanceServiceUTXOBased_test.cpp
+    OperationServiceOnDB_test.cpp
+    OperationFromBitcoinTransaction_test.cpp
+    UTXOSourceInMemory_test.cpp
 )
 
 target_link_libraries(ledger-core-wallet-tests gtest gtest_main)

--- a/core/test/wallet/CommonFixtureFunctions.cpp
+++ b/core/test/wallet/CommonFixtureFunctions.cpp
@@ -15,6 +15,7 @@ namespace ledger {
                 ON_CALL(*mock, getBlocks(_, _)).WillByDefault(Invoke(&fake, &BlocksDatabase::getBlocks));
                 ON_CALL(*mock, getBlock(_)).WillByDefault(Invoke(&fake, &BlocksDatabase::getBlock));
                 ON_CALL(*mock, getLastBlock()).WillByDefault(Invoke(&fake, &BlocksDatabase::getLastBlock));
+                ON_CALL(*mock, getLastBlockHeight()).WillByDefault(Invoke(&fake, &BlocksDatabase::getLastBlockHeight));
             }
 
         }

--- a/core/test/wallet/Helpers.hpp
+++ b/core/test/wallet/Helpers.hpp
@@ -70,7 +70,7 @@ namespace ledger {
 
             //Transaction
             struct TR {
-                std::vector<std::string> inputs;
+                std::vector<std::pair<std::string, uint32_t>> inputs;
                 /// The first part of the pair is the address and the second part is the amount.
                 std::vector<std::pair<std::string, uint32_t>> outputs;
             };

--- a/core/test/wallet/Helpers.hpp
+++ b/core/test/wallet/Helpers.hpp
@@ -44,7 +44,7 @@ namespace ledger {
 
             class SimpleExecutionContext : public api::ExecutionContext {
             public:
-                virtual void execute(const std::shared_ptr<api::Runnable> & runnable) {
+                virtual void execute(const std::shared_ptr<api::Runnable> & runnable) override {
                     q.push(runnable);
                 }
 

--- a/core/test/wallet/Helpers.hpp
+++ b/core/test/wallet/Helpers.hpp
@@ -74,6 +74,7 @@ namespace ledger {
                 /// The first part of the pair is the address and the second part is the amount.
                 std::vector<std::pair<std::string, uint32_t>> outputs;
             };
+
             //Block
             struct BL {
                 uint32_t height;

--- a/core/test/wallet/Helpers.hpp
+++ b/core/test/wallet/Helpers.hpp
@@ -71,6 +71,7 @@ namespace ledger {
             //Transaction
             struct TR {
                 std::vector<std::string> inputs;
+                /// The first part of the pair is the address and the second part is the amount.
                 std::vector<std::pair<std::string, uint32_t>> outputs;
             };
             //Block

--- a/core/test/wallet/Mocks.hpp
+++ b/core/test/wallet/Mocks.hpp
@@ -40,6 +40,7 @@ namespace ledger {
                 MOCK_METHOD2(getBlocks, Future<std::vector<BitcoinLikeNetwork::FilledBlock>>(uint32_t heightFrom, uint32_t heightTo));
                 MOCK_METHOD1(getBlock, Future<Option<BitcoinLikeNetwork::FilledBlock>>(uint32_t height));
                 MOCK_METHOD0(getLastBlock, Future<Option<std::pair<uint32_t, BitcoinLikeNetwork::FilledBlock>>>());
+                MOCK_METHOD0(getLastBlockHeight, Future<Option<uint32_t>>());
             };
 
             class BlockchainDBMock : public db::BlockchainDB {

--- a/core/test/wallet/OperationServiceOnDB_test.cpp
+++ b/core/test/wallet/OperationServiceOnDB_test.cpp
@@ -64,7 +64,7 @@ TEST_F(OperationServiceOnDBTest, TransactionInStableOnly) {
     auto filledBlock = toFilledBlock(
         BL{ 10, "block 10",
         {
-            TR{ { "X" },{ { "0", 10000 } } }
+            TR{ { { "X", 0 } }, { { "0", 10000 } } }
         } });
     fakeStableDB.addBlock(10, filledBlock);
     EXPECT_CALL(*stableDBMock, getBlocks(0, 1000000)).Times(1);
@@ -85,7 +85,7 @@ TEST_F(OperationServiceOnDBTest, TransactionInUnStableOnly) {
     auto filledBlock = toFilledBlock(
         BL{ 10, "block 10",
         {
-            TR{ { "X" },{ { "0", 10000 } } }
+            TR{ { { "X", 0 } }, { { "0", 10000 } } }
         } });
     fakeUnstableDB.addBlock(10, filledBlock);
     EXPECT_CALL(*stableDBMock, getBlocks(0, 1000000)).Times(1);
@@ -106,7 +106,7 @@ TEST_F(OperationServiceOnDBTest, TransactionInPendingOnly) {
     auto filledBlock = toFilledBlock(
         BL{ 10, "block 10",
         {
-            TR{ { "X" },{ { "0", 10000 } } }
+            TR{ { { "X", 0 } }, { { "0", 10000 } } }
         } });
     fakePendingDB.addBlock(0, filledBlock);
     EXPECT_CALL(*stableDBMock, getBlocks(0, 1000000)).Times(1);
@@ -127,18 +127,18 @@ TEST_F(OperationServiceOnDBTest, TransactionInAllDB) {
     auto filledBlock = toFilledBlock(
         BL{ 10, "block 10",
         {
-            TR{ { "Z" },{ { "0", 10000 } } }
+            TR{ { { "Z", 0 } }, { { "0", 10000 } } }
         } });
     fakePendingDB.addBlock(0, filledBlock);
     fakeStableDB.addBlock(10, toFilledBlock(
         BL{ 10, "block 10",
         {
-            TR{ { "X" },{ { "0", 10000 } } }
+            TR{ { { "X", 0 } }, { { "0", 10000 } } }
         } }));
     fakeUnstableDB.addBlock(10, toFilledBlock(
         BL{ 11, "block 11",
         {
-            TR{ { "Y" },{ { "0", 10000 } } }
+            TR{ { { "Y", 0 } }, { { "0", 10000 } } }
         } }));
     EXPECT_CALL(*stableDBMock, getBlocks(0, 1000000)).Times(1);
     EXPECT_CALL(*unstableDBMock, getBlocks(0, 1000000)).Times(1);

--- a/core/test/wallet/UTXOSourceInMemory_test.cpp
+++ b/core/test/wallet/UTXOSourceInMemory_test.cpp
@@ -41,3 +41,14 @@ TEST_F(UTXOSourceInMemoryFixture, NoInitialUTXO) {
     EXPECT_TRUE(sourceList.available.empty());
     EXPECT_TRUE(sourceList.spent.empty());
 }
+
+TEST_F(UTXOSourceInMemoryFixture, PruneUsedUTXO) {
+    auto future = _source->getUTXOs(_ctx);
+    auto filledBlock = toFilledBlock(
+        BL{ 10, "block 10",
+            {
+                TR{ { "X" }, { { "0", 10000 } } }
+            }
+        }
+    );
+}

--- a/core/test/wallet/UTXOSourceInMemory_test.cpp
+++ b/core/test/wallet/UTXOSourceInMemory_test.cpp
@@ -1,28 +1,43 @@
+#include <CommonFixtureFunctions.hpp>
 #include <Mocks.hpp>
 #include <Helpers.hpp>
+#include <async/Future.hpp>
 #include <gtest/gtest.h>
 #include <memory>
+#include <wallet/common/InMemoryBlockchainDatabase.hpp>
 #include <wallet/bitcoin/UTXOSourceInMemory.hpp>
 
 using namespace ledger::core;
+using namespace ledger::core::common;
 using namespace ledger::core::bitcoin;
 using namespace ledger::core::tests;
+using namespace ::testing;
 
-struct UTXOSourceInMemoryTest: ::testing::Test {
+struct UTXOSourceInMemoryFixture: virtual Test, CommonFixtureFunctions {
 protected:
     std::shared_ptr<SimpleExecutionContext> _ctx;
-    UTXOSourceInMemory _source;
+    std::shared_ptr<NiceMock<BlocksDBMock>> _blocksDB;
+    std::shared_ptr<InMemoryBlockchainDatabase<BitcoinLikeNetwork::FilledBlock>> _fakeDB;
+    std::shared_ptr<UTXOSourceInMemory> _source;
 
 public:
-    UTXOSourceInMemoryTest()
-        : _ctx(new SimpleExecutionContext()),
-          _source(std::make_shared(BlocksDBMock),
-                  std::make_shared(KeychainRegistryMock)) {
+    UTXOSourceInMemoryFixture()
+        : _ctx(std::make_shared<SimpleExecutionContext>()),
+          _blocksDB(std::make_shared<NiceMock<BlocksDBMock>>()),
+          _fakeDB(std::make_shared<InMemoryBlockchainDatabase<BitcoinLikeNetwork::FilledBlock>>(_ctx)),
+          _source(std::make_shared<UTXOSourceInMemory>(
+              _blocksDB,
+              std::make_shared<KeychainRegistryMock>()
+          )) {
+        linkMockDbToFake(_blocksDB, *_fakeDB);
     }
-}
+};
 
-struct UTXOSourceInMemorySimpleTest: UTXOSourceInMemoryTest;
+TEST_F(UTXOSourceInMemoryFixture, NoInitialUTXO) {
+    auto future = _source->getUTXOs(_ctx);
+    _ctx->wait();
+    auto sourceList = getFutureResult(future);
 
-TEST_F(UTXOSourceInMemorySimpleTest, NoInitialUTXO) {
-    EXPECT_TRUE(false);
+    EXPECT_TRUE(sourceList.available.empty());
+    EXPECT_TRUE(sourceList.spent.empty());
 }

--- a/core/test/wallet/UTXOSourceInMemory_test.cpp
+++ b/core/test/wallet/UTXOSourceInMemory_test.cpp
@@ -1,0 +1,28 @@
+#include <Mocks.hpp>
+#include <Helpers.hpp>
+#include <gtest/gtest.h>
+#include <memory>
+#include <wallet/bitcoin/UTXOSourceInMemory.hpp>
+
+using namespace ledger::core;
+using namespace ledger::core::bitcoin;
+using namespace ledger::core::tests;
+
+struct UTXOSourceInMemoryTest: ::testing::Test {
+protected:
+    std::shared_ptr<SimpleExecutionContext> _ctx;
+    UTXOSourceInMemory _source;
+
+public:
+    UTXOSourceInMemoryTest()
+        : _ctx(new SimpleExecutionContext()),
+          _source(std::make_shared(BlocksDBMock),
+                  std::make_shared(KeychainRegistryMock)) {
+    }
+}
+
+struct UTXOSourceInMemorySimpleTest: UTXOSourceInMemoryTest;
+
+TEST_F(UTXOSourceInMemorySimpleTest, NoInitialUTXO) {
+    EXPECT_TRUE(false);
+}


### PR DESCRIPTION
This PR adds the persistence layer implementation for UTXO sources. This is currently based on the blockchain abstraction made by @teams2ua.

We need to provide a proper design schema / RFC / document to explicitly state what’s going on with that database blockchain as I fear it would become bloated quickly — this is not trivial and we might face issue with concurrency if we’re not crystal clear about what’s happening.

Specifically:

  - The DB abstraction works on the concept of a _block_, which is NOT a blockchain’s block like from the bitcoin network. It’s a bucket that has the concept of _block height_ and is used to tag along real blocks with raw and untyped data. Another abstraction provides a typed API so that we can have typed data in those _blocks_.
  - The current implementation of persistent UTXO source also relies on the in-memory implementation to provide an efficient lookup method for the cache. We might want to have a better control on that so that we can disable the memory lookup and always go with a disk / solid state lookup (that might be needed for mobile app, for instance).
  - The tests currently are failing — segfaults — and I need to fix them so that the PR can pass completely.