### PR TITLE
Revert "Generate directly the .cpp output in the node bindings direct…

### DIFF
--- a/tools/generateBindings.sh
+++ b/tools/generateBindings.sh
@@ -19,7 +19,7 @@ fi
 
 ./djinni/src/run \
   --idl ./core/core.djinni \
-  --cpp-out $DEST/include \
+  --cpp-out $CORE_CPP_API \
   --cpp-namespace ledger::core::api \
   --cpp-optional-template std::experimental::optional \
   --cpp-optional-header "\"../utils/optional.hpp\"" \
@@ -29,6 +29,10 @@ fi
   --node-type-prefix NJS \
   --node-include-cpp ../include \
   --node-package $PACKAGE_NAME
+
+# copy include files
+rm -rf $DEST/include
+cp -r $CORE_CPP_API $DEST/include
 
 # copy util files
 rm -rf $DEST/utils


### PR DESCRIPTION
…ory."

This reverts commit 66b193347b9e16cab1c47f424b30b7f95d18e7cf.

This change was unneeded and we went a bit too fast on that one. We
actually need the header files in both libcore AND $DEST because we need
to implement the interface in libcore.

[skip ci]