### PR TITLE
Point leveldb submodule back to LedgerHQ

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
     url = https://github.com/gabime/spdlog.git
 [submodule "core/lib/leveldb"]
     path = core/lib/leveldb
-    url = https://github.com/teams2ua/leveldb.git
+    url = https://github.com/LedgerHQ/leveldb.git
 [submodule "core/lib/ethash"]
     path = core/lib/ethash
     url = https://github.com/LedgerHQ/ethash.git
@@ -20,5 +20,5 @@
     path = core/test/lib/googletest
     url = https://github.com/google/googletest.git
 [submodule "core/lib/fmt"]
-	path = core/lib/fmt
-	url = https://github.com/fmtlib/fmt.git
+    path = core/lib/fmt
+    url = https://github.com/fmtlib/fmt.git


### PR DESCRIPTION
We have CMakeLists.txt in our repo, this is the only difference that we care about (in upstream there where one commit to support old versions of VSs), we could move our CMakeLists.txt out of repo and be upstream, but [FAR]