### PR TITLE
Review password encoding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 > ????/??/??
 
+- Change encoding of passwords in the public interface (wallet pool). Passwords are not optional
+  anymore. This means that:
+    - `Optional::NONE` and `Optional("")` (that were both ambiguity encoding) are now replaced by
+      the empty string.
+    - Because the empty string is used to state _no password_, empty passwords cannot be used
+      anymore. The previous situation was that empty passwords were allowed but transformed into a
+      `Optional::NONE`, which was a bit confusing.
 - Native Segwit support:
     - Implement P2WPKH and P2WSH keychains, references:
         - BIP141: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#P2WSH

--- a/core/idl/wallet/wallet_pool.djinni
+++ b/core/idl/wallet/wallet_pool.djinni
@@ -17,12 +17,11 @@
 @import "common/wallet.djinni"
 @import "../debug/logger.djinni"
 
-
 # Class respresenting a pool of wallets.
 WalletPool = interface +c {
     # Create a new instance of WalletPool object.
     # @param name, string, name of the wallet pool
-    # @param password, optional string, password to lock wallet pool
+    # @param password, string, password to lock wallet pool (empty string means no password)
     # @param http, HttpClient object, http client used for all calls made by wallet pool (and aggregated wallets)
     # @param webSocketClient, WebSocketClient object, socket through which wallet pool observe and get notified (explorer, DBs ...)
     # @param pathResolver, PathResolver Object, resolve paths to logs, databases, preferences ...
@@ -32,11 +31,18 @@ WalletPool = interface +c {
     # @param backend, DatabseBackend object, DB in which wallet pool store all required infos (created wallets, their options, their accounts ...)
     # @param configuration, DynamicObject object, desired configuration for this wallet pool
     # @return WalletPool object, instance of WalletPool
-    static newInstance(name: string, password: optional<string>, httpClient: HttpClient,
-                        webSocketClient: WebSocketClient, pathResolver: PathResolver,
-                        logPrinter: LogPrinter, dispatcher: ThreadDispatcher,
-                        rng: RandomNumberGenerator, backend: DatabaseBackend,
-                        configuration: DynamicObject): WalletPool;
+    static newInstance(
+        name: string,
+        password: string,
+        httpClient: HttpClient,
+        webSocketClient: WebSocketClient,
+        pathResolver: PathResolver,
+        logPrinter: LogPrinter,
+        dispatcher: ThreadDispatcher,
+        rng: RandomNumberGenerator,
+        backend: DatabaseBackend,
+        configuration: DynamicObject
+    ): WalletPool;
 
     # Return used logger to dump logs in defined log path by PathResolver.
     # @return Logger object

--- a/core/src/api/WalletPool.hpp
+++ b/core/src/api/WalletPool.hpp
@@ -4,7 +4,6 @@
 #ifndef DJINNI_GENERATED_WALLETPOOL_HPP
 #define DJINNI_GENERATED_WALLETPOOL_HPP
 
-#include "../utils/optional.hpp"
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -47,7 +46,7 @@ public:
     /**
      * Create a new instance of WalletPool object.
      * @param name, string, name of the wallet pool
-     * @param password, optional string, password to lock wallet pool
+     * @param password, string, password to lock wallet pool (empty string means no password)
      * @param http, HttpClient object, http client used for all calls made by wallet pool (and aggregated wallets)
      * @param webSocketClient, WebSocketClient object, socket through which wallet pool observe and get notified (explorer, DBs ...)
      * @param pathResolver, PathResolver Object, resolve paths to logs, databases, preferences ...
@@ -58,7 +57,7 @@ public:
      * @param configuration, DynamicObject object, desired configuration for this wallet pool
      * @return WalletPool object, instance of WalletPool
      */
-    static std::shared_ptr<WalletPool> newInstance(const std::string & name, const std::experimental::optional<std::string> & password, const std::shared_ptr<HttpClient> & httpClient, const std::shared_ptr<WebSocketClient> & webSocketClient, const std::shared_ptr<PathResolver> & pathResolver, const std::shared_ptr<LogPrinter> & logPrinter, const std::shared_ptr<ThreadDispatcher> & dispatcher, const std::shared_ptr<RandomNumberGenerator> & rng, const std::shared_ptr<DatabaseBackend> & backend, const std::shared_ptr<DynamicObject> & configuration);
+    static std::shared_ptr<WalletPool> newInstance(const std::string & name, const std::string & password, const std::shared_ptr<HttpClient> & httpClient, const std::shared_ptr<WebSocketClient> & webSocketClient, const std::shared_ptr<PathResolver> & pathResolver, const std::shared_ptr<LogPrinter> & logPrinter, const std::shared_ptr<ThreadDispatcher> & dispatcher, const std::shared_ptr<RandomNumberGenerator> & rng, const std::shared_ptr<DatabaseBackend> & backend, const std::shared_ptr<DynamicObject> & configuration);
 
     /**
      * Return used logger to dump logs in defined log path by PathResolver.

--- a/core/src/jni/jni/WalletPool.cpp
+++ b/core/src/jni/jni/WalletPool.cpp
@@ -43,7 +43,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_WalletPool_newInstance(JNIEnv* jn
     try {
         DJINNI_FUNCTION_PROLOGUE0(jniEnv);
         auto r = ::ledger::core::api::WalletPool::newInstance(::djinni::String::toCpp(jniEnv, j_name),
-                                                              ::djinni::Optional<std::experimental::optional, ::djinni::String>::toCpp(jniEnv, j_password),
+                                                              ::djinni::String::toCpp(jniEnv, j_password),
                                                               ::djinni_generated::HttpClient::toCpp(jniEnv, j_httpClient),
                                                               ::djinni_generated::WebSocketClient::toCpp(jniEnv, j_webSocketClient),
                                                               ::djinni_generated::PathResolver::toCpp(jniEnv, j_pathResolver),

--- a/core/src/wallet/pool/WalletPool.hpp
+++ b/core/src/wallet/pool/WalletPool.hpp
@@ -74,7 +74,7 @@ namespace ledger {
             std::shared_ptr<DynamicObject> getConfiguration() const;
             std::shared_ptr<api::EventBus> getEventBus() const;
             const std::string& getName() const;
-            const Option<std::string> getPassword() const;
+            const std::string getPassword() const;
 
             std::shared_ptr<AbstractWalletFactory> getFactory(const std::string& currencyName) const;
 
@@ -111,7 +111,7 @@ namespace ledger {
             Future<Unit> removeCurrency(const std::string& currencyName);
             static std::shared_ptr<WalletPool> newInstance(
                 const std::string &name,
-                const Option<std::string> &password,
+                const std::string &password,
                 const std::shared_ptr<api::HttpClient> &httpClient,
                 const std::shared_ptr<api::WebSocketClient> &webSocketClient,
                 const std::shared_ptr<api::PathResolver> &pathResolver,
@@ -143,7 +143,7 @@ namespace ledger {
         private:
             WalletPool(
                 const std::string &name,
-                const Option<std::string> &password,
+                const std::string &password,
                 const std::shared_ptr<api::HttpClient> &httpClient,
                 const std::shared_ptr<api::WebSocketClient> &webSocketClient,
                 const std::shared_ptr<api::PathResolver> &pathResolver,
@@ -166,7 +166,7 @@ namespace ledger {
 
             // General
             std::string _poolName;
-            Option<std::string> _password;
+            std::string _password;
             std::shared_ptr<DynamicObject> _configuration;
 
             // File system management

--- a/core/src/wallet/pool/api/WalletPoolApi.cpp
+++ b/core/src/wallet/pool/api/WalletPoolApi.cpp
@@ -43,7 +43,8 @@ namespace ledger {
     namespace core {
         std::shared_ptr<api::WalletPool>
         api::WalletPool::newInstance(
-            const std::string &name, const optional<std::string> &password,
+            const std::string &name,
+            const std::string &password,
             const std::shared_ptr<api::HttpClient> &httpClient,
             const std::shared_ptr<api::WebSocketClient> &webSocketClient,
             const std::shared_ptr<api::PathResolver> &pathResolver,
@@ -53,25 +54,26 @@ namespace ledger {
             const std::shared_ptr<api::DatabaseBackend> &backend,
             const std::shared_ptr<api::DynamicObject> &configuration
         ) {
-            auto pool = ledger::core::WalletPool::newInstance(name, Option<std::string>(password), httpClient, webSocketClient, pathResolver, logPrinter, dispatcher, rng, backend, configuration);
+            auto pool = ledger::core::WalletPool::newInstance(name, password, httpClient, webSocketClient, pathResolver, logPrinter, dispatcher, rng, backend, configuration);
             return std::make_shared<WalletPoolApi>(pool);
         }
 
-        void WalletPoolApi::open(const std::string &name, const std::experimental::optional<std::string> &password,
-                                 const std::shared_ptr<api::HttpClient> &httpClient,
-                                 const std::shared_ptr<api::WebSocketClient> &webSocketClient,
-                                 const std::shared_ptr<api::PathResolver> &pathResolver,
-                                 const std::shared_ptr<api::LogPrinter> &logPrinter,
-                                 const std::shared_ptr<api::ThreadDispatcher> &dispatcher,
-                                 const std::shared_ptr<api::RandomNumberGenerator> &rng,
-                                 const std::shared_ptr<api::DatabaseBackend> &backend,
-                                 const std::shared_ptr<api::DynamicObject>& configuration,
-                                 const std::shared_ptr<api::WalletPoolCallback> &listener) {
+        void WalletPoolApi::open(const std::string &name,
+            const std::string &password,
+            const std::shared_ptr<api::HttpClient> &httpClient,
+            const std::shared_ptr<api::WebSocketClient> &webSocketClient,
+            const std::shared_ptr<api::PathResolver> &pathResolver,
+            const std::shared_ptr<api::LogPrinter> &logPrinter,
+            const std::shared_ptr<api::ThreadDispatcher> &dispatcher,
+            const std::shared_ptr<api::RandomNumberGenerator> &rng,
+            const std::shared_ptr<api::DatabaseBackend> &backend,
+            const std::shared_ptr<api::DynamicObject>& configuration,
+            const std::shared_ptr<api::WalletPoolCallback> &listener) {
             auto context = dispatcher->getSerialExecutionContext(fmt::format("pool_queue_{}", name));
             FuturePtr<WalletPoolApi>::async(context, [=] () {
                 auto pool = ledger::core::WalletPool::newInstance(
                     name,
-                    Option<std::string>(password),
+                    password,
                     httpClient,
                     webSocketClient,
                     pathResolver,

--- a/core/src/wallet/pool/api/WalletPoolApi.hpp
+++ b/core/src/wallet/pool/api/WalletPoolApi.hpp
@@ -90,7 +90,7 @@ namespace ledger {
 
         public:
             static void open( const std::string &name,
-                              const std::experimental::optional<std::string> &password,
+                              const std::string &password,
                               const std::shared_ptr<api::HttpClient> &httpClient,
                               const std::shared_ptr<api::WebSocketClient> &webSocketClient,
                               const std::shared_ptr<api::PathResolver> &pathResolver,

--- a/core/src/wallet/pool/api/WalletPoolBuilder.hpp
+++ b/core/src/wallet/pool/api/WalletPoolBuilder.hpp
@@ -82,7 +82,7 @@ namespace ledger {
             std::shared_ptr<api::LogPrinter> _logPrinter;
             std::shared_ptr<api::ThreadDispatcher> _dispatcher;
             std::string _name;
-            std::experimental::optional<std::string> _password;
+            std::string _password;
             std::shared_ptr<api::RandomNumberGenerator> _rng;
             std::shared_ptr<api::DatabaseBackend> _backend;
             std::shared_ptr<api::DynamicObject> _configuration;

--- a/core/test/database/BaseFixture.cpp
+++ b/core/test/database/BaseFixture.cpp
@@ -65,7 +65,7 @@ void BaseFixture::TearDown() {
 std::shared_ptr<WalletPool> BaseFixture::newDefaultPool(std::string poolName) {
     return WalletPool::newInstance(
             poolName,
-            Option<std::string>::NONE,
+            "",
             http,
             nullptr,
             resolver,

--- a/core/test/database/pool_tests.cpp
+++ b/core/test/database/pool_tests.cpp
@@ -92,7 +92,7 @@ TEST(DatabaseSessionPool, InitializeCurrencies) {
     auto printer = std::make_shared<CoutLogPrinter>(dispatcher->getMainExecutionContext());
     auto pool = WalletPool::newInstance(
     "my_pool",
-    Option<std::string>::NONE,
+    "",
     nullptr,
     nullptr,
     resolver,

--- a/core/test/integration/BaseFixture.cpp
+++ b/core/test/integration/BaseFixture.cpp
@@ -110,7 +110,7 @@ void BaseFixture::TearDown() {
 std::shared_ptr<WalletPool> BaseFixture::newDefaultPool(std::string poolName) {
     return WalletPool::newInstance(
             poolName,
-            Option<std::string>("test"),
+            "test",
             http,
             ws,
             resolver,


### PR DESCRIPTION
This commit removes and replaces the optional string encoding by a
mandatory string. It means that both Optional::NONE and Optional("") are
mapped to "": empty passwords are never accepted for encoding, so they
no mean “no password”.

As soon as this commit gets merged, the bindings must be updated
accordingly as well as any dependent application as this is a breaking
change.