### PR TITLE
ETH Fix: Parse balance from explorer as string

### DIFF
--- a/core/src/net/HttpClient.hpp
+++ b/core/src/net/HttpClient.hpp
@@ -88,7 +88,7 @@ namespace ledger {
                 });
             }
 
-            Future<JsonResult> json() const;
+            Future<JsonResult> json(bool parseNumbersAsString = false) const;
             std::shared_ptr<api::HttpRequest> toApiRequest() const;
 
 


### PR DESCRIPTION
This is an urgent fix for Vault ! 
Later, we can use a template based `json` method (based on `rapidjson::ParseFlag`) 