### PR TITLE
Remove throw(Exception) from function definition

### DIFF
--- a/core/src/math/Base58.cpp
+++ b/core/src/math/Base58.cpp
@@ -117,7 +117,7 @@ std::string ledger::core::Base58::encodeWithEIP55(const std::string &address) {
 }
 
 std::vector<uint8_t> ledger::core::Base58::decode(const std::string &str,
-                                                  const std::shared_ptr<api::DynamicObject> &config) throw(ledger::core::Exception) {
+                                                  const std::shared_ptr<api::DynamicObject> &config) {
     BigInt intData(0);
     std::vector<uint8_t> prefix;
     auto useBase58Dict = shouldUseNetworkBase58Dictionary(config);

--- a/core/src/math/Base58.hpp
+++ b/core/src/math/Base58.hpp
@@ -51,7 +51,7 @@ namespace ledger {
             static std::string encodeWithEIP55(const std::string &address);
 
             static std::vector<uint8_t> decode(const std::string& str,
-                                               const std::shared_ptr<api::DynamicObject> &config) throw(Exception);
+                                               const std::shared_ptr<api::DynamicObject> &config);
             static Try<std::vector<uint8_t>> checkAndDecode(const std::string& str,
                                                             const std::shared_ptr<api::DynamicObject> &config);
 

--- a/core/src/utils/DerivationPath.cpp
+++ b/core/src/utils/DerivationPath.cpp
@@ -50,7 +50,7 @@ namespace ledger {
 
         }
 
-        std::vector<uint32_t> DerivationPath::parse(const std::string &path){
+        std::vector<uint32_t> DerivationPath::parse(const std::string &path) {
             std::string currentNode = "";
             bool hardened = false;
             bool lastCharWasZero = false;
@@ -115,7 +115,7 @@ namespace ledger {
             return (uint32_t) _path.size();
         }
 
-        uint32_t DerivationPath::getLastChildNum() const{
+        uint32_t DerivationPath::getLastChildNum() const {
             assertIndexIsValid(getDepth() - 1, "ledger::core::DerivationPath::getLastChildNum");
             return _path.back();
         }

--- a/core/src/utils/DerivationPath.cpp
+++ b/core/src/utils/DerivationPath.cpp
@@ -50,7 +50,7 @@ namespace ledger {
 
         }
 
-        std::vector<uint32_t> DerivationPath::parse(const std::string &path) throw(Exception) {
+        std::vector<uint32_t> DerivationPath::parse(const std::string &path){
             std::string currentNode = "";
             bool hardened = false;
             bool lastCharWasZero = false;
@@ -115,12 +115,12 @@ namespace ledger {
             return (uint32_t) _path.size();
         }
 
-        uint32_t DerivationPath::getLastChildNum() const throw(Exception) {
+        uint32_t DerivationPath::getLastChildNum() const{
             assertIndexIsValid(getDepth() - 1, "ledger::core::DerivationPath::getLastChildNum");
             return _path.back();
         }
 
-        uint32_t DerivationPath::getNonHardenedChildNum(int index) const throw(ledger::core::Exception) {
+        uint32_t DerivationPath::getNonHardenedChildNum(int index) const  {
             assertIndexIsValid(index, "ledger::core::DerivationPath::getNonHardenedChildNum");
             if (isHardened(index)) {
                 return (*this)[index] & ~HARD_BIT;
@@ -129,12 +129,12 @@ namespace ledger {
             }
         }
 
-        uint32_t DerivationPath::getNonHardenedLastChildNum() const throw(ledger::core::Exception) {
+        uint32_t DerivationPath::getNonHardenedLastChildNum() const {
             assertIndexIsValid(getDepth() - 1, "ledger::core::DerivationPath::getNonHardenedLastChildNum");
             return getLastChildNum() & ~HARD_BIT;
         }
 
-        uint32_t DerivationPath::operator[](int index) const throw(ledger::core::Exception) {
+        uint32_t DerivationPath::operator[](int index) const {
             assertIndexIsValid(index, "ledger::core::DerivationPath::operator[]");
             return _path[index];
         }
@@ -153,7 +153,7 @@ namespace ledger {
             return !((*this) == path);
         }
 
-        DerivationPath DerivationPath::getParent() const throw(ledger::core::Exception) {
+        DerivationPath DerivationPath::getParent() const {
             assertIndexIsValid(getDepth() - 1, "ledger::core::DerivationPath::getParent");
             return DerivationPath(std::vector<uint32_t>(_path.begin(), _path.end() - 1));
         }
@@ -185,17 +185,17 @@ namespace ledger {
             return _path;
         }
 
-        bool DerivationPath::isHardened(int index) const throw(ledger::core::Exception) {
+        bool DerivationPath::isHardened(int index) const {
             assertIndexIsValid(index, "ledger::core::DerivationPath::isHardened");
             return (_path[index] & HARD_BIT) == HARD_BIT;
         }
 
-        bool DerivationPath::isLastChildHardened() const throw(ledger::core::Exception) {
+        bool DerivationPath::isLastChildHardened() const {
             assertIndexIsValid(getDepth() - 1, "ledger::core::DerivationPath::isLastChildHardened");
             return isHardened(getDepth() - 1);
         }
 
-        void DerivationPath::assertIndexIsValid(int index, const std::string& method) const throw(Exception) {
+        void DerivationPath::assertIndexIsValid(int index, const std::string& method) const {
             if (index >= getDepth()) {
                 throw Exception(api::ErrorCode::RUNTIME_ERROR, fmt::format("{} - Index ({}) is out of bound. Path depth is {}", method, index, getDepth()));
             } else if (index < 0) {

--- a/core/src/utils/DerivationPath.hpp
+++ b/core/src/utils/DerivationPath.hpp
@@ -46,22 +46,22 @@ namespace ledger {
             DerivationPath& operator=(DerivationPath&& path);
             DerivationPath& operator=(const DerivationPath& path);
             uint32_t getDepth() const;
-            uint32_t getLastChildNum() const throw(ledger::core::Exception);
-            uint32_t getNonHardenedChildNum(int index) const throw(ledger::core::Exception);
-            uint32_t getNonHardenedLastChildNum() const throw(ledger::core::Exception);
-            uint32_t operator[](int index) const throw(Exception);
+            uint32_t getLastChildNum() const;
+            uint32_t getNonHardenedChildNum(int index) const;
+            uint32_t getNonHardenedLastChildNum() const;
+            uint32_t operator[](int index) const;
             DerivationPath operator+(const DerivationPath& derivationPath) const;
             bool operator==(const DerivationPath& path) const;
             bool operator!=(const DerivationPath& path) const;
-            DerivationPath getParent() const throw(ledger::core::Exception);
+            DerivationPath getParent() const;
             bool isRoot() const;
             std::string toString(bool addLeadingM = false) const;
             std::vector<uint32_t> toVector() const;
-            bool isHardened(int index) const throw(ledger::core::Exception);
-            bool isLastChildHardened() const throw(ledger::core::Exception);
+            bool isHardened(int index) const;
+            bool isLastChildHardened() const;
 
         public:
-            static std::vector<uint32_t> parse(const std::string& path) throw(Exception);
+            static std::vector<uint32_t> parse(const std::string& path);
             static DerivationPath fromScheme(
                 const std::string& scheme,
                 int coinType,
@@ -72,7 +72,7 @@ namespace ledger {
             );
 
         private:
-            inline void assertIndexIsValid(int index, const std::string& method) const throw(Exception);
+            inline void assertIndexIsValid(int index, const std::string& method) const;
 
         private:
             std::vector<uint32_t> _path;


### PR DESCRIPTION
Remove a lot of warnings and prepare for C++17 (throw(Something) is removed from C++)