### PR TITLE
Fix the logger that truncated the current log.

### DIFF
--- a/core/src/debug/RotatingEncryptableSink.cpp
+++ b/core/src/debug/RotatingEncryptableSink.cpp
@@ -146,7 +146,8 @@ namespace ledger {
                     throw spdlog::spdlog_ex("rotating_file_sink: failed renaming " + spdlog::details::os::filename_to_str(src) + " to " + spdlog::details::os::filename_to_str(target), errno);
                 }
             }
-            _file_helper.reopen(true);
+
+            _file_helper.reopen(false);
         }
     }
 }


### PR DESCRIPTION
We were explicitly asking to truncate files on rotations. I’m asking @pollastri-pierre reviewal because it was his code and maybe he had a good reason to do that.