### PR TITLE
Preparing optional for C++17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
-## 2.7.0 (on-going)
+## 2.8.0 (on-going)
 
-> ????/??/??
+> YYYY/MM/DD
+
+- Change std::experimental::optional to std::ledger_exp::optional
+
+## 2.7.0
+
+> 2019/04/15
 
 - Change encoding of passwords in the public interface (wallet pool). Passwords are not optional
   anymore. This means that:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(UseBackportedModules)
 
 # The project version number.
 set(VERSION_MAJOR   2   CACHE STRING "Project major version number.")
-set(VERSION_MINOR   7   CACHE STRING "Project minor version number.")
+set(VERSION_MINOR   8   CACHE STRING "Project minor version number.")
 set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 

--- a/core/src/api/AccountCallback.hpp
+++ b/core/src/api/AccountCallback.hpp
@@ -29,7 +29,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::shared_ptr<Account> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::shared_ptr<Account> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/AccountCreationInfoCallback.hpp
+++ b/core/src/api/AccountCreationInfoCallback.hpp
@@ -28,7 +28,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::experimental::optional<AccountCreationInfo> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::ledger_exp::optional<AccountCreationInfo> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/AccountListCallback.hpp
+++ b/core/src/api/AccountListCallback.hpp
@@ -30,7 +30,7 @@ public:
      * @params result optional of type list<T>, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::experimental::optional<std::vector<std::shared_ptr<Account>>> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<Account>>> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/Address.hpp
+++ b/core/src/api/Address.hpp
@@ -28,7 +28,7 @@ public:
      * Gets an optional derivation path (if the address is owned by an account).
      * @return The derivation path of the address
      */
-    virtual std::experimental::optional<std::string> getDerivationPath() = 0;
+    virtual std::ledger_exp::optional<std::string> getDerivationPath() = 0;
 
     /**
      * Serialize the address to a string. The serialization method depends of the underlying currency and

--- a/core/src/api/AddressListCallback.hpp
+++ b/core/src/api/AddressListCallback.hpp
@@ -30,7 +30,7 @@ public:
      * @params result optional of type list<T>, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::experimental::optional<std::vector<std::shared_ptr<Address>>> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<Address>>> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/Amount.hpp
+++ b/core/src/api/Amount.hpp
@@ -76,7 +76,7 @@ public:
     virtual double toDouble() = 0;
 
     /** Format an amount with a locale and some formatting rules. */
-    virtual std::string format(const Locale & locale, const std::experimental::optional<FormatRules> & rules) = 0;
+    virtual std::string format(const Locale & locale, const std::ledger_exp::optional<FormatRules> & rules) = 0;
 
     /** Transform an hexadecimal string into an amount (expressed in the given currency). */
     static std::shared_ptr<Amount> fromHex(const Currency & currency, const std::string & hex);

--- a/core/src/api/AmountCallback.hpp
+++ b/core/src/api/AmountCallback.hpp
@@ -29,7 +29,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::shared_ptr<Amount> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::shared_ptr<Amount> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/AmountListCallback.hpp
+++ b/core/src/api/AmountListCallback.hpp
@@ -30,7 +30,7 @@ public:
      * @params result optional of type list<T>, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::experimental::optional<std::vector<std::shared_ptr<Amount>>> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<Amount>>> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/BinaryCallback.hpp
+++ b/core/src/api/BinaryCallback.hpp
@@ -29,7 +29,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::experimental::optional<std::vector<uint8_t>> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::ledger_exp::optional<std::vector<uint8_t>> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/BitcoinLikeAccount.hpp
+++ b/core/src/api/BitcoinLikeAccount.hpp
@@ -48,7 +48,7 @@ public:
 
     virtual void broadcastTransaction(const std::shared_ptr<BitcoinLikeTransaction> & transaction, const std::shared_ptr<StringCallback> & callback) = 0;
 
-    virtual std::shared_ptr<BitcoinLikeTransactionBuilder> buildTransaction(std::experimental::optional<bool> partial) = 0;
+    virtual std::shared_ptr<BitcoinLikeTransactionBuilder> buildTransaction(std::ledger_exp::optional<bool> partial) = 0;
 
     /**
      * Get fees from network, fees are ordered in descending order (i.e. fastest to slowest confirmation)

--- a/core/src/api/BitcoinLikeInput.hpp
+++ b/core/src/api/BitcoinLikeInput.hpp
@@ -31,7 +31,7 @@ public:
     virtual ~BitcoinLikeInput() {}
 
     /** Returns the address of the input (if an address can be computed). */
-    virtual std::experimental::optional<std::string> getAddress() = 0;
+    virtual std::ledger_exp::optional<std::string> getAddress() = 0;
 
     /**
      * Returns the public associated with the address. This value can be NULL if you are building a transaction with an
@@ -52,7 +52,7 @@ public:
      * Get the transaction hash of the output spent by this input. The result can be NULL if the output is not owned by
      * the wallet.
      */
-    virtual std::experimental::optional<std::string> getPreviousTxHash() = 0;
+    virtual std::ledger_exp::optional<std::string> getPreviousTxHash() = 0;
 
     /**
      * Check whether input is for a coinbase.
@@ -64,13 +64,13 @@ public:
      * Stored data cointained in coinbase.
      * @return Optional String
      */
-    virtual std::experimental::optional<std::string> getCoinbase() = 0;
+    virtual std::ledger_exp::optional<std::string> getCoinbase() = 0;
 
     /**
      * Get output index, it identifies which UTXO from tht transaction to spend.
      * @return Optional 32 bits integer, index of previous transaction
      */
-    virtual std::experimental::optional<int32_t> getPreviousOutputIndex() = 0;
+    virtual std::ledger_exp::optional<int32_t> getPreviousOutputIndex() = 0;
 
     /**
      * Retrieve the output spent by this input. Depending on the implementation this method may

--- a/core/src/api/BitcoinLikeOutput.hpp
+++ b/core/src/api/BitcoinLikeOutput.hpp
@@ -58,7 +58,7 @@ public:
      * Get address that spent the output.
      * @return Optional String, address that spent
      */
-    virtual std::experimental::optional<std::string> getAddress() = 0;
+    virtual std::ledger_exp::optional<std::string> getAddress() = 0;
 
     virtual std::shared_ptr<DerivationPath> getDerivationPath() = 0;
 };

--- a/core/src/api/BitcoinLikeOutputListCallback.hpp
+++ b/core/src/api/BitcoinLikeOutputListCallback.hpp
@@ -30,7 +30,7 @@ public:
      * @params result optional of type list<T>, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::experimental::optional<std::vector<std::shared_ptr<BitcoinLikeOutput>>> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<BitcoinLikeOutput>>> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/BitcoinLikeScriptChunk.hpp
+++ b/core/src/api/BitcoinLikeScriptChunk.hpp
@@ -28,9 +28,9 @@ public:
 
     virtual bool isPushedData() = 0;
 
-    virtual std::experimental::optional<BitcoinLikeOperator> getOperator() = 0;
+    virtual std::ledger_exp::optional<BitcoinLikeOperator> getOperator() = 0;
 
-    virtual std::experimental::optional<std::vector<uint8_t>> getPushedData() = 0;
+    virtual std::ledger_exp::optional<std::vector<uint8_t>> getPushedData() = 0;
 
     virtual std::shared_ptr<BitcoinLikeScriptChunk> next() = 0;
 

--- a/core/src/api/BitcoinLikeTransaction.hpp
+++ b/core/src/api/BitcoinLikeTransaction.hpp
@@ -56,7 +56,7 @@ public:
     virtual std::chrono::system_clock::time_point getTime() = 0;
 
     /** Get the timestamps serialized in the raw transaction if the underlying currency handles it. */
-    virtual std::experimental::optional<int32_t> getTimestamp() = 0;
+    virtual std::ledger_exp::optional<int32_t> getTimestamp() = 0;
 
     /** Get Transaction version. */
     virtual int32_t getVersion() = 0;
@@ -68,7 +68,7 @@ public:
     virtual std::vector<uint8_t> serializeOutputs() = 0;
 
     /** Get the witness if the underlying transaction is a segwit transaction. */
-    virtual std::experimental::optional<std::vector<uint8_t>> getWitness() = 0;
+    virtual std::ledger_exp::optional<std::vector<uint8_t>> getWitness() = 0;
 
     /**
      * Estimate the size of the raw transaction in bytes. This method returns a minimum estimated size and a maximum estimated

--- a/core/src/api/BitcoinLikeTransactionBuilder.hpp
+++ b/core/src/api/BitcoinLikeTransactionBuilder.hpp
@@ -124,7 +124,7 @@ public:
      * Parsing unsigned transaction.
      * parsing a tx might change depending on block height we are on (if an update is effective starting from a given hight)
      */
-    static std::shared_ptr<BitcoinLikeTransaction> parseRawUnsignedTransaction(const Currency & currency, const std::vector<uint8_t> & rawTransaction, std::experimental::optional<int32_t> currentBlockHeight);
+    static std::shared_ptr<BitcoinLikeTransaction> parseRawUnsignedTransaction(const Currency & currency, const std::vector<uint8_t> & rawTransaction, std::ledger_exp::optional<int32_t> currentBlockHeight);
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/BitcoinLikeTransactionCallback.hpp
+++ b/core/src/api/BitcoinLikeTransactionCallback.hpp
@@ -29,7 +29,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::shared_ptr<BitcoinLikeTransaction> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::shared_ptr<BitcoinLikeTransaction> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/BitcoinLikeTransactionRequest.hpp
+++ b/core/src/api/BitcoinLikeTransactionRequest.hpp
@@ -27,13 +27,13 @@ struct BitcoinLikeTransactionRequest final {
     /** Optional Amount object, amount of total fees. */
     std::shared_ptr<Amount> totalFees;
     /** Optional 32 bits integer, transaction's lock time (refer to BitcoinLikeTransaction class). */
-    std::experimental::optional<int32_t> lockTime;
+    std::ledger_exp::optional<int32_t> lockTime;
 
     BitcoinLikeTransactionRequest(std::vector<std::shared_ptr<BitcoinLikeOutput>> utxo_,
                                   std::vector<std::shared_ptr<BitcoinLikeOutput>> outputs_,
                                   std::shared_ptr<Amount> baseFees_,
                                   std::shared_ptr<Amount> totalFees_,
-                                  std::experimental::optional<int32_t> lockTime_)
+                                  std::ledger_exp::optional<int32_t> lockTime_)
     : utxo(std::move(utxo_))
     , outputs(std::move(outputs_))
     , baseFees(std::move(baseFees_))

--- a/core/src/api/BlockCallback.hpp
+++ b/core/src/api/BlockCallback.hpp
@@ -28,7 +28,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::experimental::optional<Block> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::ledger_exp::optional<Block> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/Currency.hpp
+++ b/core/src/api/Currency.hpp
@@ -37,20 +37,20 @@ struct Currency final {
      *TODO: find a better solution to have only a networkParameters
      * Optional BitcoinLikeNetworkParameters, for more details refer to BitcoinLikeNetworkParameters doc
      */
-    std::experimental::optional<BitcoinLikeNetworkParameters> bitcoinLikeNetworkParameters;
+    std::ledger_exp::optional<BitcoinLikeNetworkParameters> bitcoinLikeNetworkParameters;
     /** Optional EthereumLikeNetworkParameters, for more details refer to EthereumLikeNetworkParameters doc */
-    std::experimental::optional<EthereumLikeNetworkParameters> ethereumLikeNetworkParameters;
+    std::ledger_exp::optional<EthereumLikeNetworkParameters> ethereumLikeNetworkParameters;
     /**Optional EthereumLikeNetworkParameters, for more details refer to EthereumLikeNetworkParameters doc */
-    std::experimental::optional<RippleLikeNetworkParameters> rippleLikeNetworkParameters;
+    std::ledger_exp::optional<RippleLikeNetworkParameters> rippleLikeNetworkParameters;
 
     Currency(WalletType walletType_,
              std::string name_,
              int32_t bip44CoinType_,
              std::string paymentUriScheme_,
              std::vector<CurrencyUnit> units_,
-             std::experimental::optional<BitcoinLikeNetworkParameters> bitcoinLikeNetworkParameters_,
-             std::experimental::optional<EthereumLikeNetworkParameters> ethereumLikeNetworkParameters_,
-             std::experimental::optional<RippleLikeNetworkParameters> rippleLikeNetworkParameters_)
+             std::ledger_exp::optional<BitcoinLikeNetworkParameters> bitcoinLikeNetworkParameters_,
+             std::ledger_exp::optional<EthereumLikeNetworkParameters> ethereumLikeNetworkParameters_,
+             std::ledger_exp::optional<RippleLikeNetworkParameters> rippleLikeNetworkParameters_)
     : walletType(std::move(walletType_))
     , name(std::move(name_))
     , bip44CoinType(std::move(bip44CoinType_))

--- a/core/src/api/CurrencyCallback.hpp
+++ b/core/src/api/CurrencyCallback.hpp
@@ -28,7 +28,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::experimental::optional<Currency> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::ledger_exp::optional<Currency> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/CurrencyListCallback.hpp
+++ b/core/src/api/CurrencyListCallback.hpp
@@ -29,7 +29,7 @@ public:
      * @params result optional of type list<T>, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::experimental::optional<std::vector<Currency>> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::ledger_exp::optional<std::vector<Currency>> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/DynamicArray.hpp
+++ b/core/src/api/DynamicArray.hpp
@@ -94,42 +94,42 @@ public:
      * @param index, 64-bit integer
      * @return Optional string
      */
-    virtual std::experimental::optional<std::string> getString(int64_t index) = 0;
+    virtual std::ledger_exp::optional<std::string> getString(int64_t index) = 0;
 
     /**
      * Get 32-bit integer at a given index.
      * @param index, 64-bit integer
      * @return Optional 32-bit integer
      */
-    virtual std::experimental::optional<int32_t> getInt(int64_t index) = 0;
+    virtual std::ledger_exp::optional<int32_t> getInt(int64_t index) = 0;
 
     /**
      * Get 64-bit integer at a given index.
      * @param index, 64-bit integer
      * @return Optional 64-bit integer
      */
-    virtual std::experimental::optional<int64_t> getLong(int64_t index) = 0;
+    virtual std::ledger_exp::optional<int64_t> getLong(int64_t index) = 0;
 
     /**
      * Get double at a given index.
      * @param index, 64-bit integer
      * @return Optional double
      */
-    virtual std::experimental::optional<double> getDouble(int64_t index) = 0;
+    virtual std::ledger_exp::optional<double> getDouble(int64_t index) = 0;
 
     /**
      * Get binary at a given index.
      * @param index, 64-bit integer
      * @return Optional binary
      */
-    virtual std::experimental::optional<std::vector<uint8_t>> getData(int64_t index) = 0;
+    virtual std::ledger_exp::optional<std::vector<uint8_t>> getData(int64_t index) = 0;
 
     /**
      * Get bool at a given index.
      * @param index, 64-bit integer
      * @return Optional bool
      */
-    virtual std::experimental::optional<bool> getBoolean(int64_t index) = 0;
+    virtual std::ledger_exp::optional<bool> getBoolean(int64_t index) = 0;
 
     /**
      * Get DynamicObject object at a given index.
@@ -157,7 +157,7 @@ public:
      * @param index, 64 bits integer
      * @return Optional DynamicType enum entry
      */
-    virtual std::experimental::optional<DynamicType> getType(int64_t index) = 0;
+    virtual std::ledger_exp::optional<DynamicType> getType(int64_t index) = 0;
 
     /**
      * Delete value stored at given index.

--- a/core/src/api/DynamicObject.hpp
+++ b/core/src/api/DynamicObject.hpp
@@ -98,42 +98,42 @@ public:
      * @param key, string, key of string to look for
      * @return Optional string
      */
-    virtual std::experimental::optional<std::string> getString(const std::string & key) = 0;
+    virtual std::ledger_exp::optional<std::string> getString(const std::string & key) = 0;
 
     /**
      * Get, if exists, stored 32 bits integer having a specific key.
      * @param key, string, key of 32 bits integer to look for
      * @return Optional 32 bits integer
      */
-    virtual std::experimental::optional<int32_t> getInt(const std::string & key) = 0;
+    virtual std::ledger_exp::optional<int32_t> getInt(const std::string & key) = 0;
 
     /**
      * Get, if exists, stored 64 bits integer having a specific key.
      * @param key, string, key of 64 bits integer to look for
      * @return Optional 64 bits integer
      */
-    virtual std::experimental::optional<int64_t> getLong(const std::string & key) = 0;
+    virtual std::ledger_exp::optional<int64_t> getLong(const std::string & key) = 0;
 
     /**
      * Get, if exists, stored double having a specific key.
      * @param key, string, key of double to look for
      * @return Optional double
      */
-    virtual std::experimental::optional<double> getDouble(const std::string & key) = 0;
+    virtual std::ledger_exp::optional<double> getDouble(const std::string & key) = 0;
 
     /**
      * Get, if exists, stored binary having a specific key.
      * @param key, string, key of binary to look for
      * @return Optional binary
      */
-    virtual std::experimental::optional<std::vector<uint8_t>> getData(const std::string & key) = 0;
+    virtual std::ledger_exp::optional<std::vector<uint8_t>> getData(const std::string & key) = 0;
 
     /**
      * Get, if exists, stored bool having a specific key.
      * @param key, string, key of bool to look for
      * @return Optional bool
      */
