### PR TITLE
LLC-183: Implement updateWalletConfig on WalletPool

### DIFF
--- a/core/idl/wallet/wallet_pool.djinni
+++ b/core/idl/wallet/wallet_pool.djinni
@@ -65,6 +65,14 @@ WalletPool = interface +c {
     # @param callback, Callback object returns a Wallet object
     getWallet(name: string, callback: Callback<Wallet>);
 
+    # Update wallet configuration
+    # @param name, string, name of wallet to update
+    # @param configuration, DynamicObject object, configuration object with fields to update
+    # @param callback, Callback object returns the error code, returns ErrorCode::FUTURE_WAS_SUCCESSFULL if everything is fine
+    # > Note: other fields that are not passed in 'configuration' parameter
+    # > that might have been created before remain intact
+    updateWalletConfig(name: string, configuration: DynamicObject, callback: Callback<ErrorCode>);
+
     # Instanciate a new wallet under wallet pool.
     # @param name, string, name of newly created wallet
     # @param currency, Currency object, currency of the wallet

--- a/core/src/api/WalletPool.hpp
+++ b/core/src/api/WalletPool.hpp
@@ -100,6 +100,16 @@ public:
     virtual void getWallet(const std::string & name, const std::shared_ptr<WalletCallback> & callback) = 0;
 
     /**
+     * Update wallet configuration
+     * @param name, string, name of wallet to update
+     * @param configuration, DynamicObject object, configuration object with fields to update
+     * @param callback, Callback object returns the error code, returns ErrorCode::FUTURE_WAS_SUCCESSFULL if everything is fine
+     * > Note: other fields that are not passed in 'configuration' parameter
+     * > that might have been created before remain intact
+     */
+    virtual void updateWalletConfig(const std::string & name, const std::shared_ptr<DynamicObject> & configuration, const std::shared_ptr<ErrorCodeCallback> & callback) = 0;
+
+    /**
      * Instanciate a new wallet under wallet pool.
      * @param name, string, name of newly created wallet
      * @param currency, Currency object, currency of the wallet

--- a/core/src/bitcoin/bech32/Bech32Parameters.h
+++ b/core/src/bitcoin/bech32/Bech32Parameters.h
@@ -76,7 +76,7 @@ namespace ledger {
             };
             extern LIBCORE_EXPORT const Bech32Struct getBech32Params(const std::string &networkIdentifier);
             extern LIBCORE_EXPORT const std::vector<Bech32Struct> ALL;
-            static bool insertParameters(soci::session& sql, const Bech32Struct &params);
+            bool insertParameters(soci::session& sql, const Bech32Struct &params);
         }
     }
 }

--- a/core/src/collections/DynamicObject.cpp
+++ b/core/src/collections/DynamicObject.cpp
@@ -184,5 +184,48 @@ namespace ledger {
                 }
             }
         }
+
+        std::shared_ptr<api::DynamicObject> DynamicObject::updateWithConfiguration(const std::shared_ptr<DynamicObject> &configuration) {
+            for (auto &key : configuration->getKeys()) {
+                auto type = configuration->getType(key).value_or(api::DynamicType::UNDEFINED);
+                switch (type) {
+                    case api::DynamicType::STRING:
+                        put(key, configuration->get<std::string>(key).value());
+                        break;
+
+                    case api::DynamicType::DATA:
+                        put(key, configuration->get<std::vector<uint8_t>>(key).value());
+                        break;
+
+                    case api::DynamicType::BOOLEAN:
+                        put(key, configuration->get<bool>(key).value());
+                        break;
+
+                    case api::DynamicType::INT32:
+                        put(key, configuration->get<int32_t>(key).value());
+                        break;
+
+                    case api::DynamicType::INT64:
+                        put(key, configuration->get<int64_t>(key).value());
+                        break;
+
+                    case api::DynamicType::DOUBLE:
+                        put(key, configuration->get<double>(key).value());
+                        break;
+
+                    case api::DynamicType::ARRAY:
+                        put(key, configuration->get<std::shared_ptr<DynamicArray>>(key).value());
+                        break;
+
+                    case api::DynamicType::OBJECT:
+                        put(key, configuration->get<std::shared_ptr<DynamicObject>>(key).value());
+                        break;
+
+                    case api::DynamicType::UNDEFINED:
+                        break;
+                }
+            }
+            return shared_from_this();
+        }
     }
 }

--- a/core/src/collections/DynamicObject.hpp
+++ b/core/src/collections/DynamicObject.hpp
@@ -102,6 +102,7 @@ namespace ledger {
             bool isReadOnly() override;
             void setReadOnly(bool enable);
 
+            std::shared_ptr<api::DynamicObject> updateWithConfiguration(const std::shared_ptr<DynamicObject> &configuration);
             int64_t size() override;
 
             std::ostream& dump(std::ostream& ss, int depth) const;

--- a/core/src/jni/jni/WalletPool.cpp
+++ b/core/src/jni/jni/WalletPool.cpp
@@ -116,6 +116,17 @@ CJNIEXPORT void JNICALL Java_co_ledger_core_WalletPool_00024CppProxy_native_1get
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
+CJNIEXPORT void JNICALL Java_co_ledger_core_WalletPool_00024CppProxy_native_1updateWalletConfig(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_name, jobject j_configuration, jobject j_callback)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::WalletPool>(nativeRef);
+        ref->updateWalletConfig(::djinni::String::toCpp(jniEnv, j_name),
+                                ::djinni_generated::DynamicObject::toCpp(jniEnv, j_configuration),
+                                ::djinni_generated::ErrorCodeCallback::toCpp(jniEnv, j_callback));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
+}
+
 CJNIEXPORT void JNICALL Java_co_ledger_core_WalletPool_00024CppProxy_native_1createWallet(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_name, jobject j_currency, jobject j_configuration, jobject j_callback)
 {
     try {

--- a/core/src/wallet/pool/WalletPool.hpp
+++ b/core/src/wallet/pool/WalletPool.hpp
@@ -82,6 +82,8 @@ namespace ledger {
             Future<int64_t> getWalletCount() const;
             Future<std::vector<std::shared_ptr<AbstractWallet>>> getWallets(int64_t from, int64_t size);
             FuturePtr<AbstractWallet> getWallet(const std::string& name);
+            Future<api::ErrorCode> updateWalletConfig(const std::string &name,
+                                                      const std::shared_ptr<api::DynamicObject> &configuration);
             Future<std::vector<std::string>> getWalletNames(int64_t from, int64_t size) const;
 
             // Create wallet
@@ -158,6 +160,9 @@ namespace ledger {
 
             void initializeFactories();
             std::shared_ptr<AbstractWallet> buildWallet(const WalletDatabaseEntry& entry);
+
+            static Option<WalletDatabaseEntry> getWalletEntryFromDatabase(const std::shared_ptr<WalletPool> &walletPool,
+                                                                          const std::string &name);
 
             // General
             std::string _poolName;

--- a/core/src/wallet/pool/api/WalletPoolApi.cpp
+++ b/core/src/wallet/pool/api/WalletPoolApi.cpp
@@ -109,6 +109,12 @@ namespace ledger {
             _pool->getWallet(name).callback(_mainContext, callback);
         }
 
+        void WalletPoolApi::updateWalletConfig(const std::string &name,
+                                               const std::shared_ptr<api::DynamicObject> &configuration,
+                                               const std::shared_ptr<api::ErrorCodeCallback> &callback) {
+            _pool->updateWalletConfig(name, configuration).callback(_mainContext, callback);
+        }
+
         void WalletPoolApi::createWallet(const std::string &name, const api::Currency &currency,
                                          const std::shared_ptr<api::DynamicObject> &configuration,
                                          const std::shared_ptr<api::WalletCallback> &callback) {

--- a/core/src/wallet/pool/api/WalletPoolApi.hpp
+++ b/core/src/wallet/pool/api/WalletPoolApi.hpp
@@ -52,6 +52,10 @@ namespace ledger {
 
             void getWallet(const std::string &name, const std::shared_ptr<api::WalletCallback> &callback) override;
 
+            void updateWalletConfig(const std::string &name,
+                                    const std::shared_ptr<api::DynamicObject> &configuration,
+                                    const std::shared_ptr<api::ErrorCodeCallback> &callback) override;
+
             void getWallets(int32_t from, int32_t size, const std::shared_ptr<api::WalletListCallback> &callback) override;
 
             void createWallet(const std::string &name, const api::Currency &currency,

--- a/core/test/collections/dynamics_tests.cpp
+++ b/core/test/collections/dynamics_tests.cpp
@@ -32,6 +32,7 @@
 #include <gtest/gtest.h>
 #include <ledger/core/api/DynamicArray.hpp>
 #include <ledger/core/api/DynamicObject.hpp>
+#include <ledger/core/collections/DynamicObject.hpp>
 #include <ledger/core/collections/DynamicValue.hpp>
 #include <ledger/core/utils/optional.hpp>
 
@@ -223,4 +224,29 @@ TEST(Dynamics, ObjectWithArray) {
         EXPECT_EQ(array->getData(5).value(), std::vector<uint8_t>({0x09, 0x03}));
         std::cout << object->dump() << std::endl;
     }
+}
+
+TEST(Dynamics, OverwriteDynamicObject) {
+    auto object = std::make_shared<ledger::core::DynamicObject>();
+    object->putBoolean("boolean", true)
+            ->putDouble("double", 12.6)
+            ->putString("string", "Hello World")
+            ->putInt("int", 12)
+            ->putLong("long", 16)
+            ->putData("data", {0x09, 0x03});
+
+    auto replacement = std::make_shared<ledger::core::DynamicObject>();
+    replacement->putString("string", "Hello")
+            ->putInt("int", 1)
+            ->putData("data", {0x19, 0x90});
+    
+    object->updateWithConfiguration(replacement);
+
+    EXPECT_EQ(object->size(), 6);
+    EXPECT_EQ(object->getBoolean("boolean").value(), true);
+    EXPECT_EQ(object->getDouble("double").value(), 12.6);
+    EXPECT_EQ(object->getString("string").value(), "Hello");
+    EXPECT_EQ(object->getInt("int").value(), 1);
+    EXPECT_EQ(object->getLong("long").value(), 16);
+    EXPECT_EQ(object->getData("data").value(), std::vector<uint8_t>({0x19, 0x90}));
 }


### PR DESCRIPTION
Wallet's configuration is provided to Wallet Pool when instantiating this same wallet, then persisted in our DB.
So when recovering a wallet we use same persisted configuration, so basically there is no way to update the configuration, except deleting the wallet and recreating it (SFYL)
We provide now a way to update the wallet's configuration, only fields present in the new configuration will be updated, others remain intact !

**Note**: user should be careful how to use this method:
- A new instance of wallet should be fetched from the Wallet Pool (e.g. through `getWallet` method) to get a wallet instance with the updated configuration,
- User should NOT update some fields (e.g. derivation scheme, keychain engine ...) that are defining the wallet itself (we can imagine in the future having of blacklisted fields and return an Error Code for that)