### PR TITLE
Adapt (again) derivation address for ETH

### DIFF
--- a/core/src/wallet/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.cpp
+++ b/core/src/wallet/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.cpp
@@ -218,12 +218,6 @@ namespace ledger {
                     "ORDER BY idx", use(out.hash)
             );
             for (auto& outputRow : outputRows) {
-                BitcoinLikeBlockchainExplorerOutput output;
-                output.index = (uint64_t) outputRow.get<int>(0);
-                output.value.assignScalar(outputRow.get<long long>(1));
-                output.script = outputRow.get<std::string>(2);
-                output.address = outputRow.get<Option<std::string>>(3);
-                out.outputs.push_back(std::move(output));
                 //Check if the output belongs to this account
                 //solve case of 2 accounts in DB one as sender and one as receiver
                 //of same transaction (filter on account_uid won't solve the issue because

--- a/core/src/wallet/ethereum/EthereumLikeWallet.cpp
+++ b/core/src/wallet/ethereum/EthereumLikeWallet.cpp
@@ -179,9 +179,9 @@ namespace ledger {
                 for (auto i = 0; i < length; i++) {
                     DerivationPath path(info.derivations[i]);
                     auto owner = info.owners[i];
-                    result.derivations.push_back(path.getParent().toString());
+                    //result.derivations.push_back(path.getParent().toString());
                     result.derivations.push_back(path.toString());
-                    result.owners.push_back(owner);
+                    //result.owners.push_back(owner);
                     result.owners.push_back(owner);
                 }
                 return result;

--- a/core/src/wallet/ethereum/ethereumNetworks.cpp
+++ b/core/src/wallet/ethereum/ethereumNetworks.cpp
@@ -59,7 +59,7 @@ namespace ledger {
                     return ETHEREUM_ROPSTEN;
                 } else if (networkName == "ethereum_classic") {
                     static const api::EthereumLikeNetworkParameters ETHEREUM_CLASSIC(
-                            "eth_classic",
+                            "etc",
                             "Ethereum signed message:\n",
                             "61",
                             {0x04, 0x88, 0xB2, 0x1E},

--- a/core/src/wallet/ethereum/keychains/EthereumLikeKeychain.cpp
+++ b/core/src/wallet/ethereum/keychains/EthereumLikeKeychain.cpp
@@ -159,6 +159,7 @@ namespace ledger {
         EthereumLikeKeychain::Address EthereumLikeKeychain::derive() {
 
             if (_address.empty()) {
+
                 _localPath = getDerivationScheme()
                         .setAccountIndex(getAccountIndex())
                         .setCoinType(getCurrency().bip44CoinType)
@@ -173,7 +174,12 @@ namespace ledger {
                             .setCoinType(getCurrency().bip44CoinType)
                             .setNode(0)
                             .setAddressIndex(0).getPath().toString();
-                    auto xpub = _xpub;
+
+                    auto localNodeScheme = getDerivationScheme().getSchemeTo(DerivationSchemeLevel::NODE)
+                            .setAccountIndex(getAccountIndex())
+                            .setCoinType(getCurrency().bip44CoinType)
+                            .setNode(0);
+                    auto xpub = std::static_pointer_cast<EthereumLikeExtendedPublicKey>(_xpub)->derive(localNodeScheme.getPath());
                     _address = xpub->derive(p)->toEIP55();
                     // Feed path -> address cache
                     // Feed address -> path cache

--- a/core/test/integration/account_info_test.cpp
+++ b/core/test/integration/account_info_test.cpp
@@ -46,6 +46,27 @@ TEST_F(AccountInfoTests, FirstAccountInfo) {
     EXPECT_EQ(info.derivations[1], "44'/0'/0'");
 }
 
+TEST_F(AccountInfoTests, FirstEthAccountInfo) {
+    auto pool = newDefaultPool();
+    auto wallet = wait(pool->createWallet("my_wallet", "ethereum", DynamicObject::newInstance()));
+    auto info = wait(wallet->getNextAccountCreationInfo());
+    EXPECT_EQ(info.index, 0);
+    EXPECT_EQ(info.owners[0], "main");
+    EXPECT_EQ(info.derivations[0], "44'/60'/0'");
+    //api::Configuration::KEYCHAIN_DERIVATION_SCHEME, "44'/<coin_type>'/<account>'/<node>/<address>"
+}
+
+TEST_F(AccountInfoTests, FirstEthCustomDerivationAccountInfo) {
+    auto config = DynamicObject::newInstance();
+    config->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME, "44'/<coin_type>'/<account>'/<node>/<address>");
+    auto pool = newDefaultPool();
+    auto wallet = wait(pool->createWallet("my_wallet", "ethereum", DynamicObject::newInstance()));
+    auto info = wait(wallet->getNextAccountCreationInfo());
+    EXPECT_EQ(info.index, 0);
+    EXPECT_EQ(info.owners[0], "main");
+    EXPECT_EQ(info.derivations[0], "44'/60'/0'");
+}
+
 TEST_F(AccountInfoTests, AnotherAccountInfo) {
     auto pool = newDefaultPool();
     auto wallet = wait(pool->createWallet("my_wallet", "bitcoin", DynamicObject::newInstance()));

--- a/core/test/integration/keychains/ethereum_keychain_test.cpp
+++ b/core/test/integration/keychains/ethereum_keychain_test.cpp
@@ -34,6 +34,7 @@
 #include <src/wallet/ethereum/keychains/EthereumLikeKeychain.hpp>
 #include <src/ethereum/EthereumLikeExtendedPublicKey.h>
 #include <src/ethereum/EthereumLikeAddress.h>
+#include <src/utils/DerivationPath.hpp>
 #include <src/utils/optional.hpp>
 #include "keychain_test_helper.h"
 #include "../BaseFixture.h"
@@ -53,7 +54,9 @@ public:
                     configuration,
                     data.currency,
                     0,
-                    ledger::core::EthereumLikeExtendedPublicKey::fromBase58(data.currency, data.xpub, optional<std::string>(data.derivationPath)),
+                    ledger::core::EthereumLikeExtendedPublicKey::fromBase58(data.currency,
+                                                                            data.xpub,
+                                                                            optional<std::string>(data.derivationPath)),
                     backend->getPreferences("keychain")
             );
             f(keychain);
@@ -65,8 +68,9 @@ public:
 
 TEST_F(EthereumKeychains, KeychainDerivation) {
     testEthKeychain(ETHEREUM_DATA, [] (EthereumLikeKeychain& keychain) {
-        auto ethAddress = keychain.getAddress();
-        EXPECT_EQ(ethAddress->toEIP55(), "0xE8F7Dc1A12F180d49c80D1c3DbEff48ee38bD1DA");
+        auto ethDerivedAddress = keychain.getAllObservableAddresses(0, 0)[0];
+        EXPECT_EQ(ethDerivedAddress->getDerivationPath().value_or(""), "0/0");
+        EXPECT_EQ(ethDerivedAddress->toEIP55(), "0xE8F7Dc1A12F180d49c80D1c3DbEff48ee38bD1DA");
     });
 }
 
@@ -77,13 +81,95 @@ TEST_F(EthereumKeychains, EthereumAddressValidation) {
 
 }
 
-TEST_F(EthereumKeychains, EthereumAddressValidationFromPubKeyAndChainCode) {
-    auto address = "0xAc6603e97e774Cd34603293b69bBBB1980acEeaA";
+
+TEST_F(EthereumKeychains, EthereumAddressValidationFromXpub) {
+    auto extKey = ledger::core::EthereumLikeExtendedPublicKey::fromBase58(ETHEREUM_DATA.currency,
+                                                                          ETHEREUM_DATA.xpub,
+                                                                          optional<std::string>(ETHEREUM_DATA.derivationPath));
+    EXPECT_EQ(extKey->toBase58(), ETHEREUM_DATA.xpub);
+
+    auto derivedPubKey = "xpub6DrvMc6me5H6sV3Wrva6thZyhxMZ7WMyB8nMWLe3T5xr79bBsDJn2zgSQiVWEbU5XfoLMEz7oZT9G49AoCcxYNrz2dVBrySzUw4k9GTNyoW";
+    auto derivedExtKey = extKey->derive(ledger::core::DerivationPath("0"));
+    EXPECT_EQ(derivedExtKey->toBase58(), derivedPubKey);
+
+    auto address = "0xE8F7Dc1A12F180d49c80D1c3DbEff48ee38bD1DA";
+    auto derivedAddress = extKey->derive("0/0");
+    EXPECT_EQ(derivedAddress->toEIP55(), address);
+}
+
+TEST_F(EthereumKeychains, EthereumChildAddressValidationFromPubKeyAndChainCode) {
     auto path = "44'/60'/0'";
-    auto pubKey = "04d1dc4a3180fe2d56a1f02a68b053e59022ce5e107eae879ebef66a46d4ffe04dc3994facd376abcbab49c421599824a2600ee30e8520878e65581f598e2c497a";
-    auto chainCode = "2d560fcaaedb929eea27d316dec7961eee884259e6483fdf192704db7582ca14";
-    auto ethXpub = ledger::core::EthereumLikeExtendedPublicKey::fromRaw(ledger::core::currencies::ETHEREUM, optional<std::vector<uint8_t >>(), hex::toByteArray(pubKey), hex::toByteArray(chainCode), path);
-    auto derive0 = ethXpub->derive("0");
+    auto pubKey = "035dd2992d954b3d232037aba9cc7fc08c2155e4f3616aa1290edc9cc09f8d64f0";
+    auto chainCode = "6a4e60e6fbd45355d840ff7a18bc7cb628318f1ba6fbcfb0c07626d8ea768aca";
+    auto ethXpub = ledger::core::EthereumLikeExtendedPublicKey::fromRaw(ledger::core::currencies::ETHEREUM,
+                                                                        optional<std::vector<uint8_t >>(),
+                                                                        hex::toByteArray(pubKey),
+                                                                        hex::toByteArray(chainCode),
+                                                                        path);
+    auto address = "0xE8F7Dc1A12F180d49c80D1c3DbEff48ee38bD1DA";
+    auto derive0 = ethXpub->derive("0/0");
     EXPECT_EQ(derive0->toEIP55(), address);
+
+}
+
+const std::vector<std::vector<std::string>> derivationTestData = {
+        {
+                "44'/<coin_type>'/<account>'/<node>/<address>",
+                "44'/60'/0'/0/0",
+                "04d1dc4a3180fe2d56a1f02a68b053e59022ce5e107eae879ebef66a46d4ffe04dc3994facd376abcbab49c421599824a2600ee30e8520878e65581f598e2c497a",
+                "2d560fcaaedb929eea27d316dec7961eee884259e6483fdf192704db7582ca14",
+                "0xAc6603e97e774Cd34603293b69bBBB1980acEeaA"
+        },
+        {
+                "44'/<coin_type>'/<account>'/<node>/<address>",
+                "44'/60'/1'/0/0",
+                "04c6dab3de86f6e44a3f54bcd204ea63dfef4e728fac050068f7fa391e0a623735258165fb5bad2a583110cb482c5d47f649ca49efc4997df77d01d0132ce4d082",
+                "2d560fcaaedb929eea27d316dec7961eee884259e6483fdf192704db7582ca14",
+                "0x8AB03601CFD6B5eda60c2ABFe4A2277F543b7f5d"
+        },
+        {
+                "44'/<coin_type>'/0'/<account>",
+                "44'/60'/0'/0",
+                "045ff91ffa3506fa2dce2175f2ef30821e89bba5e9581d348d34b976acd37d83aa1d4491cef5282ff02dcb7d98ca885bfdf72b473165ef952d9912540e89735b13",
+                "3cb96430fa5528cd8ec4cbc4184645466f3df040fa780354c2151f0b906f0bb3",
+                "0x7F916511864686e5a9952f1d66595e1A90520670"
+        },
+        {
+                "44'/<coin_type>'/0'/<account>",
+                "44'/60'/0'/1",
+                "04beb03c024dd2d199fe2c137c9dc2c89345a2578f2c65fad3aae0e970e90a352d18725b1eec1b3dbe00d62be83bb48b74138dcc7d86a16c6610ed203d4e09aa33",
+                "4d0565d7f8ea65680c4c148635385eecfd10c8453f47986942197bcebf1a5ae8",
+                "0x179B50609c17AC28c25Df0Abe0E1A2Fdc75dcF56"
+        },
+        {
+                "44'/<coin_type>'/0'/<account>'",
+                "44'/60'/0'/0'",
+                "04d2ee4bb49221f9f1662e4791748e68354c26d7d5290ad518c86c4d714c785e6533e0286d3803b0ddde3287eb6f31f77792fdf7323f76152c14069805f23121d2",
+                "ddf5a9cf1fdf4746a4495cf36328c7e2af31d18dd0a8f8302f3e13c900f4bfb9",
+                "0x390De614378307a6d85cD0e68460378A745295b1"
+        }
+
+};
+
+TEST_F(EthereumKeychains, EthereumAddressValidationFromPubKeyAndChainCode) {
+
+    for (auto &elem : derivationTestData) {
+        //So we know what we are dealing with
+        auto derivationScheme = elem[0];
+        auto path = elem[1];
+        auto publicKey = elem[2];
+        auto chainCode = elem[3];
+        auto expectedAddress = elem[4];
+
+        auto config = DynamicObject::newInstance();
+        config->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,derivationScheme);
+        auto ethXpub = ledger::core::EthereumLikeExtendedPublicKey::fromRaw(ledger::core::currencies::ETHEREUM,
+                                                                            optional<std::vector<uint8_t >>(),
+                                                                            hex::toByteArray(publicKey),
+                                                                            hex::toByteArray(chainCode),
+                                                                            path);
+        auto derivedAddress = ethXpub->derive("");
+        EXPECT_EQ(derivedAddress->toEIP55(), expectedAddress);
+    }
 
 }

--- a/core/test/integration/keychains/keychain_test_helper.cpp
+++ b/core/test/integration/keychains/keychain_test_helper.cpp
@@ -163,11 +163,12 @@ KeychainTestData DECRED_DATA(ledger::core::networks::getNetworkParameters("decre
                                "dpubZFUiMExUREbqJQVJkfXSs4wjUb1jwVkoofnPK8Mt95j3PanCyq9Mc4aFnWtRZkhci9ZYPVLZybVLMMkS6g1nKBTN4899KJwGeVBvyumvcjW",
                                "44'/42'/0'");
 //seed: split chuckle nerve
+//BIP32 xpub6DQva5oVJA2gMT4Z2hUfuXMgss4MdGVUoPohC2qp3cZYM7oKyLTaENeRbm42mxF5Y6r1VZK2vmsvxWtwzMBsyYztNQub8natARB2Dk1bdgJ
 //BIP32 xpub6DrvMc6me5H6sV3Wrva6thZyhxMZ7WMyB8nMWLe3T5xr79bBsDJn2zgSQiVWEbU5XfoLMEz7oZT9G49AoCcxYNrz2dVBrySzUw4k9GTNyoW
 //0xE8F7Dc1A12F180d49c80D1c3DbEff48ee38bD1DA
 //0xEC9eD3b9489735992B3c48DE9F3b6bD076eC3bfA
 
 KeychainTestData ETHEREUM_DATA(ledger::core::networks::getEthLikeNetworkParameters("ethereum"),
                                ledger::core::currencies::ETHEREUM,
-                               "xpub6DrvMc6me5H6sV3Wrva6thZyhxMZ7WMyB8nMWLe3T5xr79bBsDJn2zgSQiVWEbU5XfoLMEz7oZT9G49AoCcxYNrz2dVBrySzUw4k9GTNyoW",
+                               "xpub6DQva5oVJA2gMT4Z2hUfuXMgss4MdGVUoPohC2qp3cZYM7oKyLTaENeRbm42mxF5Y6r1VZK2vmsvxWtwzMBsyYztNQub8natARB2Dk1bdgJ",
                                "44'/60'/0'");


### PR DESCRIPTION
- ETH address derivation is now like Bitcoin (with respect to BIP32 and BIP44),
- We support also configurable new derivation schemes (as shown in tests), this will allow Live to support legacy derivation paths and custom (weird) ones,
- When asked about new account's creation info, client will receive a structure`{index, owners, derivations}` e.g. if we ask for first ETH account of a wallet with derivation scheme `44'/<coin_type>'/<account>'/<node>/<address>` we will receive: 
`{0, { main }, {" 44'/60'/0' "}}`
- Tests that were added were checked against returned values by a NanoS
