### PR TITLE
Fix a bug in Live with the AESCipher (that doesn’t like empty passwor…

### DIFF
--- a/core/src/wallet/pool/WalletPool.cpp
+++ b/core/src/wallet/pool/WalletPool.cpp
@@ -53,7 +53,16 @@ namespace ledger {
         ): DedicatedContext(dispatcher->getSerialExecutionContext(fmt::format("pool_queue_{}", name))) {
             // General
             _poolName = name;
-            _password = password;
+
+            // if the password has the form Some(""), we set it to None as this is not an accepted
+            // situation (to fix this in a more type-safe way, we need to change the encoding and go
+            // to std::string only, no more optional)
+            if (password.hasValue() && password->empty()) {
+                _password = Option<std::string>::NONE;
+            } else {
+                _password = password;
+            }
+
             _configuration = std::static_pointer_cast<DynamicObject>(configuration);
 
             // File system management
@@ -78,9 +87,9 @@ namespace ledger {
             );
 
             // Encrypt the preferences, if needed
-            if (password.hasValue()) {
-                _externalPreferencesBackend->setEncryption(rng, *password);
-                _internalPreferencesBackend->setEncryption(rng, *password);
+            if (_password.hasValue()) {
+                _externalPreferencesBackend->setEncryption(rng, *_password);
+                _internalPreferencesBackend->setEncryption(rng, *_password);
             }
 
             // Logger management
@@ -88,7 +97,7 @@ namespace ledger {
             auto enableLogger = _configuration->getBoolean(api::PoolConfiguration::ENABLE_INTERNAL_LOGGING).value_or(true);
             _logger = logger::create(
                     name + "-l",
-                    password.toOptional(),
+                    _password.toOptional(),
                     dispatcher->getSerialExecutionContext(fmt::format("logger_queue_{}", name)),
                     pathResolver,
                     logPrinter,


### PR DESCRIPTION
…ds).

This fixes the first part of the problem. I’ll open a Jira ticket to fix
AES/PBKDF2 when the key / passphrase is empty.

Also, note: we might want to change the interface of the WalletPool
creation. This would be a breaking change, though. I’ll also open a Jira
ticket for that.