### PR TITLE
Add support for destination tags for XRP

### DIFF
--- a/core/idl/wallet/ripple/ripple_like_wallet.djinni
+++ b/core/idl/wallet/ripple/ripple_like_wallet.djinni
@@ -38,6 +38,8 @@ RippleLikeTransaction = interface +c {
     getMemos(): list<RippleLikeMemo>;
     # Add a memo to a transaction.
     addMemo(memo: RippleLikeMemo);
+    # An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account
+    getDestinationTag(): optional<i64>;
 }
 
 #Class representing a Ripple Operation
@@ -80,6 +82,9 @@ RippleLikeTransactionBuilder = interface +c {
     # Add a memo.
     # @return A reference on the same builder in order to chain calls.
     addMemo(memo: RippleLikeMemo): RippleLikeTransactionBuilder;
+
+    # An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account
+    setDestinationTag(tag: i64): RippleLikeTransactionBuilder;
 
     # Build a transaction from the given builder parameters.
     build(callback: Callback<RippleLikeTransaction>);

--- a/core/src/api/RippleLikeTransaction.hpp
+++ b/core/src/api/RippleLikeTransaction.hpp
@@ -4,6 +4,7 @@
 #ifndef DJINNI_GENERATED_RIPPLELIKETRANSACTION_HPP
 #define DJINNI_GENERATED_RIPPLELIKETRANSACTION_HPP
 
+#include "../utils/optional.hpp"
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -80,6 +81,9 @@ public:
 
     /** Add a memo to a transaction. */
     virtual void addMemo(const RippleLikeMemo & memo) = 0;
+
+    /** An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account */
+    virtual std::experimental::optional<int64_t> getDestinationTag() = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/RippleLikeTransactionBuilder.hpp
+++ b/core/src/api/RippleLikeTransactionBuilder.hpp
@@ -55,6 +55,9 @@ public:
      */
     virtual std::shared_ptr<RippleLikeTransactionBuilder> addMemo(const RippleLikeMemo & memo) = 0;
 
+    /** An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account */
+    virtual std::shared_ptr<RippleLikeTransactionBuilder> setDestinationTag(int64_t tag) = 0;
+
     /** Build a transaction from the given builder parameters. */
     virtual void build(const std::shared_ptr<RippleLikeTransactionCallback> & callback) = 0;
 

--- a/core/src/jni/jni/RippleLikeTransaction.cpp
+++ b/core/src/jni/jni/RippleLikeTransaction.cpp
@@ -161,4 +161,14 @@ CJNIEXPORT void JNICALL Java_co_ledger_core_RippleLikeTransaction_00024CppProxy_
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
+CJNIEXPORT jobject JNICALL Java_co_ledger_core_RippleLikeTransaction_00024CppProxy_native_1getDestinationTag(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::RippleLikeTransaction>(nativeRef);
+        auto r = ref->getDestinationTag();
+        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::I64>::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 }  // namespace djinni_generated

--- a/core/src/jni/jni/RippleLikeTransactionBuilder.cpp
+++ b/core/src/jni/jni/RippleLikeTransactionBuilder.cpp
@@ -65,6 +65,16 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_RippleLikeTransactionBuilder_0002
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jobject JNICALL Java_co_ledger_core_RippleLikeTransactionBuilder_00024CppProxy_native_1setDestinationTag(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jlong j_tag)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::RippleLikeTransactionBuilder>(nativeRef);
+        auto r = ref->setDestinationTag(::djinni::I64::toCpp(jniEnv, j_tag));
+        return ::djinni::release(::djinni_generated::RippleLikeTransactionBuilder::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT void JNICALL Java_co_ledger_core_RippleLikeTransactionBuilder_00024CppProxy_native_1build(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jobject j_callback)
 {
     try {

--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
@@ -494,6 +494,8 @@ namespace ledger {
                                 sum = sum - (operation.amount + operation.fees.getValueOr(BigInt::ZERO));
                                 break;
                             }
+                            case api::OperationType::NONE:
+                                break;
                         }
                     }
                     operationsCount += 1;

--- a/core/src/wallet/ripple/RippleLikeAccount.cpp
+++ b/core/src/wallet/ripple/RippleLikeAccount.cpp
@@ -407,6 +407,10 @@ namespace ledger {
                     tx->addMemo(memo);
                 }
 
+                if (request.destinationTag.hasValue()) {
+                    tx->setDestinationTag(request.destinationTag.getValue());
+                }
+
                 return explorer->getSequence(accountAddress->toString()).mapPtr<api::RippleLikeTransaction>(self->getContext(), [self, tx] (const std::shared_ptr<BigInt> &sequence) -> std::shared_ptr<api::RippleLikeTransaction> {
                     tx->setSequence(BigInt(sequence->toString()) + BigInt("1"));
                     return tx;

--- a/core/src/wallet/ripple/api_impl/RippleLikeTransactionApi.cpp
+++ b/core/src/wallet/ripple/api_impl/RippleLikeTransactionApi.cpp
@@ -194,6 +194,13 @@ namespace ledger {
             auto sequence = _sequence->toString(16);
             writer.writeBeValue<uint32_t>(static_cast<const uint32_t>(_sequence->intValue()));
 
+            if (_destinationTag.hasValue()) {
+                //1 byte Destination tag:   Type Code = 2, Field Code = 14
+                writer.writeByte(0x2E);
+                //4 bytes Destination tag
+                writer.writeBeValue<uint32_t>(static_cast<const uint32_t>(_destinationTag.getValue()));
+            }
+
             //2 bytes LastLedgerSequence Field ID:   Type Code = 2, Field Code = 27
             writer.writeByteArray({0x20, 0x1B});
             //LastLedgerSequence
@@ -349,6 +356,15 @@ namespace ledger {
         RippleLikeTransactionApi &RippleLikeTransactionApi::setHash(const std::string &hash) {
             _hash = hash;
             return *this;
+        }
+
+        RippleLikeTransactionApi &RippleLikeTransactionApi::setDestinationTag(uint32_t tag) {
+            _destinationTag = tag;
+            return *this;
+        }
+
+        std::experimental::optional<int64_t> RippleLikeTransactionApi::getDestinationTag() {
+            return _destinationTag.toOptional();
         }
 
         std::vector<api::RippleLikeMemo> RippleLikeTransactionApi::getMemos() {

--- a/core/src/wallet/ripple/api_impl/RippleLikeTransactionApi.h
+++ b/core/src/wallet/ripple/api_impl/RippleLikeTransactionApi.h
@@ -68,9 +68,10 @@ namespace ledger {
             RippleLikeTransactionApi & setReceiver(const std::shared_ptr<api::RippleLikeAddress> &receiver);
             RippleLikeTransactionApi & setSigningPubKey(const std::vector<uint8_t> &pubKey);
             RippleLikeTransactionApi & setHash(const std::string &hash);
+            RippleLikeTransactionApi & setDestinationTag(uint32_t tag);
             std::vector<api::RippleLikeMemo> getMemos() override;
             void addMemo(api::RippleLikeMemo const& memo) override;
-
+            std::experimental::optional<int64_t> getDestinationTag() override;
         private:
             std::chrono::system_clock::time_point _time;
             std::shared_ptr<RippleLikeBlockApi> _block;
@@ -86,6 +87,7 @@ namespace ledger {
             std::vector<uint8_t> _sSignature;
             std::vector<uint8_t> _signingPubKey;
             std::vector<api::RippleLikeMemo> _memos;
+            Option<int64_t> _destinationTag;
         };
     }
 }

--- a/core/src/wallet/ripple/transaction_builders/RippleLikeTransactionBuilder.h
+++ b/core/src/wallet/ripple/transaction_builders/RippleLikeTransactionBuilder.h
@@ -58,6 +58,7 @@ namespace ledger {
             BigInt sequence;
             bool wipe;
             std::vector<api::RippleLikeMemo> memos;
+            Option<int64_t> destinationTag;
         };
 
         using RippleLikeTransactionBuildFunction = std::function<Future<std::shared_ptr<api::RippleLikeTransaction>>(
@@ -84,6 +85,8 @@ namespace ledger {
             std::shared_ptr<api::RippleLikeTransactionBuilder> setFees(const std::shared_ptr<api::Amount> & fees) override;
 
             std::shared_ptr<api::RippleLikeTransactionBuilder> addMemo(const api::RippleLikeMemo& memo) override;
+
+            std::shared_ptr<api::RippleLikeTransactionBuilder> setDestinationTag(int64_t tag) override;
 
             void build(const std::shared_ptr<api::RippleLikeTransactionCallback> &callback) override;
 

--- a/core/test/common/balance_history.cpp
+++ b/core/test/common/balance_history.cpp
@@ -71,6 +71,9 @@ struct DummyOperationStrategy {
             case api::OperationType::SEND:
                 sum -= op.amount;
                 break;
+
+            case api::OperationType::NONE:
+                break;
         }
     }
 };

--- a/core/test/integration/CMakeLists.txt
+++ b/core/test/integration/CMakeLists.txt
@@ -173,3 +173,5 @@ add_test (NAME ledger-core-integration-RippleLikeWalletSynchronization.EmitNewBl
 
 add_test (NAME ledger-core-integration-RippleMakeTransaction.CreateTx COMMAND ledger-core-integration-tests --gtest_filter="RippleMakeTransaction.CreateTx")
 add_test (NAME ledger-core-integration-RippleMakeTransaction.ParseSignedRawTransaction COMMAND ledger-core-integration-tests --gtest_filter="RippleMakeTransaction.ParseSignedRawTransaction")
+add_test (NAME ledger-core-integration-RippleMakeTransaction.ParseSignedRawTransactionWithMemo COMMAND ledger-core-integration-tests --gtest_filter="RippleMakeTransaction.ParseSignedRawTransactionWithMemo")
+add_test (NAME ledger-core-integration-RippleMakeTransaction.ParseSignedRawTransactionWithDestinationTag COMMAND ledger-core-integration-tests --gtest_filter="RippleMakeTransaction.ParseSignedRawTransactionWithDestinationTag")


### PR DESCRIPTION
This is a required feature for Live ! 
For more infos about destination tag: 
https://developers.ripple.com/rippleapi-reference.html#payment
https://support.kraken.com/hc/en-us/articles/360000184443-What-is-the-Destination-Tag-for-XRP-Deposits-
Corresponding task: https://ledgerhq.atlassian.net/browse/LLC-222
Note: we don't retrieve/parse the destination tag from received transactions in purpose, because it is useless/not used. 