### PR TITLE
Fix JNI compilation for Apple (macOSX) platforms.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,6 @@ if(IS_IOS GREATER_EQUAL 0 OR TARGET_JNI OR ANDROID)
     set(BUILD_TESTS OFF CACHE BOOL "Cannot run tests for these options" FORCE)
 endif()
 
-if(APPLE)
-    set(JAVA_INCLUDE_PATH2 "$ENV{JAVA_HOME}/include" CACHE PATH "")
-endif()
-
 add_subdirectory(doc)
 add_subdirectory(core)
 


### PR DESCRIPTION
Here, we set (erase) an important environment variable. I guess the
toolchain of polly does that (or maybe CMake, who knows). Fixes all the
problem with jni_md.h paths.