### PR TITLE
NEW: Energi (NRG) support

### DIFF
--- a/core/src/wallet/bitcoin/networks.cpp
+++ b/core/src/wallet/bitcoin/networks.cpp
@@ -410,6 +410,21 @@ namespace ledger {
                             {}
                     );
                     return STAKENET;
+                } else if (networkName == "energi") {
+                    static const api::BitcoinLikeNetworkParameters ENERGI(
+                            "energi",
+                            {0x21},
+                            {0x35},
+                            {0x03, 0xB8, 0xC8, 0x56},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "DarkCoin Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return ENERGI;
                 }
 
                 throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "No network parameters set for {}", networkName);
@@ -439,7 +454,8 @@ namespace ledger {
                 getNetworkParameters("pivx"),
                 getNetworkParameters("clubcoin"),
                 getNetworkParameters("decred"),
-                getNetworkParameters("stakenet")
+                getNetworkParameters("stakenet"),
+                getNetworkParameters("energi")
             });
         }
     }

--- a/core/src/wallet/currencies.cpp
+++ b/core/src/wallet/currencies.cpp
@@ -272,6 +272,17 @@ namespace ledger {
                             .unit("mwei", 6, "mwei")
                             .unit("gwei", 9, "gwei");
 
+            const api::Currency ENERGI =
+                    Currency("energi")
+                            .forkOfBitcoin(networks::getNetworkParameters("energi"))
+                            .bip44(9797)
+                            .paymentUri("energi")
+                            .unit("atom", 0, "atoms")
+                            .unit("energi", 8, "NRG")
+                            .unit("milli-energi", 5, "mNRG")
+                            .unit("micro-energi", 2, "μNRG");
+
+
             const std::vector<api::Currency> ALL({
                 BITCOIN,
                 BITCOIN_TESTNET,
@@ -298,7 +309,8 @@ namespace ledger {
                 STAKENET,
                 ETHEREUM,
                 ETHEREUM_ROPSTEN,
-                ETHEREUM_CLASSIC
+                ETHEREUM_CLASSIC,
+                ENERGI,
             });
         }
     }

--- a/core/src/wallet/currencies.hpp
+++ b/core/src/wallet/currencies.hpp
@@ -71,6 +71,7 @@ namespace ledger {
             extern LIBCORE_EXPORT const api::Currency ETHEREUM;
             extern LIBCORE_EXPORT const api::Currency ETHEREUM_CLASSIC;
             extern LIBCORE_EXPORT const api::Currency ETHEREUM_ROPSTEN;
+            extern LIBCORE_EXPORT const api::Currency ENERGI;
         };
     }
 }

