### PR TITLE
Fix updateWalletConfig method

### DIFF
--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
@@ -606,7 +606,7 @@ namespace ledger {
                     }
 
                     //Store in DB
-                    self->putTransaction(sql, txExplorer);
+                    return self->putTransaction(sql, txExplorer);
                 });
 
                 // Failing optimistic update should not throw an exception

--- a/core/src/wallet/pool/WalletPool.cpp
+++ b/core/src/wallet/pool/WalletPool.cpp
@@ -318,6 +318,9 @@ namespace ledger {
                 walletEntry.configuration->updateWithConfiguration(std::static_pointer_cast<ledger::core::DynamicObject>(configuration));
                 soci::session sql(self->getDatabaseSessionPool()->getPool());
                 PoolDatabaseHelper::putWallet(sql, walletEntry);
+                // No need to check if currency supported (factory non null), because we are supposed to fetch
+                // walletEntry from database, which implies that it was already checked before at creation
+                self->_wallets[walletEntry.uid] = self->getFactory(walletEntry.currencyName)->build(walletEntry);
                 return api::ErrorCode::FUTURE_WAS_SUCCESSFULL;
             });
         }

--- a/core/src/wallet/pool/database/PoolDatabaseHelper.cpp
+++ b/core/src/wallet/pool/database/PoolDatabaseHelper.cpp
@@ -48,7 +48,7 @@ namespace ledger {
                         use(DateUtils::now());
             } else {
                 sql << "UPDATE wallets SET configuration = :configuration WHERE uid = :uid",
-                into(configuration), use(wallet.uid);
+                use(configuration), use(wallet.uid);
             }
         }
 

--- a/core/test/integration/CMakeLists.txt
+++ b/core/test/integration/CMakeLists.txt
@@ -154,6 +154,7 @@ add_test (NAME ledger-core-integration-WalletTests.GetAccountAfterPoolReopen COM
 add_test (NAME ledger-core-integration-WalletTests.CreateNonContiguousAccount COMMAND ledger-core-integration-tests --gtest_filter="WalletTests.CreateNonContiguousAccount")
 add_test (NAME ledger-core-integration-WalletTests.CreateNonContiguousAccountBis COMMAND ledger-core-integration-tests --gtest_filter="WalletTests.CreateNonContiguousAccountBis")
 add_test (NAME ledger-core-integration-WalletTests.CreateAccountBug COMMAND ledger-core-integration-tests --gtest_filter="WalletTests.CreateAccountBug")
+add_test (NAME ledger-core-integration-WalletTests.ChangeWalletConfig COMMAND ledger-core-integration-tests --gtest_filter="WalletTests.ChangeWalletConfig")
 
 add_test (NAME ledger-core-integration-EthereumLikeWalletSynchronization.MediumXpubSynchronization COMMAND ledger-core-integration-tests --gtest_filter="EthereumLikeWalletSynchronization.MediumXpubSynchronization")
 add_test (NAME ledger-core-integration-EthereumLikeWalletSynchronization.XpubSynchronization COMMAND ledger-core-integration-tests --gtest_filter="EthereumLikeWalletSynchronization.XpubSynchronization")


### PR DESCRIPTION
Basically updateWalletConfig was not working and test covering it was not triggered because it was missing from `CMakeLists.txt` ... meh !
Also we were not using the configuration in the `UPDATE` sql call ... meh ! 