### PR TITLE
Remove all references to passwords in the logger code.

### DIFF
--- a/core/src/debug/RotatingEncryptableSink.cpp
+++ b/core/src/debug/RotatingEncryptableSink.cpp
@@ -37,7 +37,6 @@ namespace ledger {
         RotatingEncryptableSink::RotatingEncryptableSink(const std::shared_ptr<api::ExecutionContext> &context,
                                                          const std::shared_ptr<api::PathResolver> &resolver,
                                                          const std::string &name,
-                                                         std::experimental::optional<std::string> password,
                                                          std::size_t maxSize,
                                                          std::size_t maxFiles) {
             _context = context;
@@ -50,7 +49,6 @@ namespace ledger {
             _base_filename = name;
             _extension = "log";
 #endif
-            _password = password;
             _max_size = maxSize;
             _max_files = maxFiles;
             _file_helper.open(calc_filename(resolver, _base_filename, 0, _extension));

--- a/core/src/debug/RotatingEncryptableSink.hpp
+++ b/core/src/debug/RotatingEncryptableSink.hpp
@@ -50,10 +50,10 @@ namespace ledger {
                     const std::shared_ptr<api::ExecutionContext> &context,
                     const std::shared_ptr<api::PathResolver> &resolver,
                     const std::string &name,
-                    std::experimental::optional<std::string> password,
                     std::size_t maxSize,
                     std::size_t maxFiles
             );
+
             virtual void log(const spdlog::details::log_msg &msg) override;
             virtual void flush() override;
 
@@ -64,16 +64,17 @@ namespace ledger {
             static spdlog::filename_t calc_filename(
                     std::shared_ptr<api::PathResolver> resolver,
                     const spdlog::filename_t& filename, std::size_t index, const spdlog::filename_t& extension);
+
             void _rotate();
+
 #if defined(_WIN32) || defined(_WIN64)
             static void ToWide(const std::string &input, std::wstring &output);
             static void ToNarrow(const std::wstring &input, std::string &output);
 #endif
-        private:
+
             std::shared_ptr<api::ExecutionContext> _context;
             std::weak_ptr<api::PathResolver> _resolver;
             std::string _name;
-            std::experimental::optional<std::string> _password;
             spdlog::filename_t _base_filename;
             spdlog::filename_t _extension;
             std::size_t _max_size;

--- a/core/src/debug/logger.cpp
+++ b/core/src/debug/logger.cpp
@@ -39,7 +39,6 @@ namespace ledger {
     namespace core {
         std::shared_ptr<spdlog::logger> logger::create(
             const std::string &name,
-            std::experimental::optional<std::string> password,
             const std::shared_ptr<api::ExecutionContext> &context,
             const std::shared_ptr<api::PathResolver> &resolver,
             const std::shared_ptr<api::LogPrinter> &printer,
@@ -48,7 +47,7 @@ namespace ledger {
         ) {
             if (enabled) {
                 auto logPrinterSink = std::make_shared<LogPrinterSink>(printer);
-                auto rotatingSink = std::make_shared<RotatingEncryptableSink>(context, resolver, name, password, maxSize, 3);
+                auto rotatingSink = std::make_shared<RotatingEncryptableSink>(context, resolver, name, maxSize, 3);
                 auto logger = spdlog::create(name, {logPrinterSink, rotatingSink});
                 spdlog::drop(name);
 

--- a/core/src/debug/logger.hpp
+++ b/core/src/debug/logger.hpp
@@ -46,7 +46,6 @@ namespace ledger {
             static const std::size_t DEFAULT_MAX_SIZE = 5 * 1048576;
             static std::shared_ptr<spdlog::logger> create(
                     const std::string& name,
-                    std::experimental::optional<std::string> password,
                     const std::shared_ptr<api::ExecutionContext>& context,
                     const std::shared_ptr<api::PathResolver>& resolver,
                     const std::shared_ptr<api::LogPrinter>& printer,

--- a/core/src/wallet/pool/WalletPool.cpp
+++ b/core/src/wallet/pool/WalletPool.cpp
@@ -97,7 +97,6 @@ namespace ledger {
             auto enableLogger = _configuration->getBoolean(api::PoolConfiguration::ENABLE_INTERNAL_LOGGING).value_or(true);
             _logger = logger::create(
                     name + "-l",
-                    _password.toOptional(),
                     dispatcher->getSerialExecutionContext(fmt::format("logger_queue_{}", name)),
                     pathResolver,
                     logPrinter,

--- a/core/test/debug/logger_test.cpp
+++ b/core/test/debug/logger_test.cpp
@@ -49,7 +49,6 @@ TEST(LoggerTest, LogAndOverflow) {
     auto resolver = std::make_shared<NativePathResolver>();
     auto logLineExample = std::string("2017-03-02T10:07:06Z+01:00 D: This is a log XXX") + spdlog::details::os::default_eol;
     std::shared_ptr<spdlog::logger> logger = ledger::core::logger::create("test_logs",
-                                               std::experimental::optional<std::string>(),
                                                dispatcher->getSerialExecutionContext("logger"),
                                                resolver,
                                                logPrinter,
@@ -81,7 +80,6 @@ TEST(LoggerTest, LogNoOverflow) {
     auto resolver = std::make_shared<NativePathResolver>();
     auto logLineExample = std::string("2017-03-02T10:07:06Z+01:00 D: This is a log XXX") + spdlog::details::os::default_eol;
     std::shared_ptr<spdlog::logger> logger = ledger::core::logger::create("test_logs_1",
-                                                                          std::experimental::optional<std::string>(),
                                                                           dispatcher->getSerialExecutionContext("logger"),
                                                                           resolver,
                                                                           logPrinter,

--- a/core/test/integration/ledger_api_blockchain_explorer_tests.cpp
+++ b/core/test/integration/ledger_api_blockchain_explorer_tests.cpp
@@ -42,7 +42,6 @@ public:
         auto client = std::make_shared<HttpClient>("http://api.ledgerwallet.com", http, worker);
         explorer = std::make_shared<LedgerApiBitcoinLikeBlockchainExplorer>(worker, client, networks::getNetworkParameters("bitcoin"), api::DynamicObject::newInstance());
         logger = ledger::core::logger::create("test_logs",
-                                              std::experimental::optional<std::string>(),
                                               dispatcher->getSerialExecutionContext("logger"),
                                               resolver,
                                               printer,


### PR DESCRIPTION
We might need to reintroduce later if we ever need to encrypt logs, but
in the meanwhile, let’s get rid of that code.

LLC-154