### PR TITLE
Secp files in build not in src

### DIFF
--- a/.circleci/build_lib.sh
+++ b/.circleci/build_lib.sh
@@ -110,8 +110,6 @@ echo "=====>Cleaning SQLCipher"
 rm -rf core/lib/sqlcipher || echo "Failed to clean sqlcipher"
 if [ "$1" == "ios" -o "$1" == "android" ]; then
     echo "=====>Cleaning to prepare clean build"
-    echo "=====>Cleaning secp256k1"
-    rm -rf core/lib/secp256k1/include core/lib/secp256k1/src core/lib/secp256k1/tmp core/lib/secp256k1/lib || echo "Failed to clean secp256k1"
     echo "=====>Remove build directory"
     rm -rf ../lib-ledger-core-build
 fi

--- a/core/lib/cmake/ProjectSecp256k1.cmake
+++ b/core/lib/cmake/ProjectSecp256k1.cmake
@@ -49,6 +49,9 @@ ExternalProject_Add(
         BUILD_COMMAND ""
         ${_overwrite_install_command}
         BUILD_BYPRODUCTS "${SECP256K1_LIBRARY}"
+        BINARY_DIR ${CMAKE_BINARY_DIR}/core/lib/secp256k1
+        STAMP_DIR ${CMAKE_BINARY_DIR}/core/lib/secp256k1
+        TMP_DIR ${CMAKE_BINARY_DIR}/core/lib/secp256k1
 )
 
 # Create imported library


### PR DESCRIPTION
This will allow to build lib-core from one source directory with different compilers without cleaning src