### PR TITLE
SQL Cipher fix

### DIFF
--- a/core/lib/cmake/ProjectSQLiteCipher.cmake
+++ b/core/lib/cmake/ProjectSQLiteCipher.cmake
@@ -3,7 +3,7 @@ include(ExternalProject)
 
 
 set(OPENSSL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/openssl")
-set(OPENSSL_LIB $<TARGET_FILE:crypto>)
+set(OPENSSL_LIB $<TARGET_FILE_DIR:crypto>)
 string(FIND "${CMAKE_OSX_SYSROOT}" "iphone" IS_IOS)
 if(IS_IOS GREATER_EQUAL 0)
     set(OPENSSL_LIB ${CMAKE_BINARY_DIR}/core/lib/openssl/crypto/${CMAKE_BUILD_TYPE}-${CMAKE_OSX_SYSROOT})


### PR DESCRIPTION
- Define OPENSSL_LIB as crypto TARGET_FILE_DIR (instead of TARGET_FILE)
- @phaazon this is probably the reason building libcore with SQLCipher was failing ( Pierre had same issue and I fixed by that), I think reason why it was not failing on my side and CI side is because probably it was linking against system's OpenSSL which happen to have right version with all symbols defined ! 