### PR TITLE
Retrieve block height of currency from DB in transaction construction

### DIFF
--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
@@ -531,6 +531,21 @@ namespace ledger {
             });
         }
 
+        // This method is used to get a block height only used to know which
+        // update/fork (activated at certain block height) is used.
+        // This explains why we take LLONG_MAX is we have no block in DB for
+        // certain currency
+        // WARNING: please don't use this method if you need an accurate value
+        // of last block
+        static uint64_t getLastBlockFromDB(soci::session &sql, const std::string &currencyName) {
+            //Get last block from DB
+            auto lastBlock = BlockDatabaseHelper::getLastBlock(sql, currencyName);
+            // If we can not retrieve a last block for currency,
+            // we set the returned block height to LLONG_MAX in order to
+            // activate/apply last BIP/update/fork for this currency.
+            return lastBlock.hasValue() ? static_cast<uint64_t >(lastBlock->height) : LLONG_MAX;
+        }
+
         void BitcoinLikeAccount::broadcastRawTransaction(const std::vector<uint8_t> &transaction,
                                                          const std::shared_ptr<api::StringCallback> &callback) {
             auto self = getSelf();
@@ -538,7 +553,12 @@ namespace ledger {
                 //Store newly broadcasted tx in db
                 //First parse it
                 auto txHash = seq.str();
-                auto tx = BitcoinLikeTransactionApi::parseRawSignedTransaction(self->getWallet()->getCurrency(), transaction, self->_currentBlockHeight);
+
+                //Get last block from DB
+                soci::session sql(self->getWallet()->getDatabase()->getPool());
+                auto lastBlockHeight = getLastBlockFromDB(sql, self->getWallet()->getCurrency().name);
+
+                auto tx = BitcoinLikeTransactionApi::parseRawSignedTransaction(self->getWallet()->getCurrency(), transaction, lastBlockHeight);
 
                 //Get a BitcoinLikeBlockchainExplorerTransaction from a BitcoinLikeTransaction
                 BitcoinLikeBlockchainExplorerTransaction txExplorer;
@@ -547,8 +567,6 @@ namespace ledger {
                 txExplorer.receivedAt = std::chrono::system_clock::now();
                 txExplorer.version = tx->getVersion();
                 txExplorer.confirmations = 0;
-
-                soci::session sql(self->getWallet()->getDatabase()->getPool());
 
                 //Inputs
                 auto inputCount = tx->getInputs().size();
@@ -607,6 +625,10 @@ namespace ledger {
             auto getTransaction = [self] (const std::string& hash) -> FuturePtr<BitcoinLikeBlockchainExplorerTransaction> {
                 return self->getTransaction(hash);
             };
+
+            soci::session sql(self->getWallet()->getDatabase()->getPool());
+            auto lastBlockHeight = getLastBlockFromDB(sql, self->getWallet()->getCurrency().name);
+
             return std::make_shared<BitcoinLikeTransactionBuilder>(
                     getContext(),
                     getWallet()->getCurrency(),
@@ -615,7 +637,7 @@ namespace ledger {
                                               getTransaction,
                                               _explorer,
                                               _keychain,
-                                              _currentBlockHeight,
+                                              lastBlockHeight,
                                               logger(),
                                               partial.value_or(false))
             );

--- a/core/src/wallet/common/AbstractAccount.cpp
+++ b/core/src/wallet/common/AbstractAccount.cpp
@@ -192,8 +192,7 @@ namespace ledger {
         }
 
         Future<api::Block> AbstractAccount::getLastBlock() {
-            auto self = shared_from_this();
-            return  getWallet()->getLastBlock();
+            return getWallet()->getLastBlock();
         }
 
         void AbstractAccount::getLastBlock(const std::shared_ptr<api::BlockCallback> &callback) {


### PR DESCRIPTION
This causes issues when using current block height stored in memory ... so parsing/serialization of transaction was using the wrong BIP/fork of a currency leading in some issues from Live side 