--- a/core/test/integration/CMakeLists.txt
+++ b/core/test/integration/CMakeLists.txt
@@ -73,6 +73,7 @@ add_test (NAME ledger-core-integration-BitcoinKeychains.KomodoKeychainDerivation
 add_test (NAME ledger-core-integration-BitcoinKeychains.PosWalletKeychainDerivation COMMAND ledger-core-integration-tests --gtest_filter="BitcoinKeychains.PosWalletKeychainDerivation")
 add_test (NAME ledger-core-integration-BitcoinKeychains.PivxKeychainDerivation COMMAND ledger-core-integration-tests --gtest_filter="BitcoinKeychains.PivxKeychainDerivation")
 add_test (NAME ledger-core-integration-BitcoinKeychains.ClubcoinKeychainDerivation COMMAND ledger-core-integration-tests --gtest_filter="BitcoinKeychains.ClubcoinKeychainDerivation")
+add_test (NAME ledger-core-integration-BitcoinKeychains.EnergiKeychainDerivation COMMAND ledger-core-integration-tests --gtest_filter="BitcoinKeychains.EnergiKeychainDerivation")
 add_test (NAME ledger-core-integration-BitcoinKeychains.SimpleUsedReceiveAddresses COMMAND ledger-core-integration-tests --gtest_filter="BitcoinKeychains.SimpleUsedReceiveAddresses")
 add_test (NAME ledger-core-integration-BitcoinKeychains.SimpleUsedChangeAddresses COMMAND ledger-core-integration-tests --gtest_filter="BitcoinKeychains.SimpleUsedChangeAddresses")
 add_test (NAME ledger-core-integration-BitcoinKeychains.NonConsecutivesReceiveUsed COMMAND ledger-core-integration-tests --gtest_filter="BitcoinKeychains.NonConsecutivesReceiveUsed")

--- a/core/test/integration/keychains/keychain_test_helper.cpp
+++ b/core/test/integration/keychains/keychain_test_helper.cpp
@@ -172,3 +172,8 @@ KeychainTestData ETHEREUM_DATA(ledger::core::networks::getEthLikeNetworkParamete
                                ledger::core::currencies::ETHEREUM,
                                "xpub6DQva5oVJA2gMT4Z2hUfuXMgss4MdGVUoPohC2qp3cZYM7oKyLTaENeRbm42mxF5Y6r1VZK2vmsvxWtwzMBsyYztNQub8natARB2Dk1bdgJ",
                                "44'/60'/0'");
+
+KeychainTestData ENERGI_DATA(ledger::core::networks::getNetworkParameters("energi"),
+                           ledger::core::currencies::ENERGI,
+                           "nprvGnSDGVHJd8Z6Ljwagt6coc7AeUVTy6aocwxJTeAoKtQqWumV5XjA1k8xkYCNfVXVWMPenZvMYTkjRYgHaiAkh8LbAcVSnep4tttprK7GN4Up",
+                           "44'/9797'/0'");

--- a/core/test/integration/keychains/keychain_test_helper.h
+++ b/core/test/integration/keychains/keychain_test_helper.h
@@ -114,4 +114,5 @@ extern KeychainTestData PIVX_DATA;
 extern KeychainTestData CLUBCOIN_DATA;
 extern KeychainTestData DECRED_DATA;
 extern KeychainTestData ETHEREUM_DATA;
+extern KeychainTestData ENERGI_DATA;
 #endif //LEDGER_CORE_KEYCHAIN_TEST_HELPER_H

--- a/core/test/integration/keychains/p2pkh_keychain_test.cpp
+++ b/core/test/integration/keychains/p2pkh_keychain_test.cpp
@@ -206,6 +206,13 @@ TEST_F(BitcoinKeychains, DecredKeychainDerivation) {
     });
 }
 
+TEST_F(BitcoinKeychains, EnergiKeychainDerivation) {
+    testP2PKHKeychain(ENERGI_DATA, [] (P2PKHBitcoinLikeKeychain& keychain) {
+        EXPECT_EQ(keychain.getFreshAddress(BitcoinLikeKeychain::KeyPurpose::RECEIVE)->toBase58(), "EZTdfysUY129hUeVSZNiTPVQ7BHLruXBE2");
+        EXPECT_EQ(keychain.getFreshAddress(BitcoinLikeKeychain::KeyPurpose::CHANGE)->toBase58(), "ENzX5eYmuBu3Dv2dKRasLJHho5vKMuQ4YD");
+    });
+}
+
 TEST_F(BitcoinKeychains, SimpleUsedReceiveAddresses) {
     testP2PKHKeychain(BTC_DATA, [] (P2PKHBitcoinLikeKeychain& keychain) {
         auto addresses = keychain.getAllObservableAddresses(0, 10);


### PR DESCRIPTION
Limited testing for building and test execution has been performed. The build was also smoke tested with local execution Ledger Live Desktop.

Notes:
1. Keccak test fails to build, if cryptopp is found in ethash. If build is fixed then values appear to mismatch. This issue is not related to changes.
2. Network tests sometimes fail due to timeout in HTTP client. Also, not related.

Depends on https://github.com/LedgerHQ/ledger-app-btc/pull/104