### PR TITLE
Fix Bech32

### DIFF
--- a/core/src/bitcoin/bech32/Bech32Factory.cpp
+++ b/core/src/bitcoin/bech32/Bech32Factory.cpp
@@ -34,13 +34,13 @@
 #include <utils/Exception.hpp>
 namespace ledger {
     namespace core {
-        std::shared_ptr<Bech32> Bech32Factory::newBech32Instance(const std::string &networkIdentifier) {
+        Option<std::shared_ptr<Bech32>> Bech32Factory::newBech32Instance(const std::string &networkIdentifier) {
             if (networkIdentifier == "btc" || networkIdentifier == "btc_testnet") {
-                return std::make_shared<BTCBech32>(networkIdentifier);
+                return Option<std::shared_ptr<Bech32>>(std::make_shared<BTCBech32>(networkIdentifier));
             } else if (networkIdentifier == "abc") {
-                return std::make_shared<BCHBech32>();
+                return Option<std::shared_ptr<Bech32>>(std::make_shared<BCHBech32>());
             }
-            throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Can not instanciate Bech32 for {}", networkIdentifier);
+            return Option<std::shared_ptr<Bech32>>();
         }
     }
 }

--- a/core/src/bitcoin/bech32/Bech32Factory.h
+++ b/core/src/bitcoin/bech32/Bech32Factory.h
@@ -35,11 +35,12 @@
 #include "Bech32.h"
 #include <string>
 #include <memory>
+#include <utils/Option.hpp>
 namespace ledger {
     namespace core {
         class Bech32Factory {
         public:
-            static std::shared_ptr<Bech32> newBech32Instance(const std::string &networkIdentifier);
+            static Option<std::shared_ptr<Bech32>> newBech32Instance(const std::string &networkIdentifier);
         };
     }
 }

--- a/core/test/integration/transactions/bitcoin_P2WPKH_transaction_tests.cpp
+++ b/core/test/integration/transactions/bitcoin_P2WPKH_transaction_tests.cpp
@@ -49,7 +49,7 @@ struct BitcoinMakeP2WPKHTransaction : public BitcoinMakeBaseTransaction {
 TEST_F(BitcoinMakeP2WPKHTransaction, CreateStandardP2WPKHWithOneOutput) {
     auto builder = tx_builder();
     auto freshAddress = wait(account->getFreshPublicAddresses())[0];
-    auto hrp = Bech32Factory::newBech32Instance("btc")->getBech32Params().hrp;
+    auto hrp = Bech32Factory::newBech32Instance("btc").getValue()->getBech32Params().hrp;
     auto freshAddressStr = freshAddress->asBitcoinLikeAddress()->toBech32();
     EXPECT_EQ(freshAddressStr.substr(0, hrp.size()), hrp);
     auto balance = wait(account->getBalance());

--- a/core/test/integration/transactions/bitcoin_P2WSH_transaction_tests.cpp
+++ b/core/test/integration/transactions/bitcoin_P2WSH_transaction_tests.cpp
@@ -49,7 +49,7 @@ struct BitcoinMakeP2WSHTransaction : public BitcoinMakeBaseTransaction {
 TEST_F(BitcoinMakeP2WSHTransaction, CreateStandardP2WSHWithOneOutput) {
     auto builder = tx_builder();
     auto freshAddress = wait(account->getFreshPublicAddresses())[0];
-    auto hrp = Bech32Factory::newBech32Instance("btc")->getBech32Params().hrp;
+    auto hrp = Bech32Factory::newBech32Instance("btc").getValue()->getBech32Params().hrp;
     auto freshAddressStr = freshAddress->asBitcoinLikeAddress()->toBech32();
     EXPECT_EQ(freshAddressStr.substr(0, hrp.size()), hrp);
     auto balance = wait(account->getBalance());


### PR DESCRIPTION
Return optional from `newBech32Instance`: `BitcoinLikeAddress::parse` method now checks if optional has a value
Other calls to `newBech32Instance`, from`toBech32`, `fromBech32` ... should has a value (throw otherwise) 