### PR TITLE
Backport/2.1.1 walletpool encrytion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(UseBackportedModules)
 # The project version number.
 set(VERSION_MAJOR   2   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   1   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   1   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 1.0.{build}
 image:
 - Visual Studio 2015
 environment:
-  LIB_VERSION: 2.1.0 #Hardcode the LIB_VERSION : should be retrieved by building libcore node module and run tests/lib_version.js
+  LIB_VERSION: 2.1.1 #Hardcode the LIB_VERSION : should be retrieved by building libcore node module and run tests/lib_version.js
   nodejs_version: "9"
   appveyor_rdp_password:
     secure: jb1LsDmcxCww7tA38S3xSw==


### PR DESCRIPTION
In order to “correctly” apply this patch, we need to:

  - `git tag 2.1.0 b79eb9cc5d974bf64bdca980b53b36d94fc1cbf6`
  - `git tag 2.1.1`, with applied patch

Once this is merged, we can remove the branch (because recreating the branch is very easy based on the (to create) `2.1.0` tag: `git branch release/2.1.0 2.1.0`. And in our case, we should never even need to use that branch again as if we need to backport another patch to `2.1`, we will do:

  - `git branch release/2.1.1 2.1.1`
  - `git cherry-pick <hash of the patch commit>`
  - `git tag 2.1.2`

I think this workflow is simple and doesn’t have the drawbacks of keeping alive tons of branches behind. You’ll tell me.