-    virtual std::experimental::optional<bool> getBoolean(const std::string & key) = 0;
+    virtual std::ledger_exp::optional<bool> getBoolean(const std::string & key) = 0;
 
     /**
      * Get, if exists, stored DynamicObject having a specific key.
@@ -174,7 +174,7 @@ public:
      * @param key, string, key to look for
      * @return Optional DynamicType enum entry
      */
-    virtual std::experimental::optional<DynamicType> getType(const std::string & key) = 0;
+    virtual std::ledger_exp::optional<DynamicType> getType(const std::string & key) = 0;
 
     /**
      * Dump whole object's content as string.

--- a/core/src/api/ErrorCodeCallback.hpp
+++ b/core/src/api/ErrorCodeCallback.hpp
@@ -28,7 +28,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(std::experimental::optional<ErrorCode> result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(std::ledger_exp::optional<ErrorCode> result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/EthereumLikeTransaction.hpp
+++ b/core/src/api/EthereumLikeTransaction.hpp
@@ -54,7 +54,7 @@ public:
     virtual std::shared_ptr<Amount> getValue() = 0;
 
     /** Get binary data payload. */
-    virtual std::experimental::optional<std::vector<uint8_t>> getData() = 0;
+    virtual std::ledger_exp::optional<std::vector<uint8_t>> getData() = 0;
 
     /** Get status of transaction: equals to 1 if succeeded, 0 otherwise */
     virtual int32_t getStatus() = 0;

