### PR TITLE
LLC-186: Add flag to avoid crash for 10.10.x macOS versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,13 @@ list(APPEND INCLUDE_DIRECTORIES core/test/include/)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Fix LLC-186: Add this flag to avoid crash for 10.10.x version
+# https://stackoverflow.com/questions/41865537/how-does-apples-codesign-utility-decide-which-sha-algorithms-to-sign-a-shared
+# Notes:
+# > This is a "blind" fix, no available 10.10.x macOS machine,
+# > Issue is specific to 10.10.x, 10.9.5 and > 10.10.x are fine
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X version to target for deployment: 10.9" FORCE)
+
 set(CMAKE_MACOSX_RPATH 1)
 
 add_definitions("-DSQLITE_HAS_CODEC")

--- a/core/lib/cmake/ProjectSecp256k1.cmake
+++ b/core/lib/cmake/ProjectSecp256k1.cmake
@@ -17,6 +17,10 @@ if (CMAKE_OSX_SYSROOT)
     set(_osx_sysroot_ -DCMAKE_OSX_SYSROOT:STRING=${CMAKE_OSX_SYSROOT})
 endif()
 
+if (CMAKE_OSX_DEPLOYMENT_TARGET)
+    set(_osx_deploy_target_ -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET})
+endif()
+
 if (CMAKE_BUILD_TYPE)
     set(_build_type_ -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE})
 endif()
@@ -42,7 +46,7 @@ ExternalProject_Add(
         -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
         ${_toolchain_file_}
         ${_only_release_configuration}
-        CMAKE_CACHE_ARGS ${_osx_arch_} ${_osx_sysroot_} ${_build_type_}
+        CMAKE_CACHE_ARGS ${_osx_arch_} ${_osx_sysroot_} ${_osx_deploy_target_} ${_build_type_}
         LOG_CONFIGURE 1
         LOG_INSTALL 1
         LOG_BUILD 1


### PR DESCRIPTION
After some investigation, it seems to be specific to `10.10.x`:
https://forums.developer.apple.com/thread/68470
https://stackoverflow.com/questions/41865537/how-does-apples-codesign-utility-decide-which-sha-algorithms-to-sign-a-shared

This is detected just now because Live jumped from `1.1.9` to `2.6.0` in the meantime we updated so many things about our build and CI, so ...
 
**Notes:**
- This is a "blind" fix, no available 10.10.x macOS machine,
- ssue is specific to 10.10.x, 10.9.5 and > 10.10.x are fine