--- a/core/src/api/EthereumLikeTransactionCallback.hpp
+++ b/core/src/api/EthereumLikeTransactionCallback.hpp
@@ -29,7 +29,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::shared_ptr<EthereumLikeTransaction> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::shared_ptr<EthereumLikeTransaction> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/ExtendedKeyAccountCreationInfoCallback.hpp
+++ b/core/src/api/ExtendedKeyAccountCreationInfoCallback.hpp
@@ -28,7 +28,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::experimental::optional<ExtendedKeyAccountCreationInfo> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::ledger_exp::optional<ExtendedKeyAccountCreationInfo> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/HttpReadBodyResult.hpp
+++ b/core/src/api/HttpReadBodyResult.hpp
@@ -16,12 +16,12 @@ namespace ledger { namespace core { namespace api {
 /** Structure representing Http response body. */
 struct HttpReadBodyResult final {
     /** Optional Error structure, error in case of http request failure. */
-    std::experimental::optional<Error> error;
+    std::ledger_exp::optional<Error> error;
     /** Optional binary, data returned by http request in case of success. */
-    std::experimental::optional<std::vector<uint8_t>> data;
+    std::ledger_exp::optional<std::vector<uint8_t>> data;
 
-    HttpReadBodyResult(std::experimental::optional<Error> error_,
-                       std::experimental::optional<std::vector<uint8_t>> data_)
+    HttpReadBodyResult(std::ledger_exp::optional<Error> error_,
+                       std::ledger_exp::optional<std::vector<uint8_t>> data_)
     : error(std::move(error_))
     , data(std::move(data_))
     {}

--- a/core/src/api/HttpRequest.hpp
+++ b/core/src/api/HttpRequest.hpp
@@ -58,7 +58,7 @@ public:
      * @param response, Optional HttpUrlConnection object, response of request if succeed
      * @param error, optional Error structure, error returned in case of request failure
      */
-    virtual void complete(const std::shared_ptr<HttpUrlConnection> & response, const std::experimental::optional<Error> & error) = 0;
+    virtual void complete(const std::shared_ptr<HttpUrlConnection> & response, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/I32Callback.hpp
+++ b/core/src/api/I32Callback.hpp
@@ -28,7 +28,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(std::experimental::optional<int32_t> result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(std::ledger_exp::optional<int32_t> result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/Operation.hpp
+++ b/core/src/api/Operation.hpp
@@ -99,7 +99,7 @@ public:
      * Get block height on which operation was included.
      * @return Optional 64-bit integer, height of block in which operation was validated
      */
-    virtual std::experimental::optional<int64_t> getBlockHeight() = 0;
+    virtual std::ledger_exp::optional<int64_t> getBlockHeight() = 0;
 
     /**
      * Convert operation as Bitcoin operation.

--- a/core/src/api/OperationListCallback.hpp
+++ b/core/src/api/OperationListCallback.hpp
@@ -30,7 +30,7 @@ public:
      * @params result optional of type list<T>, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::experimental::optional<std::vector<std::shared_ptr<Operation>>> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<Operation>>> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/RippleLikeTransactionCallback.hpp
+++ b/core/src/api/RippleLikeTransactionCallback.hpp
@@ -29,7 +29,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::shared_ptr<RippleLikeTransaction> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::shared_ptr<RippleLikeTransaction> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/StringCallback.hpp
+++ b/core/src/api/StringCallback.hpp
@@ -28,7 +28,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::experimental::optional<std::string> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::ledger_exp::optional<std::string> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/WalletCallback.hpp
+++ b/core/src/api/WalletCallback.hpp
@@ -29,7 +29,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::shared_ptr<Wallet> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::shared_ptr<Wallet> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/WalletListCallback.hpp
+++ b/core/src/api/WalletListCallback.hpp
@@ -30,7 +30,7 @@ public:
      * @params result optional of type list<T>, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::experimental::optional<std::vector<std::shared_ptr<Wallet>>> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<Wallet>>> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/WalletPoolCallback.hpp
+++ b/core/src/api/WalletPoolCallback.hpp
@@ -29,7 +29,7 @@ public:
      * @params result optional of type T, non null if main task failed
      * @params error optional of type Error, non null if main task succeeded
      */
-    virtual void onCallback(const std::shared_ptr<WalletPool> & result, const std::experimental::optional<Error> & error) = 0;
+    virtual void onCallback(const std::shared_ptr<WalletPool> & result, const std::ledger_exp::optional<Error> & error) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/async/CompletionBlock.hpp
+++ b/core/src/async/CompletionBlock.hpp
@@ -46,7 +46,7 @@ namespace ledger {
         template <typename T, class Class>
         class CompletionBlock<T, Class, true> : public Class {
         public:
-            virtual void complete(const std::shared_ptr<T>& result, const std::experimental::optional<api::Error>& error) override {
+            virtual void complete(const std::shared_ptr<T>& result, const std::ledger_exp::optional<api::Error>& error) override {
                 if (error) {
                     _promise.failure(Exception(error.value().code, error.value().message));
                 } else {
@@ -65,7 +65,7 @@ namespace ledger {
         template <typename T, class Class>
         class CompletionBlock<T, Class, false> : public Class {
         public:
-            virtual void complete(const std::experimental::optional<T>& result, const std::experimental::optional<api::Error>& error) override {
+            virtual void complete(const std::ledger_exp::optional<T>& result, const std::ledger_exp::optional<api::Error>& error) override {
                 if (error) {
                     _promise.failure(Exception(error.value().code, error.value().message));
                 } else {
@@ -82,9 +82,9 @@ namespace ledger {
         };
 
         template <typename T, class Class>
-        std::shared_ptr<CompletionBlock<T, Class, has_complete_method<Class, void (const std::shared_ptr<T>&, const std::experimental::optional<api::Error>&)>::value>>
+        std::shared_ptr<CompletionBlock<T, Class, has_complete_method<Class, void (const std::shared_ptr<T>&, const std::ledger_exp::optional<api::Error>&)>::value>>
         make_api_completion_block() {
-            return std::make_shared<CompletionBlock<T, Class, has_complete_method<Class, void (const std::shared_ptr<T>&, const std::experimental::optional<api::Error>&)>::value>>();
+            return std::make_shared<CompletionBlock<T, Class, has_complete_method<Class, void (const std::shared_ptr<T>&, const std::ledger_exp::optional<api::Error>&)>::value>>();
         };
 
     }

--- a/core/src/async/Future.hpp
+++ b/core/src/async/Future.hpp
@@ -226,7 +226,7 @@ namespace ledger {
             };
 
             template<typename Callback>
-            typename std::enable_if<has_on_callback_method<Callback, void (const std::experimental::optional<T>&, const std::experimental::optional<api::Error>&)>::value, void>::type
+            typename std::enable_if<has_on_callback_method<Callback, void (const std::ledger_exp::optional<T>&, const std::ledger_exp::optional<api::Error>&)>::value, void>::type
             callback(const Context& context, std::shared_ptr<Callback> cb) {
                 onComplete(context, [cb] (const Try<T>& result) {
                     if (result.isSuccess()) {
@@ -239,7 +239,7 @@ namespace ledger {
             };
 
             template<typename Callback>
-            typename std::enable_if<is_shared_ptr<T>::value && has_on_callback_method<Callback, void (const T&, const std::experimental::optional<api::Error>&)>::value, void>::type
+            typename std::enable_if<is_shared_ptr<T>::value && has_on_callback_method<Callback, void (const T&, const std::ledger_exp::optional<api::Error>&)>::value, void>::type
             callback(const Context& context, std::shared_ptr<Callback> cb) {
                 onComplete(context, [cb] (const Try<T>& result) {
                     if (result.isSuccess()) {

--- a/core/src/bitcoin/BitcoinLikeAddress.cpp
+++ b/core/src/bitcoin/BitcoinLikeAddress.cpp
@@ -122,7 +122,7 @@ namespace ledger {
             return _keychainEngine == api::KeychainEngines::BIP173_P2WPKH;
         }
 
-        std::experimental::optional<std::string> BitcoinLikeAddress::getDerivationPath() {
+        std::ledger_exp::optional<std::string> BitcoinLikeAddress::getDerivationPath() {
             return _derivationPath.toOptional();
         }
 

--- a/core/src/bitcoin/BitcoinLikeAddress.hpp
+++ b/core/src/bitcoin/BitcoinLikeAddress.hpp
@@ -58,7 +58,7 @@ namespace ledger {
             virtual bool isP2PKH() override;
             virtual bool isP2WSH() override;
             virtual bool isP2WPKH() override;
-            virtual optional<std::string> getDerivationPath() override;
+            virtual std::ledger_exp::optional<std::string> getDerivationPath() override;
 
             std::string toString() override;
 

--- a/core/src/bitcoin/BitcoinLikeExtendedPublicKey.cpp
+++ b/core/src/bitcoin/BitcoinLikeExtendedPublicKey.cpp
@@ -58,7 +58,7 @@ namespace ledger {
             return std::make_shared<BitcoinLikeAddress>(_currency,
                                                         key.getPublicKeyHash160(),
                                                         keychainEngine,
-                                                        optional<std::string>((_path + p).toString()));
+                                                        std::ledger_exp::optional<std::string>((_path + p).toString()));
         }
 
         std::shared_ptr<BitcoinLikeExtendedPublicKey> BitcoinLikeExtendedPublicKey::derive(const DerivationPath &path) {
@@ -72,7 +72,7 @@ namespace ledger {
 
         std::shared_ptr<BitcoinLikeExtendedPublicKey>
         BitcoinLikeExtendedPublicKey::fromRaw(const api::Currency &currency,
-                                              const optional<std::vector<uint8_t>> &parentPublicKey,
+                                              const std::ledger_exp::optional<std::vector<uint8_t>> &parentPublicKey,
                                               const std::vector<uint8_t> &publicKey,
                                               const std::vector<uint8_t> &chainCode,
                                               const std::string &path,

--- a/core/src/bitcoin/BitcoinLikeExtendedPublicKey.hpp
+++ b/core/src/bitcoin/BitcoinLikeExtendedPublicKey.hpp
@@ -63,7 +63,7 @@ namespace ledger {
         public:
             static std::shared_ptr<BitcoinLikeExtendedPublicKey> fromRaw(
                     const api::Currency& params,
-                    const optional<std::vector<uint8_t>>& parentPublicKey,
+                    const std::ledger_exp::optional<std::vector<uint8_t>>& parentPublicKey,
                     const std::vector<uint8_t>& publicKey,
                     const std::vector<uint8_t> &chainCode,
                     const std::string& path,

--- a/core/src/collections/DynamicArray.cpp
+++ b/core/src/collections/DynamicArray.cpp
@@ -45,27 +45,27 @@ namespace ledger {
             return (int64_t)_values.size();
         }
 
-        optional<std::string> DynamicArray::getString(int64_t index) {
+        std::ledger_exp::optional<std::string> DynamicArray::getString(int64_t index) {
             return get<std::string>(index);
         }
 
-        optional<int32_t> DynamicArray::getInt(int64_t index) {
+        std::ledger_exp::optional<int32_t> DynamicArray::getInt(int64_t index) {
             return get<int32_t>(index);
         }
 
-        optional<int64_t> DynamicArray::getLong(int64_t index) {
+        std::ledger_exp::optional<int64_t> DynamicArray::getLong(int64_t index) {
             return get<int64_t>(index);
         }
 
-        optional<double> DynamicArray::getDouble(int64_t index) {
+        std::ledger_exp::optional<double> DynamicArray::getDouble(int64_t index) {
             return get<double>(index);
         }
 
-        optional<bool> DynamicArray::getBoolean(int64_t index) {
+        std::ledger_exp::optional<bool> DynamicArray::getBoolean(int64_t index) {
             return get<bool>(index);
         }
 
-        optional<std::vector<uint8_t>> DynamicArray::getData(int64_t index) {
+        std::ledger_exp::optional<std::vector<uint8_t>> DynamicArray::getData(int64_t index) {
             return get<std::vector<uint8_t>>(index);
         }
 
@@ -109,16 +109,16 @@ namespace ledger {
             return push(std::static_pointer_cast<DynamicObject>(value));
         }
 
-        optional<api::DynamicType> DynamicArray::getType(int64_t index) {
+        std::ledger_exp::optional<api::DynamicType> DynamicArray::getType(int64_t index) {
             if (index < size()) {
                 auto v = _values.get(index);
                 if (v) {
-                    return optional<api::DynamicType>(v->getType());
+                    return std::ledger_exp::optional<api::DynamicType>(v->getType());
                 } else {
-                    return optional<api::DynamicType>();
+                    return std::ledger_exp::optional<api::DynamicType>();
                 }
             } else {
-                return optional<api::DynamicType>();
+                return std::ledger_exp::optional<api::DynamicType>();
             }
         }
 

--- a/core/src/collections/DynamicArray.hpp
+++ b/core/src/collections/DynamicArray.hpp
@@ -50,26 +50,26 @@ namespace ledger {
 
             /// A generic indexed and type-safe getter.
             template <typename T>
-            optional<T> get(int64_t index) {
+            std::ledger_exp::optional<T> get(int64_t index) {
                 if (index < size()) {
                     auto v = _values.get(index);
 
                     if (v) {
                         return v->get<T>();
                     } else {
-                        return optional<T>();
+                        return std::ledger_exp::optional<T>();
                     }
                 } else {
-                    return optional<T>();
+                    return std::ledger_exp::optional<T>();
                 }
             }
 
-            optional<std::string> getString(int64_t index) override;
-            optional<int32_t> getInt(int64_t index) override;
-            optional<int64_t> getLong(int64_t index) override;
-            optional<double> getDouble(int64_t index) override;
-            optional<std::vector<uint8_t>> getData(int64_t index) override;
-            optional<bool> getBoolean(int64_t index) override;
+            std::ledger_exp::optional<std::string> getString(int64_t index) override;
+            std::ledger_exp::optional<int32_t> getInt(int64_t index) override;
+            std::ledger_exp::optional<int64_t> getLong(int64_t index) override;
+            std::ledger_exp::optional<double> getDouble(int64_t index) override;
+            std::ledger_exp::optional<std::vector<uint8_t>> getData(int64_t index) override;
+            std::ledger_exp::optional<bool> getBoolean(int64_t index) override;
             std::shared_ptr<api::DynamicObject> getObject(int64_t index) override;
             std::shared_ptr<api::DynamicArray> getArray(int64_t index) override;
 
@@ -97,7 +97,7 @@ namespace ledger {
             bool isReadOnly() override;
             void setReadOnly(bool enable);
 
-            optional<api::DynamicType> getType(int64_t index) override;
+            std::ledger_exp::optional<api::DynamicType> getType(int64_t index) override;
             bool remove(int64_t index) override;
             std::string dump() override;
             std::vector<uint8_t> serialize() override;

--- a/core/src/collections/DynamicObject.cpp
+++ b/core/src/collections/DynamicObject.cpp
@@ -39,27 +39,27 @@
 
 namespace ledger {
     namespace core {
-        optional<std::string> DynamicObject::getString(const std::string &key) {
+        std::ledger_exp::optional<std::string> DynamicObject::getString(const std::string &key) {
             return get<std::string>(key);
         }
 
-        optional<int32_t> DynamicObject::getInt(const std::string &key) {
+        std::ledger_exp::optional<int32_t> DynamicObject::getInt(const std::string &key) {
             return get<int32_t>(key);
         }
 
-        optional<int64_t> DynamicObject::getLong(const std::string &key) {
+        std::ledger_exp::optional<int64_t> DynamicObject::getLong(const std::string &key) {
             return get<int64_t>(key);
         }
 
-        optional<double> DynamicObject::getDouble(const std::string &key) {
+        std::ledger_exp::optional<double> DynamicObject::getDouble(const std::string &key) {
             return get<double>(key);
         }
 
-        optional<bool> DynamicObject::getBoolean(const std::string &key) {
+        std::ledger_exp::optional<bool> DynamicObject::getBoolean(const std::string &key) {
             return get<bool>(key);
         }
 
-        optional<std::vector<uint8_t>> DynamicObject::getData(const std::string &key) {
+        std::ledger_exp::optional<std::vector<uint8_t>> DynamicObject::getData(const std::string &key) {
             return get<std::vector<uint8_t>>(key);
         }
 
@@ -116,11 +116,11 @@ namespace ledger {
             return _values.getKeys().getContainer();
         }
 
-        optional<api::DynamicType> DynamicObject::getType(const std::string &key) {
+        std::ledger_exp::optional<api::DynamicType> DynamicObject::getType(const std::string &key) {
             auto v = _values.lift(key);
             if (_values.empty() || !v.hasValue())
-                return optional<api::DynamicType>();
-            return optional<api::DynamicType>(v.getValue().getType());
+                return std::ledger_exp::optional<api::DynamicType>();
+            return std::ledger_exp::optional<api::DynamicType>(v.getValue().getType());
         }
 
         std::string DynamicObject::dump() {

--- a/core/src/collections/DynamicObject.hpp
+++ b/core/src/collections/DynamicObject.hpp
@@ -49,13 +49,13 @@ namespace ledger {
 
             /// A generic indexed and type-safe getter.
             template <typename T>
-            optional<T> get(const std::string& key) {
-                const auto v = optional<DynamicValue>(_values.lift(key));
+            std::ledger_exp::optional<T> get(const std::string& key) {
+                const auto v = std::ledger_exp::optional<DynamicValue>(_values.lift(key));
 
                 if (v) {
                     return v->get<T>();
                 } else {
-                    return optional<T>();
+                    return std::ledger_exp::optional<T>();
                 }
             }
 
@@ -69,12 +69,12 @@ namespace ledger {
                 return shared_from_this();
             }
 
-            optional<std::string> getString(const std::string &key) override;
-            optional<int32_t> getInt(const std::string &key) override;
-            optional<int64_t> getLong(const std::string &key) override;
-            optional<double> getDouble(const std::string &key) override;
-            optional<bool> getBoolean(const std::string &key) override;
-            optional<std::vector<uint8_t>> getData(const std::string &key) override;
+            std::ledger_exp::optional<std::string> getString(const std::string &key) override;
+            std::ledger_exp::optional<int32_t> getInt(const std::string &key) override;
+            std::ledger_exp::optional<int64_t> getLong(const std::string &key) override;
+            std::ledger_exp::optional<double> getDouble(const std::string &key) override;
+            std::ledger_exp::optional<bool> getBoolean(const std::string &key) override;
+            std::ledger_exp::optional<std::vector<uint8_t>> getData(const std::string &key) override;
             std::shared_ptr<api::DynamicObject> getObject(const std::string &key) override;
             std::shared_ptr<api::DynamicArray> getArray(const std::string &key) override;
 
@@ -93,7 +93,7 @@ namespace ledger {
 
             std::vector<std::string> getKeys() override;
 
-            optional<api::DynamicType> getType(const std::string &key) override;
+            std::ledger_exp::optional<api::DynamicType> getType(const std::string &key) override;
 
             std::string dump() override;
 

--- a/core/src/collections/DynamicValue.hpp
+++ b/core/src/collections/DynamicValue.hpp
@@ -99,7 +99,7 @@ namespace ledger {
 
             /// Try to get the value as if it were of a given type.
             template <typename T>
-            optional<T> get() const {
+            std::ledger_exp::optional<T> get() const {
                 static const OptionalVisitor<T> visitor;
                 return boost::apply_visitor(visitor, data);
             }
@@ -112,14 +112,14 @@ namespace ledger {
 
             // A visitor used to cast from DynamicValue to typed optional values.
             template <typename T>
-            struct OptionalVisitor: boost::static_visitor<optional<T>> {
-                optional<T> operator()(T x) const {
+            struct OptionalVisitor: boost::static_visitor<std::ledger_exp::optional<T>> {
+                std::ledger_exp::optional<T> operator()(T x) const {
                     return x;
                 }
 
                 template <typename Q>
-                optional<T> operator()(const Q&) const {
-                    return optional<T>();
+                std::ledger_exp::optional<T> operator()(const Q&) const {
+                    return std::ledger_exp::optional<T>();
                 }
             };
 

--- a/core/src/collections/Sequence.hpp
+++ b/core/src/collections/Sequence.hpp
@@ -50,20 +50,20 @@ namespace ledger {
             }
 
             /// Type-safe indexed getter.
-            optional<T&> get(size_t index) {
+            std::ledger_exp::optional<T&> get(size_t index) {
                 if (index < size()) {
                     return this->operator[](index);
                 } else {
-                    return optional<T&>();
+                    return std::ledger_exp::optional<T&>();
                 }
             }
 
             /// Type-safe indexed getter.
-            optional<const T&> get(size_t index) const {
+            std::ledger_exp::optional<const T&> get(size_t index) const {
                 if (index < size()) {
                     return this->operator[](index);
                 } else {
-                    return optional<const T&>();
+                    return std::ledger_exp::optional<const T&>();
                 }
             }
 

--- a/core/src/common/AbstractExtendedPublicKey.h
+++ b/core/src/common/AbstractExtendedPublicKey.h
@@ -70,7 +70,7 @@ namespace ledger {
             static DeterministicPublicKey
             fromRaw(const api::Currency &currency,
                     const NetworkParameters &params,
-                    const optional<std::vector<uint8_t>> &parentPublicKey,
+                    const std::ledger_exp::optional<std::vector<uint8_t>> &parentPublicKey,
                     const std::vector<uint8_t> &publicKey,
                     const std::vector<uint8_t> &chainCode,
                     const std::string &path) {

--- a/core/src/ethereum/EthereumLikeAddress.cpp
+++ b/core/src/ethereum/EthereumLikeAddress.cpp
@@ -66,7 +66,7 @@ namespace ledger {
             return Base58::encodeWithEIP55(_keccak256);
         }
 
-        std::experimental::optional<std::string> EthereumLikeAddress::getDerivationPath() {
+        std::ledger_exp::optional<std::string> EthereumLikeAddress::getDerivationPath() {
             return _derivationPath.toOptional();
         }
 

--- a/core/src/ethereum/EthereumLikeAddress.h
+++ b/core/src/ethereum/EthereumLikeAddress.h
@@ -48,7 +48,7 @@ namespace ledger {
             api::EthereumLikeNetworkParameters getNetworkParameters() override ;
             std::string toEIP55() override ;
 
-            virtual optional<std::string> getDerivationPath() override;
+            virtual std::ledger_exp::optional<std::string> getDerivationPath() override;
             std::string toString() override;
 
             static std::shared_ptr<AbstractAddress> parse(const std::string& address, const api::Currency& currency,

--- a/core/src/ethereum/EthereumLikeExtendedPublicKey.cpp
+++ b/core/src/ethereum/EthereumLikeExtendedPublicKey.cpp
@@ -59,7 +59,7 @@ namespace ledger {
         EthereumLikeExtendedPublicKey::derive(const std::string & path) {
             DerivationPath p(path);
             auto key = _derive(0, p.toVector(), _key);
-            return std::make_shared<EthereumLikeAddress>(_currency, key.getPublicKeyKeccak256(), optional<std::string>((_path + p).toString()));
+            return std::make_shared<EthereumLikeAddress>(_currency, key.getPublicKeyKeccak256(), std::ledger_exp::optional<std::string>((_path + p).toString()));
         }
 
         std::shared_ptr<EthereumLikeExtendedPublicKey>
@@ -88,7 +88,7 @@ namespace ledger {
 
         std::shared_ptr<EthereumLikeExtendedPublicKey>
         EthereumLikeExtendedPublicKey::fromRaw(const api::Currency& currency,
-                const optional<std::vector<uint8_t>>& parentPublicKey,
+                const std::ledger_exp::optional<std::vector<uint8_t>>& parentPublicKey,
                 const std::vector<uint8_t>& publicKey,
                 const std::vector<uint8_t> &chainCode,
                 const std::string& path) {

--- a/core/src/ethereum/EthereumLikeExtendedPublicKey.h
+++ b/core/src/ethereum/EthereumLikeExtendedPublicKey.h
@@ -61,7 +61,7 @@ namespace ledger {
             std::string getRootPath() override ;
 
             static std::shared_ptr<EthereumLikeExtendedPublicKey> fromRaw(const api::Currency& params,
-                                                                          const optional<std::vector<uint8_t>>& parentPublicKey,
+                                                                          const std::ledger_exp::optional<std::vector<uint8_t>>& parentPublicKey,
                                                                           const std::vector<uint8_t>& publicKey,
                                                                           const std::vector<uint8_t> &chainCode,
                                                                           const std::string& path);

--- a/core/src/jni/jni/AccountCallback.cpp
+++ b/core/src/jni/jni/AccountCallback.cpp
@@ -16,13 +16,13 @@ AccountCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetThread
 
 AccountCallback::JavaProxy::~JavaProxy() = default;
 
-void AccountCallback::JavaProxy::onCallback(const std::shared_ptr<::ledger::core::api::Account> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void AccountCallback::JavaProxy::onCallback(const std::shared_ptr<::ledger::core::api::Account> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::AccountCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Account>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Account>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/AccountCallback.hpp
+++ b/core/src/jni/jni/AccountCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::shared_ptr<::ledger::core::api::Account> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::shared_ptr<::ledger::core::api::Account> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::AccountCallback, ::djinni_generated::AccountCallback>;

--- a/core/src/jni/jni/AccountCreationInfoCallback.cpp
+++ b/core/src/jni/jni/AccountCreationInfoCallback.cpp
@@ -16,13 +16,13 @@ AccountCreationInfoCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::
 
 AccountCreationInfoCallback::JavaProxy::~JavaProxy() = default;
 
-void AccountCreationInfoCallback::JavaProxy::onCallback(const std::experimental::optional<::ledger::core::api::AccountCreationInfo> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void AccountCreationInfoCallback::JavaProxy::onCallback(const std::ledger_exp::optional<::ledger::core::api::AccountCreationInfo> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::AccountCreationInfoCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::AccountCreationInfo>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::AccountCreationInfo>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/AccountCreationInfoCallback.hpp
+++ b/core/src/jni/jni/AccountCreationInfoCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::experimental::optional<::ledger::core::api::AccountCreationInfo> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::ledger_exp::optional<::ledger::core::api::AccountCreationInfo> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::AccountCreationInfoCallback, ::djinni_generated::AccountCreationInfoCallback>;

--- a/core/src/jni/jni/AccountListCallback.cpp
+++ b/core/src/jni/jni/AccountListCallback.cpp
@@ -16,13 +16,13 @@ AccountListCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetTh
 
 AccountListCallback::JavaProxy::~JavaProxy() = default;
 
-void AccountListCallback::JavaProxy::onCallback(const std::experimental::optional<std::vector<std::shared_ptr<::ledger::core::api::Account>>> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void AccountListCallback::JavaProxy::onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<::ledger::core::api::Account>>> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::AccountListCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni::List<::djinni_generated::Account>>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni::List<::djinni_generated::Account>>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/AccountListCallback.hpp
+++ b/core/src/jni/jni/AccountListCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::experimental::optional<std::vector<std::shared_ptr<::ledger::core::api::Account>>> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<::ledger::core::api::Account>>> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::AccountListCallback, ::djinni_generated::AccountListCallback>;

--- a/core/src/jni/jni/Address.cpp
+++ b/core/src/jni/jni/Address.cpp
@@ -27,7 +27,7 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_Address_00024CppProxy_native_1get
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::Address>(nativeRef);
         auto r = ref->getDerivationPath();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::String>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::String>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -47,7 +47,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_Address_00024CppProxy_native_1asB
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::Address>(nativeRef);
         auto r = ref->asBitcoinLikeAddress();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::BitcoinLikeAddress>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::BitcoinLikeAddress>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -77,7 +77,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_Address_parse(JNIEnv* jniEnv, job
         DJINNI_FUNCTION_PROLOGUE0(jniEnv);
         auto r = ::ledger::core::api::Address::parse(::djinni::String::toCpp(jniEnv, j_address),
                                                      ::djinni_generated::Currency::toCpp(jniEnv, j_currency));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::Address>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Address>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 

--- a/core/src/jni/jni/AddressListCallback.cpp
+++ b/core/src/jni/jni/AddressListCallback.cpp
@@ -16,13 +16,13 @@ AddressListCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetTh
 
 AddressListCallback::JavaProxy::~JavaProxy() = default;
 
-void AddressListCallback::JavaProxy::onCallback(const std::experimental::optional<std::vector<std::shared_ptr<::ledger::core::api::Address>>> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void AddressListCallback::JavaProxy::onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<::ledger::core::api::Address>>> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::AddressListCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni::List<::djinni_generated::Address>>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni::List<::djinni_generated::Address>>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/AddressListCallback.hpp
+++ b/core/src/jni/jni/AddressListCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::experimental::optional<std::vector<std::shared_ptr<::ledger::core::api::Address>>> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<::ledger::core::api::Address>>> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::AddressListCallback, ::djinni_generated::AddressListCallback>;

--- a/core/src/jni/jni/Amount.cpp
+++ b/core/src/jni/jni/Amount.cpp
@@ -110,7 +110,7 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_Amount_00024CppProxy_native_1form
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::Amount>(nativeRef);
         auto r = ref->format(::djinni_generated::Locale::toCpp(jniEnv, j_locale),
-                             ::djinni::Optional<std::experimental::optional, ::djinni_generated::FormatRules>::toCpp(jniEnv, j_rules));
+                             ::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::FormatRules>::toCpp(jniEnv, j_rules));
         return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }

--- a/core/src/jni/jni/AmountCallback.cpp
+++ b/core/src/jni/jni/AmountCallback.cpp
@@ -16,13 +16,13 @@ AmountCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetThreadE
 
 AmountCallback::JavaProxy::~JavaProxy() = default;
 
-void AmountCallback::JavaProxy::onCallback(const std::shared_ptr<::ledger::core::api::Amount> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void AmountCallback::JavaProxy::onCallback(const std::shared_ptr<::ledger::core::api::Amount> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::AmountCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Amount>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Amount>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/AmountCallback.hpp
+++ b/core/src/jni/jni/AmountCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::shared_ptr<::ledger::core::api::Amount> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::shared_ptr<::ledger::core::api::Amount> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::AmountCallback, ::djinni_generated::AmountCallback>;

--- a/core/src/jni/jni/AmountListCallback.cpp
+++ b/core/src/jni/jni/AmountListCallback.cpp
@@ -16,13 +16,13 @@ AmountListCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetThr
 
 AmountListCallback::JavaProxy::~JavaProxy() = default;
 
-void AmountListCallback::JavaProxy::onCallback(const std::experimental::optional<std::vector<std::shared_ptr<::ledger::core::api::Amount>>> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void AmountListCallback::JavaProxy::onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<::ledger::core::api::Amount>>> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::AmountListCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni::List<::djinni_generated::Amount>>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni::List<::djinni_generated::Amount>>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/AmountListCallback.hpp
+++ b/core/src/jni/jni/AmountListCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::experimental::optional<std::vector<std::shared_ptr<::ledger::core::api::Amount>>> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<::ledger::core::api::Amount>>> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::AmountListCallback, ::djinni_generated::AmountListCallback>;

--- a/core/src/jni/jni/BinaryCallback.cpp
+++ b/core/src/jni/jni/BinaryCallback.cpp
@@ -15,13 +15,13 @@ BinaryCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetThreadE
 
 BinaryCallback::JavaProxy::~JavaProxy() = default;
 
-void BinaryCallback::JavaProxy::onCallback(const std::experimental::optional<std::vector<uint8_t>> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void BinaryCallback::JavaProxy::onCallback(const std::ledger_exp::optional<std::vector<uint8_t>> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::BinaryCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni::Binary>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni::Binary>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/BinaryCallback.hpp
+++ b/core/src/jni/jni/BinaryCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::experimental::optional<std::vector<uint8_t>> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::ledger_exp::optional<std::vector<uint8_t>> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::BinaryCallback, ::djinni_generated::BinaryCallback>;

--- a/core/src/jni/jni/BitcoinLikeAccount.cpp
+++ b/core/src/jni/jni/BitcoinLikeAccount.cpp
@@ -70,7 +70,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeAccount_00024CppProxy_
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeAccount>(nativeRef);
-        auto r = ref->buildTransaction(::djinni::Optional<std::experimental::optional, ::djinni::Bool>::toCpp(jniEnv, j_partial));
+        auto r = ref->buildTransaction(::djinni::Optional<std::ledger_exp::optional, ::djinni::Bool>::toCpp(jniEnv, j_partial));
         return ::djinni::release(::djinni_generated::BitcoinLikeTransactionBuilder::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }

--- a/core/src/jni/jni/BitcoinLikeInput.cpp
+++ b/core/src/jni/jni/BitcoinLikeInput.cpp
@@ -30,7 +30,7 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_BitcoinLikeInput_00024CppProxy_na
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeInput>(nativeRef);
         auto r = ref->getAddress();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::String>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::String>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -60,7 +60,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeInput_00024CppProxy_na
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeInput>(nativeRef);
         auto r = ref->getValue();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::Amount>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Amount>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -70,7 +70,7 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_BitcoinLikeInput_00024CppProxy_na
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeInput>(nativeRef);
         auto r = ref->getPreviousTxHash();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::String>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::String>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -90,7 +90,7 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_BitcoinLikeInput_00024CppProxy_na
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeInput>(nativeRef);
         auto r = ref->getCoinbase();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::String>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::String>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -100,7 +100,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeInput_00024CppProxy_na
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeInput>(nativeRef);
         auto r = ref->getPreviousOutputIndex();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::I32>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::I32>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 

--- a/core/src/jni/jni/BitcoinLikeOutput.cpp
+++ b/core/src/jni/jni/BitcoinLikeOutput.cpp
@@ -78,7 +78,7 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_BitcoinLikeOutput_00024CppProxy_n
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeOutput>(nativeRef);
         auto r = ref->getAddress();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::String>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::String>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -88,7 +88,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeOutput_00024CppProxy_n
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeOutput>(nativeRef);
         auto r = ref->getDerivationPath();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::DerivationPath>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::DerivationPath>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 

--- a/core/src/jni/jni/BitcoinLikeOutputListCallback.cpp
+++ b/core/src/jni/jni/BitcoinLikeOutputListCallback.cpp
@@ -16,13 +16,13 @@ BitcoinLikeOutputListCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni
 
 BitcoinLikeOutputListCallback::JavaProxy::~JavaProxy() = default;
 
-void BitcoinLikeOutputListCallback::JavaProxy::onCallback(const std::experimental::optional<std::vector<std::shared_ptr<::ledger::core::api::BitcoinLikeOutput>>> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void BitcoinLikeOutputListCallback::JavaProxy::onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<::ledger::core::api::BitcoinLikeOutput>>> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::BitcoinLikeOutputListCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni::List<::djinni_generated::BitcoinLikeOutput>>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni::List<::djinni_generated::BitcoinLikeOutput>>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/BitcoinLikeOutputListCallback.hpp
+++ b/core/src/jni/jni/BitcoinLikeOutputListCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::experimental::optional<std::vector<std::shared_ptr<::ledger::core::api::BitcoinLikeOutput>>> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<::ledger::core::api::BitcoinLikeOutput>>> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::BitcoinLikeOutputListCallback, ::djinni_generated::BitcoinLikeOutputListCallback>;

--- a/core/src/jni/jni/BitcoinLikeScriptChunk.cpp
+++ b/core/src/jni/jni/BitcoinLikeScriptChunk.cpp
@@ -46,7 +46,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeScriptChunk_00024CppPr
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeScriptChunk>(nativeRef);
         auto r = ref->getOperator();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::BitcoinLikeOperator>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::BitcoinLikeOperator>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -56,7 +56,7 @@ CJNIEXPORT jbyteArray JNICALL Java_co_ledger_core_BitcoinLikeScriptChunk_00024Cp
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeScriptChunk>(nativeRef);
         auto r = ref->getPushedData();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::Binary>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::Binary>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 

--- a/core/src/jni/jni/BitcoinLikeTransaction.cpp
+++ b/core/src/jni/jni/BitcoinLikeTransaction.cpp
@@ -60,7 +60,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeTransaction_00024CppPr
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeTransaction>(nativeRef);
         auto r = ref->getBlock();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::BitcoinLikeBlock>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::BitcoinLikeBlock>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -100,7 +100,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeTransaction_00024CppPr
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeTransaction>(nativeRef);
         auto r = ref->getTimestamp();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::I32>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::I32>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -140,7 +140,7 @@ CJNIEXPORT jbyteArray JNICALL Java_co_ledger_core_BitcoinLikeTransaction_00024Cp
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeTransaction>(nativeRef);
         auto r = ref->getWitness();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::Binary>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::Binary>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 

--- a/core/src/jni/jni/BitcoinLikeTransactionBuilder.cpp
+++ b/core/src/jni/jni/BitcoinLikeTransactionBuilder.cpp
@@ -175,7 +175,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeTransactionBuilder_par
         DJINNI_FUNCTION_PROLOGUE0(jniEnv);
         auto r = ::ledger::core::api::BitcoinLikeTransactionBuilder::parseRawUnsignedTransaction(::djinni_generated::Currency::toCpp(jniEnv, j_currency),
                                                                                                  ::djinni::Binary::toCpp(jniEnv, j_rawTransaction),
-                                                                                                 ::djinni::Optional<std::experimental::optional, ::djinni::I32>::toCpp(jniEnv, j_currentBlockHeight));
+                                                                                                 ::djinni::Optional<std::ledger_exp::optional, ::djinni::I32>::toCpp(jniEnv, j_currentBlockHeight));
         return ::djinni::release(::djinni_generated::BitcoinLikeTransaction::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }

--- a/core/src/jni/jni/BitcoinLikeTransactionCallback.cpp
+++ b/core/src/jni/jni/BitcoinLikeTransactionCallback.cpp
@@ -16,13 +16,13 @@ BitcoinLikeTransactionCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinn
 
 BitcoinLikeTransactionCallback::JavaProxy::~JavaProxy() = default;
 
-void BitcoinLikeTransactionCallback::JavaProxy::onCallback(const std::shared_ptr<::ledger::core::api::BitcoinLikeTransaction> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void BitcoinLikeTransactionCallback::JavaProxy::onCallback(const std::shared_ptr<::ledger::core::api::BitcoinLikeTransaction> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::BitcoinLikeTransactionCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::BitcoinLikeTransaction>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::BitcoinLikeTransaction>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/BitcoinLikeTransactionCallback.hpp
+++ b/core/src/jni/jni/BitcoinLikeTransactionCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::shared_ptr<::ledger::core::api::BitcoinLikeTransaction> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::shared_ptr<::ledger::core::api::BitcoinLikeTransaction> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::BitcoinLikeTransactionCallback, ::djinni_generated::BitcoinLikeTransactionCallback>;

--- a/core/src/jni/jni/BitcoinLikeTransactionRequest.cpp
+++ b/core/src/jni/jni/BitcoinLikeTransactionRequest.cpp
@@ -17,9 +17,9 @@ auto BitcoinLikeTransactionRequest::fromCpp(JNIEnv* jniEnv, const CppType& c) ->
     auto r = ::djinni::LocalRef<JniType>{jniEnv->NewObject(data.clazz.get(), data.jconstructor,
                                                            ::djinni::get(::djinni::List<::djinni_generated::BitcoinLikeOutput>::fromCpp(jniEnv, c.utxo)),
                                                            ::djinni::get(::djinni::List<::djinni_generated::BitcoinLikeOutput>::fromCpp(jniEnv, c.outputs)),
-                                                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Amount>::fromCpp(jniEnv, c.baseFees)),
-                                                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Amount>::fromCpp(jniEnv, c.totalFees)),
-                                                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni::I32>::fromCpp(jniEnv, c.lockTime)))};
+                                                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Amount>::fromCpp(jniEnv, c.baseFees)),
+                                                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Amount>::fromCpp(jniEnv, c.totalFees)),
+                                                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni::I32>::fromCpp(jniEnv, c.lockTime)))};
     ::djinni::jniExceptionCheck(jniEnv);
     return r;
 }
@@ -30,9 +30,9 @@ auto BitcoinLikeTransactionRequest::toCpp(JNIEnv* jniEnv, JniType j) -> CppType 
     const auto& data = ::djinni::JniClass<BitcoinLikeTransactionRequest>::get();
     return {::djinni::List<::djinni_generated::BitcoinLikeOutput>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_utxo)),
             ::djinni::List<::djinni_generated::BitcoinLikeOutput>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_outputs)),
-            ::djinni::Optional<std::experimental::optional, ::djinni_generated::Amount>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_baseFees)),
-            ::djinni::Optional<std::experimental::optional, ::djinni_generated::Amount>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_totalFees)),
-            ::djinni::Optional<std::experimental::optional, ::djinni::I32>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_lockTime))};
+            ::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Amount>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_baseFees)),
+            ::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Amount>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_totalFees)),
+            ::djinni::Optional<std::ledger_exp::optional, ::djinni::I32>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_lockTime))};
 }
 
 }  // namespace djinni_generated

--- a/core/src/jni/jni/BlockCallback.cpp
+++ b/core/src/jni/jni/BlockCallback.cpp
@@ -16,13 +16,13 @@ BlockCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetThreadEn
 
 BlockCallback::JavaProxy::~JavaProxy() = default;
 
-void BlockCallback::JavaProxy::onCallback(const std::experimental::optional<::ledger::core::api::Block> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void BlockCallback::JavaProxy::onCallback(const std::ledger_exp::optional<::ledger::core::api::Block> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::BlockCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Block>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Block>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/BlockCallback.hpp
+++ b/core/src/jni/jni/BlockCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::experimental::optional<::ledger::core::api::Block> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::ledger_exp::optional<::ledger::core::api::Block> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::BlockCallback, ::djinni_generated::BlockCallback>;

--- a/core/src/jni/jni/Currency.cpp
+++ b/core/src/jni/jni/Currency.cpp
@@ -23,9 +23,9 @@ auto Currency::fromCpp(JNIEnv* jniEnv, const CppType& c) -> ::djinni::LocalRef<J
                                                            ::djinni::get(::djinni::I32::fromCpp(jniEnv, c.bip44CoinType)),
                                                            ::djinni::get(::djinni::String::fromCpp(jniEnv, c.paymentUriScheme)),
                                                            ::djinni::get(::djinni::List<::djinni_generated::CurrencyUnit>::fromCpp(jniEnv, c.units)),
-                                                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::BitcoinLikeNetworkParameters>::fromCpp(jniEnv, c.bitcoinLikeNetworkParameters)),
-                                                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::EthereumLikeNetworkParameters>::fromCpp(jniEnv, c.ethereumLikeNetworkParameters)),
-                                                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::RippleLikeNetworkParameters>::fromCpp(jniEnv, c.rippleLikeNetworkParameters)))};
+                                                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::BitcoinLikeNetworkParameters>::fromCpp(jniEnv, c.bitcoinLikeNetworkParameters)),
+                                                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::EthereumLikeNetworkParameters>::fromCpp(jniEnv, c.ethereumLikeNetworkParameters)),
+                                                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::RippleLikeNetworkParameters>::fromCpp(jniEnv, c.rippleLikeNetworkParameters)))};
     ::djinni::jniExceptionCheck(jniEnv);
     return r;
 }
@@ -39,9 +39,9 @@ auto Currency::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
             ::djinni::I32::toCpp(jniEnv, jniEnv->GetIntField(j, data.field_bip44CoinType)),
             ::djinni::String::toCpp(jniEnv, (jstring)jniEnv->GetObjectField(j, data.field_paymentUriScheme)),
             ::djinni::List<::djinni_generated::CurrencyUnit>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_units)),
-            ::djinni::Optional<std::experimental::optional, ::djinni_generated::BitcoinLikeNetworkParameters>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_bitcoinLikeNetworkParameters)),
-            ::djinni::Optional<std::experimental::optional, ::djinni_generated::EthereumLikeNetworkParameters>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_ethereumLikeNetworkParameters)),
-            ::djinni::Optional<std::experimental::optional, ::djinni_generated::RippleLikeNetworkParameters>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_rippleLikeNetworkParameters))};
+            ::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::BitcoinLikeNetworkParameters>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_bitcoinLikeNetworkParameters)),
+            ::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::EthereumLikeNetworkParameters>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_ethereumLikeNetworkParameters)),
+            ::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::RippleLikeNetworkParameters>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_rippleLikeNetworkParameters))};
 }
 
 }  // namespace djinni_generated

--- a/core/src/jni/jni/CurrencyCallback.cpp
+++ b/core/src/jni/jni/CurrencyCallback.cpp
@@ -16,13 +16,13 @@ CurrencyCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetThrea
 
 CurrencyCallback::JavaProxy::~JavaProxy() = default;
 
-void CurrencyCallback::JavaProxy::onCallback(const std::experimental::optional<::ledger::core::api::Currency> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void CurrencyCallback::JavaProxy::onCallback(const std::ledger_exp::optional<::ledger::core::api::Currency> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::CurrencyCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Currency>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Currency>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/CurrencyCallback.hpp
+++ b/core/src/jni/jni/CurrencyCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::experimental::optional<::ledger::core::api::Currency> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::ledger_exp::optional<::ledger::core::api::Currency> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::CurrencyCallback, ::djinni_generated::CurrencyCallback>;

--- a/core/src/jni/jni/CurrencyListCallback.cpp
+++ b/core/src/jni/jni/CurrencyListCallback.cpp
@@ -16,13 +16,13 @@ CurrencyListCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetT
 
 CurrencyListCallback::JavaProxy::~JavaProxy() = default;
 
-void CurrencyListCallback::JavaProxy::onCallback(const std::experimental::optional<std::vector<::ledger::core::api::Currency>> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void CurrencyListCallback::JavaProxy::onCallback(const std::ledger_exp::optional<std::vector<::ledger::core::api::Currency>> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::CurrencyListCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni::List<::djinni_generated::Currency>>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni::List<::djinni_generated::Currency>>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/CurrencyListCallback.hpp
+++ b/core/src/jni/jni/CurrencyListCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::experimental::optional<std::vector<::ledger::core::api::Currency>> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::ledger_exp::optional<std::vector<::ledger::core::api::Currency>> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::CurrencyListCallback, ::djinni_generated::CurrencyListCallback>;

--- a/core/src/jni/jni/DynamicArray.cpp
+++ b/core/src/jni/jni/DynamicArray.cpp
@@ -117,7 +117,7 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_DynamicArray_00024CppProxy_native
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicArray>(nativeRef);
         auto r = ref->getString(::djinni::I64::toCpp(jniEnv, j_index));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::String>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::String>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -127,7 +127,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicArray_00024CppProxy_native
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicArray>(nativeRef);
         auto r = ref->getInt(::djinni::I64::toCpp(jniEnv, j_index));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::I32>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::I32>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -137,7 +137,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicArray_00024CppProxy_native
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicArray>(nativeRef);
         auto r = ref->getLong(::djinni::I64::toCpp(jniEnv, j_index));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::I64>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::I64>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -147,7 +147,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicArray_00024CppProxy_native
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicArray>(nativeRef);
         auto r = ref->getDouble(::djinni::I64::toCpp(jniEnv, j_index));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::F64>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::F64>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -157,7 +157,7 @@ CJNIEXPORT jbyteArray JNICALL Java_co_ledger_core_DynamicArray_00024CppProxy_nat
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicArray>(nativeRef);
         auto r = ref->getData(::djinni::I64::toCpp(jniEnv, j_index));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::Binary>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::Binary>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -167,7 +167,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicArray_00024CppProxy_native
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicArray>(nativeRef);
         auto r = ref->getBoolean(::djinni::I64::toCpp(jniEnv, j_index));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::Bool>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::Bool>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -177,7 +177,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicArray_00024CppProxy_native
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicArray>(nativeRef);
         auto r = ref->getObject(::djinni::I64::toCpp(jniEnv, j_index));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::DynamicObject>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::DynamicObject>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -187,7 +187,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicArray_00024CppProxy_native
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicArray>(nativeRef);
         auto r = ref->getArray(::djinni::I64::toCpp(jniEnv, j_index));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::DynamicArray>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::DynamicArray>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -207,7 +207,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicArray_00024CppProxy_native
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicArray>(nativeRef);
         auto r = ref->getType(::djinni::I64::toCpp(jniEnv, j_index));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::DynamicType>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::DynamicType>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -265,7 +265,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicArray_load(JNIEnv* jniEnv,
     try {
         DJINNI_FUNCTION_PROLOGUE0(jniEnv);
         auto r = ::ledger::core::api::DynamicArray::load(::djinni::Binary::toCpp(jniEnv, j_serialized));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::DynamicArray>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::DynamicArray>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 

--- a/core/src/jni/jni/DynamicObject.cpp
+++ b/core/src/jni/jni/DynamicObject.cpp
@@ -115,7 +115,7 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_DynamicObject_00024CppProxy_nativ
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicObject>(nativeRef);
         auto r = ref->getString(::djinni::String::toCpp(jniEnv, j_key));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::String>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::String>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -125,7 +125,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicObject_00024CppProxy_nativ
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicObject>(nativeRef);
         auto r = ref->getInt(::djinni::String::toCpp(jniEnv, j_key));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::I32>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::I32>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -135,7 +135,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicObject_00024CppProxy_nativ
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicObject>(nativeRef);
         auto r = ref->getLong(::djinni::String::toCpp(jniEnv, j_key));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::I64>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::I64>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -145,7 +145,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicObject_00024CppProxy_nativ
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicObject>(nativeRef);
         auto r = ref->getDouble(::djinni::String::toCpp(jniEnv, j_key));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::F64>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::F64>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -155,7 +155,7 @@ CJNIEXPORT jbyteArray JNICALL Java_co_ledger_core_DynamicObject_00024CppProxy_na
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicObject>(nativeRef);
         auto r = ref->getData(::djinni::String::toCpp(jniEnv, j_key));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::Binary>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::Binary>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -165,7 +165,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicObject_00024CppProxy_nativ
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicObject>(nativeRef);
         auto r = ref->getBoolean(::djinni::String::toCpp(jniEnv, j_key));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::Bool>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::Bool>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -175,7 +175,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicObject_00024CppProxy_nativ
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicObject>(nativeRef);
         auto r = ref->getObject(::djinni::String::toCpp(jniEnv, j_key));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::DynamicObject>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::DynamicObject>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -185,7 +185,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicObject_00024CppProxy_nativ
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicObject>(nativeRef);
         auto r = ref->getArray(::djinni::String::toCpp(jniEnv, j_key));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::DynamicArray>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::DynamicArray>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -225,7 +225,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicObject_00024CppProxy_nativ
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::DynamicObject>(nativeRef);
         auto r = ref->getType(::djinni::String::toCpp(jniEnv, j_key));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::DynamicType>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::DynamicType>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -283,7 +283,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_DynamicObject_load(JNIEnv* jniEnv
     try {
         DJINNI_FUNCTION_PROLOGUE0(jniEnv);
         auto r = ::ledger::core::api::DynamicObject::load(::djinni::Binary::toCpp(jniEnv, j_serialized));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::DynamicObject>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::DynamicObject>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 

--- a/core/src/jni/jni/ErrorCodeCallback.cpp
+++ b/core/src/jni/jni/ErrorCodeCallback.cpp
@@ -16,13 +16,13 @@ ErrorCodeCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetThre
 
 ErrorCodeCallback::JavaProxy::~JavaProxy() = default;
 
-void ErrorCodeCallback::JavaProxy::onCallback(std::experimental::optional<::ledger::core::api::ErrorCode> c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void ErrorCodeCallback::JavaProxy::onCallback(std::ledger_exp::optional<::ledger::core::api::ErrorCode> c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::ErrorCodeCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::ErrorCode>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::ErrorCode>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/ErrorCodeCallback.hpp
+++ b/core/src/jni/jni/ErrorCodeCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(std::experimental::optional<::ledger::core::api::ErrorCode> result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(std::ledger_exp::optional<::ledger::core::api::ErrorCode> result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::ErrorCodeCallback, ::djinni_generated::ErrorCodeCallback>;

--- a/core/src/jni/jni/EthereumLikeTransaction.cpp
+++ b/core/src/jni/jni/EthereumLikeTransaction.cpp
@@ -108,7 +108,7 @@ CJNIEXPORT jbyteArray JNICALL Java_co_ledger_core_EthereumLikeTransaction_00024C
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::EthereumLikeTransaction>(nativeRef);
         auto r = ref->getData();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::Binary>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::Binary>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -177,7 +177,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_EthereumLikeTransaction_00024CppP
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::EthereumLikeTransaction>(nativeRef);
         auto r = ref->getBlock();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::EthereumLikeBlock>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::EthereumLikeBlock>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 

--- a/core/src/jni/jni/EthereumLikeTransactionCallback.cpp
+++ b/core/src/jni/jni/EthereumLikeTransactionCallback.cpp
@@ -16,13 +16,13 @@ EthereumLikeTransactionCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djin
 
 EthereumLikeTransactionCallback::JavaProxy::~JavaProxy() = default;
 
-void EthereumLikeTransactionCallback::JavaProxy::onCallback(const std::shared_ptr<::ledger::core::api::EthereumLikeTransaction> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void EthereumLikeTransactionCallback::JavaProxy::onCallback(const std::shared_ptr<::ledger::core::api::EthereumLikeTransaction> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::EthereumLikeTransactionCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::EthereumLikeTransaction>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::EthereumLikeTransaction>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/EthereumLikeTransactionCallback.hpp
+++ b/core/src/jni/jni/EthereumLikeTransactionCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::shared_ptr<::ledger::core::api::EthereumLikeTransaction> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::shared_ptr<::ledger::core::api::EthereumLikeTransaction> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::EthereumLikeTransactionCallback, ::djinni_generated::EthereumLikeTransactionCallback>;

--- a/core/src/jni/jni/ExtendedKeyAccountCreationInfoCallback.cpp
+++ b/core/src/jni/jni/ExtendedKeyAccountCreationInfoCallback.cpp
@@ -16,13 +16,13 @@ ExtendedKeyAccountCreationInfoCallback::JavaProxy::JavaProxy(JniType j) : Handle
 
 ExtendedKeyAccountCreationInfoCallback::JavaProxy::~JavaProxy() = default;
 
-void ExtendedKeyAccountCreationInfoCallback::JavaProxy::onCallback(const std::experimental::optional<::ledger::core::api::ExtendedKeyAccountCreationInfo> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void ExtendedKeyAccountCreationInfoCallback::JavaProxy::onCallback(const std::ledger_exp::optional<::ledger::core::api::ExtendedKeyAccountCreationInfo> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::ExtendedKeyAccountCreationInfoCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::ExtendedKeyAccountCreationInfo>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::ExtendedKeyAccountCreationInfo>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/ExtendedKeyAccountCreationInfoCallback.hpp
+++ b/core/src/jni/jni/ExtendedKeyAccountCreationInfoCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::experimental::optional<::ledger::core::api::ExtendedKeyAccountCreationInfo> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::ledger_exp::optional<::ledger::core::api::ExtendedKeyAccountCreationInfo> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::ExtendedKeyAccountCreationInfoCallback, ::djinni_generated::ExtendedKeyAccountCreationInfoCallback>;

--- a/core/src/jni/jni/HttpReadBodyResult.cpp
+++ b/core/src/jni/jni/HttpReadBodyResult.cpp
@@ -14,8 +14,8 @@ HttpReadBodyResult::~HttpReadBodyResult() = default;
 auto HttpReadBodyResult::fromCpp(JNIEnv* jniEnv, const CppType& c) -> ::djinni::LocalRef<JniType> {
     const auto& data = ::djinni::JniClass<HttpReadBodyResult>::get();
     auto r = ::djinni::LocalRef<JniType>{jniEnv->NewObject(data.clazz.get(), data.jconstructor,
-                                                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c.error)),
-                                                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni::Binary>::fromCpp(jniEnv, c.data)))};
+                                                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c.error)),
+                                                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni::Binary>::fromCpp(jniEnv, c.data)))};
     ::djinni::jniExceptionCheck(jniEnv);
     return r;
 }
@@ -24,8 +24,8 @@ auto HttpReadBodyResult::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     ::djinni::JniLocalScope jscope(jniEnv, 3);
     assert(j != nullptr);
     const auto& data = ::djinni::JniClass<HttpReadBodyResult>::get();
-    return {::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_error)),
-            ::djinni::Optional<std::experimental::optional, ::djinni::Binary>::toCpp(jniEnv, (jbyteArray)jniEnv->GetObjectField(j, data.field_data))};
+    return {::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::toCpp(jniEnv, jniEnv->GetObjectField(j, data.field_error)),
+            ::djinni::Optional<std::ledger_exp::optional, ::djinni::Binary>::toCpp(jniEnv, (jbyteArray)jniEnv->GetObjectField(j, data.field_data))};
 }
 
 }  // namespace djinni_generated

--- a/core/src/jni/jni/HttpRequest.cpp
+++ b/core/src/jni/jni/HttpRequest.cpp
@@ -67,8 +67,8 @@ CJNIEXPORT void JNICALL Java_co_ledger_core_HttpRequest_00024CppProxy_native_1co
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::HttpRequest>(nativeRef);
-        ref->complete(::djinni::Optional<std::experimental::optional, ::djinni_generated::HttpUrlConnection>::toCpp(jniEnv, j_response),
-                      ::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::toCpp(jniEnv, j_error));
+        ref->complete(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::HttpUrlConnection>::toCpp(jniEnv, j_response),
+                      ::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::toCpp(jniEnv, j_error));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/core/src/jni/jni/I32Callback.cpp
+++ b/core/src/jni/jni/I32Callback.cpp
@@ -15,13 +15,13 @@ I32Callback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetThreadEnv(
 
 I32Callback::JavaProxy::~JavaProxy() = default;
 
-void I32Callback::JavaProxy::onCallback(std::experimental::optional<int32_t> c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void I32Callback::JavaProxy::onCallback(std::ledger_exp::optional<int32_t> c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::I32Callback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni::I32>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni::I32>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/I32Callback.hpp
+++ b/core/src/jni/jni/I32Callback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(std::experimental::optional<int32_t> result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(std::ledger_exp::optional<int32_t> result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::I32Callback, ::djinni_generated::I32Callback>;

--- a/core/src/jni/jni/Operation.cpp
+++ b/core/src/jni/jni/Operation.cpp
@@ -104,7 +104,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_Operation_00024CppProxy_native_1g
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::Operation>(nativeRef);
         auto r = ref->getFees();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni_generated::Amount>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Amount>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
@@ -134,7 +134,7 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_Operation_00024CppProxy_native_1g
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::Operation>(nativeRef);
         auto r = ref->getBlockHeight();
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::I64>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::ledger_exp::optional, ::djinni::I64>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 

--- a/core/src/jni/jni/OperationListCallback.cpp
+++ b/core/src/jni/jni/OperationListCallback.cpp
@@ -16,13 +16,13 @@ OperationListCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGet
 
 OperationListCallback::JavaProxy::~JavaProxy() = default;
 
-void OperationListCallback::JavaProxy::onCallback(const std::experimental::optional<std::vector<std::shared_ptr<::ledger::core::api::Operation>>> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void OperationListCallback::JavaProxy::onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<::ledger::core::api::Operation>>> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::OperationListCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni::List<::djinni_generated::Operation>>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni::List<::djinni_generated::Operation>>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/OperationListCallback.hpp
+++ b/core/src/jni/jni/OperationListCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::experimental::optional<std::vector<std::shared_ptr<::ledger::core::api::Operation>>> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<::ledger::core::api::Operation>>> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::OperationListCallback, ::djinni_generated::OperationListCallback>;

--- a/core/src/jni/jni/RippleLikeTransactionCallback.cpp
+++ b/core/src/jni/jni/RippleLikeTransactionCallback.cpp
@@ -16,13 +16,13 @@ RippleLikeTransactionCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni
 
 RippleLikeTransactionCallback::JavaProxy::~JavaProxy() = default;
 
-void RippleLikeTransactionCallback::JavaProxy::onCallback(const std::shared_ptr<::ledger::core::api::RippleLikeTransaction> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void RippleLikeTransactionCallback::JavaProxy::onCallback(const std::shared_ptr<::ledger::core::api::RippleLikeTransaction> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::RippleLikeTransactionCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::RippleLikeTransaction>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::RippleLikeTransaction>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/RippleLikeTransactionCallback.hpp
+++ b/core/src/jni/jni/RippleLikeTransactionCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::shared_ptr<::ledger::core::api::RippleLikeTransaction> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::shared_ptr<::ledger::core::api::RippleLikeTransaction> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::RippleLikeTransactionCallback, ::djinni_generated::RippleLikeTransactionCallback>;

--- a/core/src/jni/jni/StringCallback.cpp
+++ b/core/src/jni/jni/StringCallback.cpp
@@ -15,13 +15,13 @@ StringCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetThreadE
 
 StringCallback::JavaProxy::~JavaProxy() = default;
 
-void StringCallback::JavaProxy::onCallback(const std::experimental::optional<std::string> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void StringCallback::JavaProxy::onCallback(const std::ledger_exp::optional<std::string> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::StringCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni::String>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni::String>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/StringCallback.hpp
+++ b/core/src/jni/jni/StringCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::experimental::optional<std::string> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::ledger_exp::optional<std::string> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::StringCallback, ::djinni_generated::StringCallback>;

--- a/core/src/jni/jni/WalletCallback.cpp
+++ b/core/src/jni/jni/WalletCallback.cpp
@@ -16,13 +16,13 @@ WalletCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetThreadE
 
 WalletCallback::JavaProxy::~JavaProxy() = default;
 
-void WalletCallback::JavaProxy::onCallback(const std::shared_ptr<::ledger::core::api::Wallet> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void WalletCallback::JavaProxy::onCallback(const std::shared_ptr<::ledger::core::api::Wallet> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::WalletCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Wallet>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Wallet>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/WalletCallback.hpp
+++ b/core/src/jni/jni/WalletCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::shared_ptr<::ledger::core::api::Wallet> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::shared_ptr<::ledger::core::api::Wallet> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::WalletCallback, ::djinni_generated::WalletCallback>;

--- a/core/src/jni/jni/WalletListCallback.cpp
+++ b/core/src/jni/jni/WalletListCallback.cpp
@@ -16,13 +16,13 @@ WalletListCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetThr
 
 WalletListCallback::JavaProxy::~JavaProxy() = default;
 
-void WalletListCallback::JavaProxy::onCallback(const std::experimental::optional<std::vector<std::shared_ptr<::ledger::core::api::Wallet>>> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void WalletListCallback::JavaProxy::onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<::ledger::core::api::Wallet>>> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::WalletListCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni::List<::djinni_generated::Wallet>>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni::List<::djinni_generated::Wallet>>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/WalletListCallback.hpp
+++ b/core/src/jni/jni/WalletListCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::experimental::optional<std::vector<std::shared_ptr<::ledger::core::api::Wallet>>> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::ledger_exp::optional<std::vector<std::shared_ptr<::ledger::core::api::Wallet>>> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::WalletListCallback, ::djinni_generated::WalletListCallback>;

--- a/core/src/jni/jni/WalletPoolCallback.cpp
+++ b/core/src/jni/jni/WalletPoolCallback.cpp
@@ -16,13 +16,13 @@ WalletPoolCallback::JavaProxy::JavaProxy(JniType j) : Handle(::djinni::jniGetThr
 
 WalletPoolCallback::JavaProxy::~JavaProxy() = default;
 
-void WalletPoolCallback::JavaProxy::onCallback(const std::shared_ptr<::ledger::core::api::WalletPool> & c_result, const std::experimental::optional<::ledger::core::api::Error> & c_error) {
+void WalletPoolCallback::JavaProxy::onCallback(const std::shared_ptr<::ledger::core::api::WalletPool> & c_result, const std::ledger_exp::optional<::ledger::core::api::Error> & c_error) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::WalletPoolCallback>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onCallback,
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::WalletPool>::fromCpp(jniEnv, c_result)),
-                           ::djinni::get(::djinni::Optional<std::experimental::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::WalletPool>::fromCpp(jniEnv, c_result)),
+                           ::djinni::get(::djinni::Optional<std::ledger_exp::optional, ::djinni_generated::Error>::fromCpp(jniEnv, c_error)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 

--- a/core/src/jni/jni/WalletPoolCallback.hpp
+++ b/core/src/jni/jni/WalletPoolCallback.hpp
@@ -34,7 +34,7 @@ private:
         JavaProxy(JniType j);
         ~JavaProxy();
 
-        void onCallback(const std::shared_ptr<::ledger::core::api::WalletPool> & result, const std::experimental::optional<::ledger::core::api::Error> & error) override;
+        void onCallback(const std::shared_ptr<::ledger::core::api::WalletPool> & result, const std::ledger_exp::optional<::ledger::core::api::Error> & error) override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::WalletPoolCallback, ::djinni_generated::WalletPoolCallback>;

--- a/core/src/net/HttpClient.cpp
+++ b/core/src/net/HttpClient.cpp
@@ -44,21 +44,21 @@ namespace ledger {
         }
 
         HttpRequest HttpClient::GET(const std::string &path, const std::unordered_map<std::string, std::string> &headers) {
-            return createRequest(api::HttpMethod::GET, path, std::experimental::optional<std::vector<uint8_t>>(), headers);
+            return createRequest(api::HttpMethod::GET, path, std::ledger_exp::optional<std::vector<uint8_t>>(), headers);
         }
 
         HttpRequest HttpClient::PUT(const std::string &path, const std::vector<uint8_t> &body,
                                     const std::unordered_map<std::string, std::string> &headers) {
-            return createRequest(api::HttpMethod::PUT, path, std::experimental::optional<std::vector<uint8_t>>(), headers);
+            return createRequest(api::HttpMethod::PUT, path, std::ledger_exp::optional<std::vector<uint8_t>>(), headers);
         }
 
         HttpRequest HttpClient::DEL(const std::string &path, const std::unordered_map<std::string, std::string> &headers) {
-            return createRequest(api::HttpMethod::DEL, path, std::experimental::optional<std::vector<uint8_t>>(), headers);
+            return createRequest(api::HttpMethod::DEL, path, std::ledger_exp::optional<std::vector<uint8_t>>(), headers);
         }
 
         HttpRequest HttpClient::POST(const std::string &path, const std::vector<uint8_t> &body,
                                      const std::unordered_map<std::string, std::string> &headers) {
-            return createRequest(api::HttpMethod::POST, path, std::experimental::optional<std::vector<uint8_t>>(body), headers);
+            return createRequest(api::HttpMethod::POST, path, std::ledger_exp::optional<std::vector<uint8_t>>(body), headers);
         }
 
         HttpClient& HttpClient::addHeader(const std::string &key, const std::string &value) {
@@ -72,7 +72,7 @@ namespace ledger {
         }
 
         HttpRequest HttpClient::createRequest(api::HttpMethod method, const std::string &path,
-                                              const std::experimental::optional<std::vector<uint8_t >> body,
+                                              const std::ledger_exp::optional<std::vector<uint8_t >> body,
                                               const std::unordered_map<std::string, std::string> &headers) {
             auto url = _baseUrl;
             if (path.front() == '/') {
@@ -101,7 +101,7 @@ namespace ledger {
 
         HttpRequest::HttpRequest(api::HttpMethod method, const std::string &url,
                                  const std::unordered_map<std::string, std::string> &headers,
-                                 const std::experimental::optional<std::vector<uint8_t >> body,
+                                 const std::ledger_exp::optional<std::vector<uint8_t >> body,
                                  const std::shared_ptr<api::HttpClient> &client,
                                  const std::shared_ptr<api::ExecutionContext> &context,
                                  const Option<std::shared_ptr<spdlog::logger>>& logger) {
@@ -188,7 +188,7 @@ namespace ledger {
         }
 
         void HttpRequest::ApiRequest::complete(const std::shared_ptr<api::HttpUrlConnection> &response,
-                                               const optional<api::Error> &error) {
+                                               const std::ledger_exp::optional<api::Error> &error) {
             if (error) {
                 _promise.failure(Exception(error->code, error->message));
             } else {

--- a/core/src/net/HttpClient.hpp
+++ b/core/src/net/HttpClient.hpp
@@ -64,7 +64,7 @@ namespace ledger {
             HttpRequest(api::HttpMethod method,
                         const std::string& url,
                         const std::unordered_map<std::string, std::string>& headers,
-                        const std::experimental::optional<std::vector<uint8_t >> body,
+                        const std::ledger_exp::optional<std::vector<uint8_t >> body,
                         const std::shared_ptr<api::HttpClient> &client,
                         const std::shared_ptr<api::ExecutionContext> &context,
                         const Option<std::shared_ptr<spdlog::logger>>& logger);
@@ -96,7 +96,7 @@ namespace ledger {
             api::HttpMethod _method;
             std::string _url;
             std::unordered_map<std::string, std::string> _headers;
-            std::experimental::optional<std::vector<uint8_t >> _body;
+            std::ledger_exp::optional<std::vector<uint8_t >> _body;
             std::shared_ptr<api::HttpClient> _client;
             std::shared_ptr<api::ExecutionContext> _context;
             Option<std::shared_ptr<spdlog::logger>> _logger;
@@ -115,7 +115,7 @@ namespace ledger {
                 virtual ~ApiRequest();
 
                 virtual void complete(const std::shared_ptr<api::HttpUrlConnection> &response,
-                              const optional<api::Error> &error) override;
+                              const std::ledger_exp::optional<api::Error> &error) override;
 
                 Future<std::shared_ptr<api::HttpUrlConnection>> getFuture() const;
 
@@ -142,7 +142,7 @@ namespace ledger {
         private:
             HttpRequest createRequest(api::HttpMethod method,
                                       const std::string& path,
-                                      const std::experimental::optional<std::vector<uint8_t >> body,
+                                      const std::ledger_exp::optional<std::vector<uint8_t >> body,
                                       const std::unordered_map<std::string, std::string>& headers
             );
 

--- a/core/src/preferences/PreferencesBackend.cpp
+++ b/core/src/preferences/PreferencesBackend.cpp
@@ -124,7 +124,7 @@ namespace ledger {
             }
         }
 
-        optional<std::string> PreferencesBackend::get(const std::vector<uint8_t>& key) {
+        std::ledger_exp::optional<std::string> PreferencesBackend::get(const std::vector<uint8_t>& key) {
             auto value = getRaw(key);
 
             if (value) {
@@ -133,12 +133,12 @@ namespace ledger {
                     auto plaindata = decrypt_preferences_change(ciphertext, *_cipher);
                     auto plaintext = std::string(plaindata.cbegin(), plaindata.cend());
 
-                    return optional<std::string>(plaintext);
+                    return std::ledger_exp::optional<std::string>(plaintext);
                 } else {
-                    return optional<std::string>(value);
+                    return std::ledger_exp::optional<std::string>(value);
                 }
             } else {
-                return optional<std::string>();
+                return std::ledger_exp::optional<std::string>();
             }
         }
 

--- a/core/src/preferences/PreferencesBackend.hpp
+++ b/core/src/preferences/PreferencesBackend.hpp
@@ -79,7 +79,7 @@ namespace ledger {
 
             std::shared_ptr<Preferences> getPreferences(const std::string& name);
             void iterate(const std::vector<uint8_t>& keyPrefix, std::function<bool (leveldb::Slice&&, leveldb::Slice&&)>);
-            optional<std::string> get(const std::vector<uint8_t>& key);
+            std::ledger_exp::optional<std::string> get(const std::vector<uint8_t>& key);
             void commit(const std::vector<PreferencesChange>& changes);
 
             /// Turn encryption on for all future uses.

--- a/core/src/ripple/RippleLikeAddress.cpp
+++ b/core/src/ripple/RippleLikeAddress.cpp
@@ -72,7 +72,7 @@ namespace ledger {
             return Base58::encodeWithChecksum(vector::concat(_version, _hash160), config);
         }
 
-        std::experimental::optional<std::string> RippleLikeAddress::getDerivationPath() {
+        std::ledger_exp::optional<std::string> RippleLikeAddress::getDerivationPath() {
             return _derivationPath.toOptional();
         }
 

--- a/core/src/ripple/RippleLikeAddress.h
+++ b/core/src/ripple/RippleLikeAddress.h
@@ -51,7 +51,7 @@ namespace ledger {
             api::RippleLikeNetworkParameters getNetworkParameters() override ;
             std::string toBase58() override ;
 
-            optional<std::string> getDerivationPath() override ;
+            std::ledger_exp::optional<std::string> getDerivationPath() override ;
             std::string toString() override ;
 
             static std::shared_ptr<AbstractAddress> parse(const std::string& address, const api::Currency& currency,

--- a/core/src/ripple/RippleLikeExtendedPublicKey.cpp
+++ b/core/src/ripple/RippleLikeExtendedPublicKey.cpp
@@ -48,7 +48,7 @@ namespace ledger {
         std::shared_ptr<api::RippleLikeAddress> RippleLikeExtendedPublicKey::derive(const std::string & path) {
             DerivationPath p(path);
             auto key = _derive(0, p.toVector(), _key);
-            return std::make_shared<RippleLikeAddress>(_currency, key.getPublicKeyHash160(), std::vector<uint8_t>({0x00}), optional<std::string>((_path + p).toString()));
+            return std::make_shared<RippleLikeAddress>(_currency, key.getPublicKeyHash160(), std::vector<uint8_t>({0x00}), std::ledger_exp::optional<std::string>((_path + p).toString()));
         }
 
         std::shared_ptr<RippleLikeExtendedPublicKey> RippleLikeExtendedPublicKey::derive(const DerivationPath &path) {
@@ -74,7 +74,7 @@ namespace ledger {
 
         std::shared_ptr<RippleLikeExtendedPublicKey>
         RippleLikeExtendedPublicKey::fromRaw(const api::Currency& currency,
-                                               const optional<std::vector<uint8_t>>& parentPublicKey,
+                                               const std::ledger_exp::optional<std::vector<uint8_t>>& parentPublicKey,
                                                const std::vector<uint8_t>& publicKey,
                                                const std::vector<uint8_t> &chainCode,
                                                const std::string& path) {

--- a/core/src/ripple/RippleLikeExtendedPublicKey.h
+++ b/core/src/ripple/RippleLikeExtendedPublicKey.h
@@ -63,7 +63,7 @@ namespace ledger {
             std::string getRootPath() override ;
 
             static std::shared_ptr<RippleLikeExtendedPublicKey> fromRaw(const api::Currency& params,
-                                                                          const optional<std::vector<uint8_t>>& parentPublicKey,
+                                                                          const std::ledger_exp::optional<std::vector<uint8_t>>& parentPublicKey,
                                                                           const std::vector<uint8_t>& publicKey,
                                                                           const std::vector<uint8_t> &chainCode,
                                                                           const std::string& path);

--- a/core/src/utils/Exception.cpp
+++ b/core/src/utils/Exception.cpp
@@ -31,7 +31,7 @@
 #include "Exception.hpp"
 #include <sstream>
 
-const ledger::core::optional<ledger::core::api::Error> ledger::core::Exception::NO_CORE_ERROR;
+const std::ledger_exp::optional<ledger::core::api::Error> ledger::core::Exception::NO_CORE_ERROR;
 
 ledger::core::Exception::Exception(api::ErrorCode code, const std::string &message, Option<std::shared_ptr<void>> userData) {
     _code = code;

--- a/core/src/utils/Exception.hpp
+++ b/core/src/utils/Exception.hpp
@@ -67,7 +67,7 @@ namespace ledger {
             }
 
         public:
-            static const optional<api::Error> NO_CORE_ERROR;
+            static const std::ledger_exp::optional<api::Error> NO_CORE_ERROR;
 
         private:
             api::ErrorCode _code;

--- a/core/src/utils/Option.hpp
+++ b/core/src/utils/Option.hpp
@@ -31,7 +31,7 @@
 #ifndef LEDGER_CORE_OPTION_HPP
 #define LEDGER_CORE_OPTION_HPP
 
-#include "optional.hpp"
+#include "utils/optional.hpp"
 #include "Unit.hpp"
 #include <cstddef>
 #include <new>
@@ -60,7 +60,7 @@ namespace ledger {
             Option(T&& value) : _optional(std::move(value)) {};
 
             Option(const Option<T>& option) : _optional(option._optional) {};
-            Option(const std::experimental::optional<T>& optional) : _optional(optional) {};
+            Option(const std::ledger_exp::optional<T>& optional) : _optional(optional) {};
             Option<T>& operator=(const Option<T>& option) {
                 if (this != &option) {
                     _optional = option._optional;
@@ -76,20 +76,20 @@ namespace ledger {
             };
 
             Option<T>& operator=(const T& v) {
-                _optional = optional<T>(v);
+                _optional = std::ledger_exp::optional<T>(v);
                 return *this;
             };
 
             Option<T>& operator=(T&& v) {
-                _optional = optional<T>(std::move(v));
+                _optional = std::ledger_exp::optional<T>(std::move(v));
                 return *this;
             };
 
             Option<T>&operator=(T* v) {
                 if (v == nullptr) {
-                    _optional = optional<T>(v);
+                    _optional = std::ledger_exp::optional<T>(v);
                 } else {
-                    _optional = optional<T>(*v);
+                    _optional = std::ledger_exp::optional<T>(*v);
                 }
                 return *this;
             };
@@ -161,7 +161,7 @@ namespace ledger {
                 return getValue();
             }
 
-            optional<T> toOptional() const {
+            std::ledger_exp::optional<T> toOptional() const {
                 return _optional;
             };
 
@@ -227,12 +227,12 @@ namespace ledger {
                 }
             }
 
-            operator optional<T>() {
+            operator std::ledger_exp::optional<T>() {
                 return _optional;
             }
 
         private:
-            optional<T> _optional;
+            std::ledger_exp::optional<T> _optional;
         };
 
         template <typename T>

--- a/core/src/utils/Try.hpp
+++ b/core/src/utils/Try.hpp
@@ -53,7 +53,7 @@ namespace ledger {
             };
 
             Try(const T&v) {
-                _value = optional<T>(v);
+                _value = std::ledger_exp::optional<T>(v);
             }
 
             Try(api::ErrorCode code, const std::string& message) {
@@ -133,8 +133,8 @@ namespace ledger {
 
             };
         private:
-            optional<Exception> _exception;
-            optional<T> _value;
+            std::ledger_exp::optional<Exception> _exception;
+            std::ledger_exp::optional<T> _value;
 
         public:
             static const Try<T> from(std::function<T ()> lambda) {

--- a/core/src/utils/optional.hpp
+++ b/core/src/utils/optional.hpp
@@ -101,7 +101,7 @@
 
 namespace std{
 
-    namespace experimental{
+    namespace ledger_exp{
 
 // BEGIN workaround for missing is_trivially_destructible
 # if defined TR2_OPTIONAL_GCC_4_8_AND_HIGHER___
@@ -113,8 +113,8 @@ namespace std{
 # elif defined TR2_OPTIONAL_DISABLE_EMULATION_OF_TYPE_TRAITS
     // leave it: the user doesn't want it
 # else
-	template <typename T>
-	using is_trivially_destructible = std::has_trivial_destructor<T>;
+    template <typename T>
+    using is_trivially_destructible = std::has_trivial_destructor<T>;
 # endif
 // END workaround for missing is_trivially_destructible
 
@@ -534,7 +534,7 @@ struct is_nothrow_move_assignable
 
   OPTIONAL_MUTABLE_CONSTEXPR T&& value() && {
     if (!initialized()) throw bad_optional_access("bad optional access");
-	return std::move(contained_val());
+    return std::move(contained_val());
   }
 
 # else
@@ -1017,16 +1017,16 @@ struct is_nothrow_move_assignable
         }
 
 
-    } // namespace experimental
+    } // namespace ledger_exp
 } // namespace std
 
 namespace std
 {
     template <typename T>
-    struct hash<std::experimental::optional<T>>
+    struct hash<std::ledger_exp::optional<T>>
     {
         typedef typename hash<T>::result_type result_type;
-                                              typedef std::experimental::optional<T> argument_type;
+                                              typedef std::ledger_exp::optional<T> argument_type;
 
                                               constexpr result_type operator()(argument_type const& arg) const {
             return arg ? std::hash<T>{}(*arg) : result_type{};
@@ -1034,22 +1034,15 @@ namespace std
     };
 
     template <typename T>
-    struct hash<std::experimental::optional<T&>>
+    struct hash<std::ledger_exp::optional<T&>>
     {
         typedef typename hash<T>::result_type result_type;
-                typedef std::experimental::optional<T&> argument_type;
+                typedef std::ledger_exp::optional<T&> argument_type;
 
         constexpr result_type operator()(argument_type const& arg) const {
             return arg ? std::hash<T>{}(*arg) : result_type{};
         }
     };
-}
-
-namespace ledger {
-    namespace core {
-        template <typename T>
-        using optional = std::experimental::optional<T>;
-    }
 }
 
 # undef TR2_OPTIONAL_REQUIRES

--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
@@ -628,7 +628,7 @@ namespace ledger {
             broadcastRawTransaction(transaction->serialize(), callback);
         }
 
-        std::shared_ptr<api::BitcoinLikeTransactionBuilder> BitcoinLikeAccount::buildTransaction(std::experimental::optional<bool> partial) {
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder> BitcoinLikeAccount::buildTransaction(std::ledger_exp::optional<bool> partial) {
             auto self = std::dynamic_pointer_cast<BitcoinLikeAccount>(shared_from_this());
             auto getUTXO = [self] () -> Future<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>> {
                 return self->getUTXO();

--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.hpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.hpp
@@ -116,7 +116,7 @@ namespace ledger {
             void broadcastTransaction(const std::shared_ptr<api::BitcoinLikeTransaction> &transaction,
                                       const std::shared_ptr<api::StringCallback> &callback) override;
 
-            std::shared_ptr<api::BitcoinLikeTransactionBuilder> buildTransaction(std::experimental::optional<bool> partial) override;
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder> buildTransaction(std::ledger_exp::optional<bool> partial) override;
 
             std::shared_ptr<api::OperationQuery> queryOperations() override;
 

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeInputApi.cpp
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeInputApi.cpp
@@ -40,7 +40,7 @@ namespace ledger {
             _inputIndex = inputIndex;
         }
 
-        optional<std::string> BitcoinLikeInputApi::getAddress() {
+        std::ledger_exp::optional<std::string> BitcoinLikeInputApi::getAddress() {
             return getInput().address.toOptional();
         }
 
@@ -54,7 +54,7 @@ namespace ledger {
             return getInput().coinbase.nonEmpty();
         }
 
-        optional<std::string> BitcoinLikeInputApi::getCoinbase() {
+        std::ledger_exp::optional<std::string> BitcoinLikeInputApi::getCoinbase() {
             return getInput().coinbase.toOptional();
         }
 
@@ -62,11 +62,11 @@ namespace ledger {
             return _operation->getBackend().bitcoinTransaction.getValue().inputs[_inputIndex];
         }
 
-        optional<std::string> BitcoinLikeInputApi::getPreviousTxHash() {
+        std::ledger_exp::optional<std::string> BitcoinLikeInputApi::getPreviousTxHash() {
             return getInput().previousTxHash.toOptional();
         }
 
-        optional<int32_t> BitcoinLikeInputApi::getPreviousOutputIndex() {
+        std::ledger_exp::optional<int32_t> BitcoinLikeInputApi::getPreviousOutputIndex() {
             return getInput().previousTxOutputIndex.map<int32_t>([] (const uint32_t& v) {
                 return (int32_t)v;
             }).toOptional();

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeInputApi.h
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeInputApi.h
@@ -35,17 +35,18 @@
 #include <wallet/common/api_impl/OperationApi.h>
 #include "../explorers/BitcoinLikeBlockchainExplorer.hpp"
 
+
 namespace ledger {
     namespace core {
         class BitcoinLikeInputApi : public api::BitcoinLikeInput {
         public:
             BitcoinLikeInputApi(const std::shared_ptr<OperationApi>& operation, int32_t inputIndex);
-            optional<std::string> getAddress() override;
+            std::ledger_exp::optional<std::string> getAddress() override;
             std::shared_ptr<api::Amount> getValue() override;
             bool isCoinbase() override;
-            optional<std::string> getCoinbase() override;
-            optional<std::string> getPreviousTxHash() override;
-            optional<int32_t> getPreviousOutputIndex() override;
+            std::ledger_exp::optional<std::string> getCoinbase() override;
+            std::ledger_exp::optional<std::string> getPreviousTxHash() override;
+            std::ledger_exp::optional<int32_t> getPreviousOutputIndex() override;
 
             std::vector<std::vector<uint8_t>> getPublicKeys() override;
 

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeOutputApi.cpp
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeOutputApi.cpp
@@ -69,7 +69,7 @@ namespace ledger {
             return hex::toByteArray(getOutput().script);
         }
 
-        optional<std::string> BitcoinLikeOutputApi::getAddress() {
+        std::ledger_exp::optional<std::string> BitcoinLikeOutputApi::getAddress() {
             return getOutput().address.toOptional();
         }
 

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeOutputApi.h
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeOutputApi.h
@@ -52,7 +52,7 @@ namespace ledger {
             int32_t getOutputIndex() override;
             std::shared_ptr<api::Amount> getValue() override;
             std::vector<uint8_t> getScript() override;
-            optional<std::string> getAddress() override;
+            std::ledger_exp::optional<std::string> getAddress() override;
 
             std::shared_ptr<api::BitcoinLikeScript> parseScript() override;
 

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeScriptApi.cpp
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeScriptApi.cpp
@@ -74,7 +74,7 @@ namespace ledger {
             _index = index;
         }
 
-        optional<api::BitcoinLikeOperator> BitcoinLikeScriptChunkApi::getOperator() {
+        std::ledger_exp::optional<api::BitcoinLikeOperator> BitcoinLikeScriptChunkApi::getOperator() {
             auto &chunk = getChunk();
             if (chunk.isBytes()) {
                 api::BitcoinLikeOperator op(btccore::GetOpName(chunk.getOpCode()), (uint8_t) chunk.getOpCode());
@@ -83,7 +83,7 @@ namespace ledger {
             return Option<api::BitcoinLikeOperator>().toOptional();
         }
 
-        optional<std::vector<uint8_t>> BitcoinLikeScriptChunkApi::getPushedData() {
+        std::ledger_exp::optional<std::vector<uint8_t>> BitcoinLikeScriptChunkApi::getPushedData() {
             auto &chunk = getChunk();
             if (chunk.isBytes()) return Option<std::vector<uint8_t> >(chunk.getBytes()).toOptional();
             return Option<std::vector<uint8_t> >().toOptional();

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeScriptApi.h
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeScriptApi.h
@@ -48,9 +48,9 @@ namespace ledger {
 
             bool isPushedData() override;
 
-            optional<api::BitcoinLikeOperator> getOperator() override;
+            std::ledger_exp::optional<api::BitcoinLikeOperator> getOperator() override;
 
-            optional<std::vector<uint8_t>> getPushedData() override;
+            std::ledger_exp::optional<std::vector<uint8_t>> getPushedData() override;
 
             std::shared_ptr<api::BitcoinLikeScriptChunk> next() override;
 

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp
@@ -123,7 +123,7 @@ namespace ledger {
             return _hash;
         }
 
-        optional<int32_t> BitcoinLikeTransactionApi::getTimestamp() {
+        std::ledger_exp::optional<int32_t> BitcoinLikeTransactionApi::getTimestamp() {
             return _timestamp.map<int32_t>([](const uint32_t &v) {
                 return (int32_t) v;
             }).toOptional();
@@ -138,7 +138,7 @@ namespace ledger {
             return writer.toByteArray();
         }
 
-        optional<std::vector<uint8_t>> BitcoinLikeTransactionApi::getWitness() {
+        std::ledger_exp::optional<std::vector<uint8_t>> BitcoinLikeTransactionApi::getWitness() {
             bool isDecred =  _params.Identifier == "dcr";
             BytesWriter witness;
 
@@ -405,21 +405,21 @@ namespace ledger {
         std::shared_ptr<api::BitcoinLikeTransaction>
         api::BitcoinLikeTransactionBuilder::parseRawUnsignedTransaction(const api::Currency &currency,
                                                                         const std::vector<uint8_t> &rawTransaction,
-                                                                        std::experimental::optional<int32_t> currentBlockHeight) {
+                                                                        std::ledger_exp::optional<int32_t> currentBlockHeight) {
             return BitcoinLikeTransactionApi::parseRawTransaction(currency, rawTransaction, currentBlockHeight, false);
         }
 
         std::shared_ptr<api::BitcoinLikeTransaction>
         BitcoinLikeTransactionApi::parseRawSignedTransaction(const api::Currency &currency,
                                                              const std::vector<uint8_t> &rawTransaction,
-                                                             std::experimental::optional<int32_t> currentBlockHeight) {
+                                                             std::ledger_exp::optional<int32_t> currentBlockHeight) {
             return BitcoinLikeTransactionApi::parseRawTransaction(currency, rawTransaction, currentBlockHeight, true);
         }
 
         std::shared_ptr<api::BitcoinLikeTransaction>
         BitcoinLikeTransactionApi::parseRawTransaction(const api::Currency &currency,
                                                        const std::vector<uint8_t> &rawTransaction,
-                                                       std::experimental::optional<int32_t> currentBlockHeight,
+                                                       std::ledger_exp::optional<int32_t> currentBlockHeight,
                                                        bool isSigned) {
             BytesReader reader(rawTransaction);
             // Parse version

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h
@@ -97,11 +97,11 @@ namespace ledger {
 
             std::chrono::system_clock::time_point getTime() override;
 
-            optional<int32_t> getTimestamp() override;
+            std::ledger_exp::optional<int32_t> getTimestamp() override;
 
             std::vector<uint8_t> serialize() override;
 
-            optional<std::vector<uint8_t>> getWitness() override;
+            std::ledger_exp::optional<std::vector<uint8_t>> getWitness() override;
 
             api::EstimatedSize getEstimatedSize() override;
 
@@ -123,12 +123,12 @@ namespace ledger {
 
             static std::shared_ptr<api::BitcoinLikeTransaction> parseRawTransaction(const api::Currency &currency,
                                                                                     const std::vector<uint8_t> &rawTransaction,
-                                                                                    std::experimental::optional<int32_t> currentBlockHeight,
+                                                                                    std::ledger_exp::optional<int32_t> currentBlockHeight,
                                                                                     bool isSigned);
 
             static std::shared_ptr<api::BitcoinLikeTransaction> parseRawSignedTransaction(const api::Currency &currency,
                                                                                           const std::vector<uint8_t> &rawTransaction,
-                                                                                          std::experimental::optional<int32_t> currentBlockHeight);
+                                                                                          std::ledger_exp::optional<int32_t> currentBlockHeight);
 
             static api::EstimatedSize estimateSize(std::size_t inputCount,
                                                    std::size_t outputCount,

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeWritableInputApi.cpp
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeWritableInputApi.cpp
@@ -32,6 +32,7 @@
 #include "BitcoinLikeWritableInputApi.h"
 #include <api/BinaryCallback.hpp>
 #include "BitcoinLikeScriptApi.h"
+#include "utils/optional.hpp"
 
 namespace ledger {
     namespace core {
@@ -61,7 +62,7 @@ namespace ledger {
             }
         }
 
-        optional<std::string> BitcoinLikeWritableInputApi::getAddress() {
+        std::ledger_exp::optional<std::string> BitcoinLikeWritableInputApi::getAddress() {
             return Option<std::string>(_address).toOptional();
         }
 
@@ -81,15 +82,15 @@ namespace ledger {
             return false;
         }
 
-        optional<std::string> BitcoinLikeWritableInputApi::getCoinbase() {
+        std::ledger_exp::optional<std::string> BitcoinLikeWritableInputApi::getCoinbase() {
             return Option<std::string>().toOptional();
         }
 
-        optional<std::string> BitcoinLikeWritableInputApi::getPreviousTxHash() {
+        std::ledger_exp::optional<std::string> BitcoinLikeWritableInputApi::getPreviousTxHash() {
             return Option<std::string>(_previousHash).toOptional();
         }
 
-        optional<int32_t> BitcoinLikeWritableInputApi::getPreviousOutputIndex() {
+        std::ledger_exp::optional<int32_t> BitcoinLikeWritableInputApi::getPreviousOutputIndex() {
             return Option<int32_t>(_index).toOptional();
         }
 

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeWritableInputApi.h
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeWritableInputApi.h
@@ -56,16 +56,16 @@ namespace ledger {
                     const std::shared_ptr<api::BitcoinLikeOutput>& previousOutput,
                     const std::string &keychainEngine = ""
             );
-            optional<std::string> getAddress() override;
+            std::ledger_exp::optional<std::string> getAddress() override;
             std::vector<std::vector<uint8_t>> getPublicKeys() override;
             std::shared_ptr<api::Amount> getValue() override;
 
             std::vector<std::shared_ptr<api::DerivationPath> > getDerivationPath() override;
 
             bool isCoinbase() override;
-            optional<std::string> getCoinbase() override;
-            optional<std::string> getPreviousTxHash() override;
-            optional<int32_t> getPreviousOutputIndex() override;
+            std::ledger_exp::optional<std::string> getCoinbase() override;
+            std::ledger_exp::optional<std::string> getPreviousTxHash() override;
+            std::ledger_exp::optional<int32_t> getPreviousOutputIndex() override;
             std::shared_ptr<api::BitcoinLikeOutput> getPreviousOuput() override;
             std::vector<uint8_t> getScriptSig() override;
             std::shared_ptr<api::BitcoinLikeScript> parseScriptSig() override;

--- a/core/src/wallet/common/AbstractAddress.cpp
+++ b/core/src/wallet/common/AbstractAddress.cpp
@@ -46,7 +46,7 @@ namespace ledger {
             return _currency;
         }
 
-        optional<std::string> AbstractAddress::getDerivationPath() {
+        std::ledger_exp::optional<std::string> AbstractAddress::getDerivationPath() {
             return _path.toOptional();
         }
 

--- a/core/src/wallet/common/AbstractAddress.h
+++ b/core/src/wallet/common/AbstractAddress.h
@@ -44,7 +44,7 @@ namespace ledger {
             explicit AbstractAddress(const api::Currency& currency, const Option<std::string>& path);
             api::Currency getCurrency() override;
 
-            optional<std::string> getDerivationPath() override;
+            std::ledger_exp::optional<std::string> getDerivationPath() override;
 
             std::shared_ptr<api::BitcoinLikeAddress> asBitcoinLikeAddress() override;
 

--- a/core/src/wallet/common/Amount.cpp
+++ b/core/src/wallet/common/Amount.cpp
@@ -98,7 +98,7 @@ namespace ledger {
             throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "double Amount::toDouble()");
         }
 
-        std::string Amount::format(const api::Locale &locale, const optional<api::FormatRules> &rules) {
+        std::string Amount::format(const api::Locale &locale, const std::ledger_exp::optional<api::FormatRules> &rules) {
             throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "std::string Amount::format(const api::Locale &locale, const optional<api::FormatRules> &rules)");
         }
 

--- a/core/src/wallet/common/Amount.h
+++ b/core/src/wallet/common/Amount.h
@@ -49,7 +49,7 @@ namespace ledger {
             std::string toString() override;
             int64_t toLong() override;
             double toDouble() override;
-            std::string format(const api::Locale &locale, const optional<api::FormatRules> &rules) override;
+            std::string format(const api::Locale &locale, const std::ledger_exp::optional<api::FormatRules> &rules) override;
             std::shared_ptr<api::Amount> toMagnitude(int32_t magnitude) override;
             std::shared_ptr<ledger::core::BigInt> value() const;
 

--- a/core/src/wallet/common/api_impl/OperationApi.cpp
+++ b/core/src/wallet/common/api_impl/OperationApi.cpp
@@ -107,7 +107,7 @@ namespace ledger {
             return _account->getOperationExternalPreferences(_backend.accountUid);
         }
 
-        optional<int64_t> OperationApi::getBlockHeight() {
+        std::ledger_exp::optional<int64_t> OperationApi::getBlockHeight() {
             return _backend.block.map<int64_t>([] (const Block& block) {
                 return (int64_t) block.height;
             });

--- a/core/src/wallet/common/api_impl/OperationApi.h
+++ b/core/src/wallet/common/api_impl/OperationApi.h
@@ -54,7 +54,7 @@ namespace ledger {
             std::shared_ptr<api::BitcoinLikeOperation> asBitcoinLikeOperation() override;
             std::shared_ptr<api::EthereumLikeOperation> asEthereumLikeOperation() override;
             std::shared_ptr<api::RippleLikeOperation> asRippleLikeOperation() override;
-            optional<int64_t> getBlockHeight() override;
+            std::ledger_exp::optional<int64_t> getBlockHeight() override;
             bool isInstanceOfBitcoinLikeOperation() override;
             bool isInstanceOfEthereumLikeOperation() override;
             bool isInstanceOfRippleLikeOperation() override;

--- a/core/src/wallet/ethereum/api_impl/EthereumLikeTransactionApi.cpp
+++ b/core/src/wallet/ethereum/api_impl/EthereumLikeTransactionApi.cpp
@@ -108,7 +108,7 @@ namespace ledger {
             return _value;
         }
         
-        std::experimental::optional<std::vector<uint8_t>> EthereumLikeTransactionApi::getData() {
+        std::ledger_exp::optional<std::vector<uint8_t>> EthereumLikeTransactionApi::getData() {
             return _data;
         }
 

--- a/core/src/wallet/ethereum/api_impl/EthereumLikeTransactionApi.h
+++ b/core/src/wallet/ethereum/api_impl/EthereumLikeTransactionApi.h
@@ -55,7 +55,7 @@ namespace ledger {
             std::shared_ptr<api::EthereumLikeAddress> getReceiver() override ;
             std::shared_ptr<api::EthereumLikeAddress> getSender() override;
             std::shared_ptr<api::Amount> getValue() override;
-            std::experimental::optional<std::vector<uint8_t>> getData() override;
+            std::ledger_exp::optional<std::vector<uint8_t>> getData() override;
             int32_t getStatus() override;
             std::vector<uint8_t> serialize() override;
             std::chrono::system_clock::time_point getDate() override;

--- a/core/test/async/future_test.cpp
+++ b/core/test/async/future_test.cpp
@@ -312,7 +312,7 @@ TEST(Future, ToCallbackSuccess) {
             this->dispatcher = dispatcher;
         }
 
-        void onCallback(const std::experimental::optional<int>& i, const std::experimental::optional<api::Error>& error) {
+        void onCallback(const std::ledger_exp::optional<int>& i, const std::ledger_exp::optional<api::Error>& error) {
             EXPECT_TRUE(!!i);
             EXPECT_TRUE(!error);
             EXPECT_EQ(i, 42);
@@ -338,7 +338,7 @@ TEST(Future, ToCallbackFailure) {
             this->dispatcher = dispatcher;
         }
 
-        void onCallback(const std::experimental::optional<int>& i, const std::experimental::optional<api::Error>& error) {
+        void onCallback(const std::ledger_exp::optional<int>& i, const std::ledger_exp::optional<api::Error>& error) {
             EXPECT_FALSE(!!i);
             EXPECT_FALSE(!error);
             EXPECT_EQ(error.value().code, api::ErrorCode::RUNTIME_ERROR);
@@ -363,7 +363,7 @@ TEST(Future, ExecuteAllThreadPoolOK) {
             this->dispatcher = dispatcher;
         }
 
-        void onCallback(const std::experimental::optional<std::vector<int>>& x, const std::experimental::optional<api::Error>& error) {
+        void onCallback(const std::ledger_exp::optional<std::vector<int>>& x, const std::ledger_exp::optional<api::Error>& error) {
             EXPECT_TRUE(!!x);
             EXPECT_TRUE(!error);
             auto vec = x.value();
@@ -397,7 +397,7 @@ TEST(Future, ExecuteAllSingleThreadOK) {
             this->dispatcher = dispatcher;
         }
 
-        void onCallback(const std::experimental::optional<std::vector<int>>& x, const std::experimental::optional<api::Error>& error) {
+        void onCallback(const std::ledger_exp::optional<std::vector<int>>& x, const std::ledger_exp::optional<api::Error>& error) {
             EXPECT_TRUE(!!x);
             EXPECT_TRUE(!error);
             auto vec = x.value();
@@ -431,7 +431,7 @@ TEST(Future, ExecuteAllSingleThreadFail) {
             this->dispatcher = dispatcher;
         }
 
-        void onCallback(const std::experimental::optional<std::vector<int>>& x, const std::experimental::optional<api::Error>& error) {
+        void onCallback(const std::ledger_exp::optional<std::vector<int>>& x, const std::ledger_exp::optional<api::Error>& error) {
             EXPECT_FALSE(!!x);
             EXPECT_FALSE(!error);
             EXPECT_EQ(error.value().code, api::ErrorCode::RUNTIME_ERROR);
@@ -467,7 +467,7 @@ TEST(Future, ExecuteAllThreadPoolFail) {
             this->dispatcher = dispatcher;
         }
 
-        void onCallback(const std::experimental::optional<std::vector<int>>& x, const std::experimental::optional<api::Error>& error) {
+        void onCallback(const std::ledger_exp::optional<std::vector<int>>& x, const std::ledger_exp::optional<api::Error>& error) {
             EXPECT_FALSE(!!x);
             EXPECT_FALSE(!error);
             EXPECT_EQ(error.value().code, api::ErrorCode::RUNTIME_ERROR);

--- a/core/test/bitcoin/address_test.cpp
+++ b/core/test/bitcoin/address_test.cpp
@@ -81,7 +81,7 @@ TEST(Address, XpubFromBase58String) {
     auto addr = "xpub6Cc939fyHvfB9pPLWd3bSyyQFvgKbwhidca49jGCM5Hz5ypEPGf9JVXB4NBuUfPgoHnMjN6oNgdC9KRqM11RZtL8QLW6rFKziNwHDYhZ6Kx";
     auto config = std::make_shared<ledger::core::DynamicObject>();
     config->putString(api::Configuration::KEYCHAIN_ENGINE, api::KeychainEngines::BIP32_P2PKH);
-    auto xpub = ledger::core::BitcoinLikeExtendedPublicKey::fromBase58(currency, addr, optional<std::string>("44'/0'/0'"), config);
+    auto xpub = ledger::core::BitcoinLikeExtendedPublicKey::fromBase58(currency, addr, std::ledger_exp::optional<std::string>("44'/0'/0'"), config);
     EXPECT_EQ(xpub->toBase58(), addr);
     EXPECT_EQ(xpub->derive("0/0")->toBase58(), "14NjenDKkGGq1McUgoSkeUHJpW3rrKLbPW");
     EXPECT_EQ(xpub->derive("0/1")->toBase58(), "1Pn6i3cvdGhqbdgNjXHfbaYfiuviPiymXj");
@@ -96,7 +96,7 @@ TEST(Address, XpubFromBase58StringToBech32) {
     auto bech32Address = "bitcoincash:qqufmrqunkr3avkswhn378fjhwl3ueawag9e3htc49";
     auto config = std::make_shared<ledger::core::DynamicObject>();
     config->putString(api::Configuration::KEYCHAIN_ENGINE, api::KeychainEngines::BIP173_P2WPKH);
-    auto xpub = ledger::core::BitcoinLikeExtendedPublicKey::fromBase58(currency, xpubStr, optional<std::string>("49'/145'/0'"), config);
+    auto xpub = ledger::core::BitcoinLikeExtendedPublicKey::fromBase58(currency, xpubStr, std::ledger_exp::optional<std::string>("49'/145'/0'"), config);
     EXPECT_EQ(xpub->toBase58(), xpubStr);
     EXPECT_EQ(xpub->derive("0/0")->toBase58(), base58Address);
     EXPECT_EQ(xpub->derive("0/0")->toBech32(), bech32Address);

--- a/core/test/integration/keychains/ethereum_keychain_test.cpp
+++ b/core/test/integration/keychains/ethereum_keychain_test.cpp
@@ -39,7 +39,7 @@
 #include "keychain_test_helper.h"
 #include "../BaseFixture.h"
 #include <iostream>
-using namespace std;
+
 class EthereumKeychains : public BaseFixture {
 public:
     void testEthKeychain(const KeychainTestData &data, std::function<void (EthereumLikeKeychain&)> f) {
@@ -56,7 +56,7 @@ public:
                     0,
                     ledger::core::EthereumLikeExtendedPublicKey::fromBase58(data.currency,
                                                                             data.xpub,
-                                                                            optional<std::string>(data.derivationPath)),
+                                                                            std::ledger_exp::optional<std::string>(data.derivationPath)),
                     backend->getPreferences("keychain")
             );
             f(keychain);
@@ -90,7 +90,7 @@ TEST_F(EthereumKeychains, EthereumEmptyAddressValidation) {
 TEST_F(EthereumKeychains, EthereumAddressValidationFromXpub) {
     auto extKey = ledger::core::EthereumLikeExtendedPublicKey::fromBase58(ETHEREUM_DATA.currency,
                                                                           ETHEREUM_DATA.xpub,
-                                                                          optional<std::string>(ETHEREUM_DATA.derivationPath));
+                                                                          std::ledger_exp::optional<std::string>(ETHEREUM_DATA.derivationPath));
     EXPECT_EQ(extKey->toBase58(), ETHEREUM_DATA.xpub);
 
     auto derivedPubKey = "xpub6DrvMc6me5H6sV3Wrva6thZyhxMZ7WMyB8nMWLe3T5xr79bBsDJn2zgSQiVWEbU5XfoLMEz7oZT9G49AoCcxYNrz2dVBrySzUw4k9GTNyoW";
@@ -107,7 +107,7 @@ TEST_F(EthereumKeychains, EthereumChildAddressValidationFromPubKeyAndChainCode) 
     auto pubKey = "035dd2992d954b3d232037aba9cc7fc08c2155e4f3616aa1290edc9cc09f8d64f0";
     auto chainCode = "6a4e60e6fbd45355d840ff7a18bc7cb628318f1ba6fbcfb0c07626d8ea768aca";
     auto ethXpub = ledger::core::EthereumLikeExtendedPublicKey::fromRaw(ledger::core::currencies::ETHEREUM,
-                                                                        optional<std::vector<uint8_t >>(),
+                                                                        std::ledger_exp::optional<std::vector<uint8_t >>(),
                                                                         hex::toByteArray(pubKey),
                                                                         hex::toByteArray(chainCode),
                                                                         path);
@@ -198,7 +198,7 @@ TEST_F(EthereumKeychains, EthereumAddressValidationFromPubKeyAndChainCode) {
         auto config = DynamicObject::newInstance();
         config->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME, derivationScheme);
         auto ethXpub = ledger::core::EthereumLikeExtendedPublicKey::fromRaw(ledger::core::currencies::ETHEREUM,
-                                                                            optional<std::vector<uint8_t >>(),
+                                                                            std::ledger_exp::optional<std::vector<uint8_t >>(),
                                                                             hex::toByteArray(publicKey),
                                                                             hex::toByteArray(chainCode),
                                                                             path);

--- a/core/test/integration/keychains/keychain_test_helper.h
+++ b/core/test/integration/keychains/keychain_test_helper.h
@@ -134,7 +134,7 @@ public:
                     0,
                     ledger::core::BitcoinLikeExtendedPublicKey::fromBase58(data.currency,
                                                                            data.xpub,
-                                                                           optional<std::string>(data.derivationPath),
+                                                                           std::ledger_exp::optional<std::string>(data.derivationPath),
                                                                            configuration),
                     backend->getPreferences("keychain")
             );

--- a/core/test/lib/libledger-test/AsioHttpClient.cpp
+++ b/core/test/lib/libledger-test/AsioHttpClient.cpp
@@ -80,7 +80,7 @@ void AsioHttpClient::execute(const std::shared_ptr<ledger::core::api::HttpReques
         api::HttpReadBodyResult readBody() override {
             auto b = body;
             body = std::vector<uint8_t>();
-            return api::HttpReadBodyResult(std::experimental::optional<api::Error>(), b);
+            return api::HttpReadBodyResult(std::ledger_exp::optional<api::Error>(), b);
         }
     };
 
@@ -203,7 +203,7 @@ void AsioHttpClient::execute(const std::shared_ptr<ledger::core::api::HttpReques
                 b = std::string(b.data(), b.size() - 1);
             }
             conn->body = std::vector<uint8_t>((uint8_t*)b.data(),(uint8_t*)(b.data() + b.size()));
-            q->apiRequest->complete(conn, std::experimental::optional<api::Error>());
+            q->apiRequest->complete(conn, std::ledger_exp::optional<api::Error>());
         }
     }));
 }

--- a/core/test/lib/libledger-test/MongooseHttpClient.cpp
+++ b/core/test/lib/libledger-test/MongooseHttpClient.cpp
@@ -65,8 +65,8 @@ public:
         auto body = _body;
         _body = std::vector<uint8_t>();
         return ledger::core::api::HttpReadBodyResult(
-                std::experimental::optional<ledger::core::api::Error>(),
-                std::experimental::optional<std::vector<uint8_t>>(body)
+                std::ledger_exp::optional<ledger::core::api::Error>(),
+                std::ledger_exp::optional<std::vector<uint8_t>>(body)
         );
     }
 private:
@@ -94,7 +94,7 @@ static void ev_handler(struct mg_connection *c, int ev, void *p) {
                 std::unordered_map<std::string, std::string>(),
                 std::vector<uint8_t>()
                 );
-                pair->first->complete(connection, std::experimental::optional<ledger::core::api::Error>());
+                pair->first->complete(connection, std::ledger_exp::optional<ledger::core::api::Error>());
                 pair->first = nullptr;
             }
             // delete pair # Yep that's a leak;
@@ -116,7 +116,7 @@ void MongooseHttpClient::ev_handler(struct mg_connection *c, int ev, struct http
             std::unordered_map<std::string, std::string>(),
             std::vector<uint8_t >((uint8_t *)hm->body.p, (uint8_t *)(hm->body.p + hm->body.len))
     );
-    request->complete(connection, std::experimental::optional<ledger::core::api::Error>());
+    request->complete(connection, std::ledger_exp::optional<ledger::core::api::Error>());
 }
 
 void MongooseHttpClient::execute(const std::shared_ptr<ledger::core::api::HttpRequest> &request) {

--- a/core/test/lib/libledger-test/callbacks.hpp
+++ b/core/test/lib/libledger-test/callbacks.hpp
@@ -53,7 +53,7 @@ public:
 
     virtual
     void
-    onCallback(const std::experimental::optional<T>& result, const std::experimental::optional<api::Error>& error) override {
+    onCallback(const std::ledger_exp::optional<T>& result, const std::ledger_exp::optional<api::Error>& error) override {
         if (error) {
             _promise.failure(ledger::core::Exception(error.value().code, error.value().message));
         } else {
@@ -75,7 +75,7 @@ public:
 
     virtual
     void
-    onCallback(const std::shared_ptr<T>& result, const std::experimental::optional<api::Error>& error) override {
+    onCallback(const std::shared_ptr<T>& result, const std::ledger_exp::optional<api::Error>& error) override {
         if (error) {
             _promise.failure(ledger::core::Exception(error.value().code, error.value().message));
         } else {
@@ -90,9 +90,9 @@ private:
 
 
 template <typename T, class Class>
-std::shared_ptr<FutureCallback<T, Class, has_on_callback_method<Class, void (const std::shared_ptr<T>&, const std::experimental::optional<api::Error>&)>::value>>
+std::shared_ptr<FutureCallback<T, Class, has_on_callback_method<Class, void (const std::shared_ptr<T>&, const std::ledger_exp::optional<api::Error>&)>::value>>
 make_api_callback() {
-    return std::make_shared<FutureCallback<T, Class, has_on_callback_method<Class, void (const std::shared_ptr<T>&, const std::experimental::optional<api::Error>&)>::value>>();
+    return std::make_shared<FutureCallback<T, Class, has_on_callback_method<Class, void (const std::shared_ptr<T>&, const std::ledger_exp::optional<api::Error>&)>::value>>();
 };
 
 #endif //LEDGER_CORE_CALLBACKS_HPP

--- a/core/test/ripple/address_test.cpp
+++ b/core/test/ripple/address_test.cpp
@@ -50,7 +50,7 @@ TEST(RippleAddress, AddressFromPubKeyAndChainCodeAccountLevel) {
     std::vector<uint8_t> chainCode = hex::toByteArray(
             "abcc4933bec06eeca6628b9e44f8e71d5e3cf510c0450dd1e29d9aa0f1717da9");
     auto xpub = ledger::core::RippleLikeExtendedPublicKey::fromRaw(currency,
-                                                                   optional<std::vector<uint8_t >>(),
+                                                                   std::ledger_exp::optional<std::vector<uint8_t >>(),
                                                                    pubKey,
                                                                    chainCode,
                                                                    "44'/144'/0'/0'");
@@ -63,7 +63,7 @@ TEST(RippleAddress, AddressFromPubKeyAndChainCodeAddressLevel) {
     std::vector<uint8_t> chainCode = hex::toByteArray(
             "0f2f1ffcfb379ceaef995d176e362e5b33ec14ba86d50f0facf46c2308f86c98");
     auto xpub = ledger::core::RippleLikeExtendedPublicKey::fromRaw(currency,
-                                                                   optional<std::vector<uint8_t >>(),
+                                                                   std::ledger_exp::optional<std::vector<uint8_t >>(),
                                                                    pubKey,
                                                                    chainCode,
                                                                    "44'/144'/0'/0/0");
@@ -72,7 +72,7 @@ TEST(RippleAddress, AddressFromPubKeyAndChainCodeAddressLevel) {
 
 TEST(RippleAddress, XpubFromBase58String) {
     auto addr = "xpub6DECL9NX5hvkRrq98MRvXCjTP8s84NZUFReEVLizQMVH8epXyoMvncB9DG4d8kY94XPVYqFWtUVaaagZkXvje4AUF3qdd71fJc8KyhRRC8V";
-    auto xpub = ledger::core::RippleLikeExtendedPublicKey::fromBase58(currency, addr, optional<std::string>("44'/144'/0'"));
+    auto xpub = ledger::core::RippleLikeExtendedPublicKey::fromBase58(currency, addr, std::ledger_exp::optional<std::string>("44'/144'/0'"));
     EXPECT_EQ(xpub->toBase58(), addr);
     EXPECT_EQ(xpub->derive("0/0")->toBase58(), "rhnLXhSgTgiPNMuxjkjL4qqR3iajiMxdmQ");
     EXPECT_EQ(xpub->derive("0/1")->toBase58(), "rgnbQkpdM6SR4vjHmxRzdSP7kUoNsgEmy");

--- a/qt-host/net/QtHttpClient.cpp
+++ b/qt-host/net/QtHttpClient.cpp
@@ -62,8 +62,8 @@ namespace ledger {
                 std::vector<uint8_t> body((uint8_t *)_body.data(), (uint8_t *)(_body.data() + _body.size()));
                 _body.clear();
                 return core::api::HttpReadBodyResult(
-                   std::experimental::optional<core::api::Error>(),
-                   std::experimental::optional<std::vector<uint8_t>>(body)
+                   std::ledger_exp::optional<core::api::Error>(),
+                   std::ledger_exp::optional<std::vector<uint8_t>>(body)
                 );
             }
 
@@ -124,7 +124,7 @@ namespace ledger {
                         body
                         );
 
-                        request->complete(connection, std::experimental::optional<core::api::Error>());
+                        request->complete(connection, std::ledger_exp::optional<core::api::Error>());
                     } else {
                         core::api::ErrorCode code = core::api::ErrorCode::UNKNOWN;
                         switch (reply->error()) {
@@ -211,7 +211,7 @@ namespace ledger {
                                 code = core::api::ErrorCode::HTTP_ERROR;
                                 break;
                         }
-                        request->complete(nullptr, std::experimental::optional<core::api::Error>(core::api::Error(
+                        request->complete(nullptr, std::ledger_exp::optional<core::api::Error>(core::api::Error(
                         code, reply->errorString().toStdString()
                         )));
                     }

--- a/tools/generateBindings.sh
+++ b/tools/generateBindings.sh
@@ -21,7 +21,7 @@ fi
   --idl ./core/core.djinni \
   --cpp-out $CORE_CPP_API \
   --cpp-namespace ledger::core::api \
-  --cpp-optional-template std::experimental::optional \
+  --cpp-optional-template std::ledger_exp::optional \
   --cpp-optional-header "\"../utils/optional.hpp\"" \
   --jni-include-cpp-prefix "../../api/" \
   --jni-out $CORE_CPP_JNI/jni \

--- a/tools/generateBindingsRN.sh
+++ b/tools/generateBindingsRN.sh
@@ -21,7 +21,7 @@ rm -r $CORE_CPP_API
     --idl ./core/core.djinni \
     --cpp-out $CORE_CPP_API \
     --cpp-namespace ledger::core::api \
-    --cpp-optional-template std::experimental::optional \
+    --cpp-optional-template std::ledger_exp::optional \
     --cpp-optional-header "\"../utils/optional.hpp\"" \
     --objc-type-prefix LG \
     --objc-out $DEST_IOS_OBJC \

--- a/tools/generate_interfaces.sh
+++ b/tools/generate_interfaces.sh
@@ -25,7 +25,7 @@ rm -rf $DEST $CORE_CPP_API_DIRECTORY $CORE_CPP_JNI_DIRECTORY
 ./djinni/src/run    --idl ./core/core.djinni \
                     --cpp-out $CORE_CPP_API_DIRECTORY \
                     --cpp-namespace ledger::core::api \
-                    --cpp-optional-template std::experimental::optional \
+                    --cpp-optional-template std::ledger_exp::optional \
                     --cpp-optional-header "\"../utils/optional.hpp\"" \
                     --jni-include-cpp-prefix "../../api/" \
                     --jni-out $CORE_CPP_JNI_DIRECTORY/jni \


### PR DESCRIPTION
std::optional is part of C++17, so to have less confusion with legitime std::exception namespace, put it to very custom namespace, in coming PRs will just do std::ledger_exp::optional = std::optional