### PR TITLE
Adapt account creation infos to exotic paths 

### DIFF
--- a/core/src/database/DatabaseSessionPool.hpp
+++ b/core/src/database/DatabaseSessionPool.hpp
@@ -59,7 +59,7 @@ namespace ledger {
                 const std::string &password = ""
             );
 
-            static const int CURRENT_DATABASE_SCHEME_VERSION = 9;
+            static const int CURRENT_DATABASE_SCHEME_VERSION = 10;
 
             void performDatabaseMigration();
             void performDatabaseRollback();

--- a/core/src/database/migrations.cpp
+++ b/core/src/database/migrations.cpp
@@ -562,5 +562,13 @@ namespace ledger {
             sql << "DROP TABLE erc20_operations";
             sql << "ALTER TABLE erc20_swap RENAME TO erc20_operations";
         }
+
+        template <> void migrate<10>(soci::session& sql) {
+            sql << "ALTER TABLE erc20_operations ADD COLUMN block_height BIGINT";
+        }
+
+        template <> void rollback<10>(soci::session& sql) {
+            // not supported in standard ways by SQLite :(
+        }
     }
 }

--- a/core/src/ethereum/EthereumLikeAddress.cpp
+++ b/core/src/ethereum/EthereumLikeAddress.cpp
@@ -82,20 +82,24 @@ namespace ledger {
             return std::dynamic_pointer_cast<AbstractAddress>(result.toOption().getValueOr(nullptr));
         }
 
-        std::shared_ptr<EthereumLikeAddress> EthereumLikeAddress::fromEIP55(const std::string& address,
-                                                                            const api::Currency& currency,
-                                                                            const Option<std::string>& derivationPath) {
-            //Remove 0x
-            auto tmpAddress = address.substr(2, address.length() - 2);
-            auto keccack256 = hex::toByteArray(tmpAddress);
-            //Now we only accept addresses that are EIP55 compliant
-            //If client want to use all lower/upper cased address
-            //they should decide if those addresses are valid or not
-            //N.B.: Live and Vault will validate these addresses and
-            //warn that this address was not validated from our side
-            if (tmpAddress.size() != 40 || address != Base58::encodeWithEIP55(keccack256)) {
-                throw Exception(api::ErrorCode::INVALID_EIP55_FORMAT, "Invalid address : Invalid EIP55 format");
+        std::shared_ptr<EthereumLikeAddress> EthereumLikeAddress::fromEIP55(const std::string &address,
+                                                                            const api::Currency &currency,
+                                                                            const Option<std::string> &derivationPath) {
+            std::vector<uint8_t> keccack256;
+            if (!address.empty()) {
+                //Remove 0x
+                auto tmpAddress = address.substr(2, address.length() - 2);
+                keccack256 = hex::toByteArray(tmpAddress);
+                //Now we only accept addresses that are EIP55 compliant
+                //If client want to use all lower/upper cased address
+                //they should decide if those addresses are valid or not
+                //N.B.: Live and Vault will validate these addresses and
+                //warn that this address was not validated from our side
+                if (tmpAddress.size() != 40 || address != Base58::encodeWithEIP55(keccack256)) {
+                    throw Exception(api::ErrorCode::INVALID_EIP55_FORMAT, "Invalid address : Invalid EIP55 format");
+                }
             }
+
             return std::make_shared<ledger::core::EthereumLikeAddress>(currency, keccack256, derivationPath);
         }
     }

--- a/core/src/ethereum/EthereumLikeAddress.cpp
+++ b/core/src/ethereum/EthereumLikeAddress.cpp
@@ -86,7 +86,7 @@ namespace ledger {
                                                                             const api::Currency &currency,
                                                                             const Option<std::string> &derivationPath) {
             std::vector<uint8_t> keccack256;
-            if (!address.empty()) {
+            if (address.length() > 2) {
                 //Remove 0x
                 auto tmpAddress = address.substr(2, address.length() - 2);
                 keccack256 = hex::toByteArray(tmpAddress);

--- a/core/src/utils/DerivationScheme.cpp
+++ b/core/src/utils/DerivationScheme.cpp
@@ -89,7 +89,9 @@ namespace ledger {
                                                                        DerivationSchemeLevel::NODE,
                                                                        DerivationSchemeLevel::ADDRESS_INDEX};
                 for (size_t i = 0; i < _scheme.size(); i++ ) {
-                    if (_scheme[i].level == DerivationSchemeLevel::UNDEFINED) {
+                    // We don't set twice a level
+                    auto it = std::find_if(_scheme.begin() + i, _scheme.end(), [&](const DerivationSchemeNode &node){return node.level == schemeLevel[i];});
+                    if (it == _scheme.end() && _scheme[i].level == DerivationSchemeLevel::UNDEFINED) {
                         _scheme[i].level = schemeLevel[i];
                     }
                 }
@@ -133,6 +135,13 @@ namespace ledger {
                     return DerivationScheme(scheme);
                 }
                 it++;
+            }
+            return *this;
+        }
+
+        DerivationScheme DerivationScheme::getSchemeToDepth(size_t depth) {
+            if (depth <= _scheme.size()) {
+                return DerivationScheme(std::vector<DerivationSchemeNode>(_scheme.begin(), _scheme.begin() + depth));
             }
             return *this;
         }

--- a/core/src/utils/DerivationScheme.cpp
+++ b/core/src/utils/DerivationScheme.cpp
@@ -139,7 +139,7 @@ namespace ledger {
             return *this;
         }
 
-        DerivationScheme DerivationScheme::getSchemeToDepth(size_t depth) {
+        DerivationScheme DerivationScheme::getSchemeToDepth(size_t depth) const {
             if (depth <= _scheme.size()) {
                 return DerivationScheme(std::vector<DerivationSchemeNode>(_scheme.begin(), _scheme.begin() + depth));
             }

--- a/core/src/utils/DerivationScheme.hpp
+++ b/core/src/utils/DerivationScheme.hpp
@@ -59,7 +59,7 @@ namespace ledger {
             DerivationScheme(const DerivationScheme& cpy);
             DerivationScheme getSchemeFrom(DerivationSchemeLevel level);
             DerivationScheme getSchemeTo(DerivationSchemeLevel level);
-            DerivationScheme getSchemeToDepth(size_t depth);
+            DerivationScheme getSchemeToDepth(size_t depth) const;
             DerivationScheme shift(int n = 1);
 
             DerivationPath getPath();

--- a/core/src/utils/DerivationScheme.hpp
+++ b/core/src/utils/DerivationScheme.hpp
@@ -59,6 +59,7 @@ namespace ledger {
             DerivationScheme(const DerivationScheme& cpy);
             DerivationScheme getSchemeFrom(DerivationSchemeLevel level);
             DerivationScheme getSchemeTo(DerivationSchemeLevel level);
+            DerivationScheme getSchemeToDepth(size_t depth);
             DerivationScheme shift(int n = 1);
 
             DerivationPath getPath();

--- a/core/src/wallet/ethereum/ERC20/ERC20LikeAccount.cpp
+++ b/core/src/wallet/ethereum/ERC20/ERC20LikeAccount.cpp
@@ -163,7 +163,7 @@ namespace ledger {
             soci::rowset<soci::row> rows = (sql.prepare << "SELECT op.uid, op.ethereum_operation_uid, op.account_uid,"
                     " op.type, op.hash, op.nonce, op.value,"
                     " op.date, op.sender, op.receiver, op.input_data,"
-                    " op.gas_price, op.gas_limit, op.gas_used, op.status"
+                    " op.gas_price, op.gas_limit, op.gas_used, op.status, op.block_height"
                     " FROM erc20_operations AS op"
                     " WHERE op.account_uid = :account_uid", soci::use(_accountUid));
             std::vector<std::shared_ptr<api::ERC20LikeOperation>> result;
@@ -189,6 +189,8 @@ namespace ledger {
                 op->setUsedGas(BigInt::fromHex(row.get<std::string>(13)));
                 auto status = row.get<int32_t>(14);
                 op->setStatus(status);
+                auto blockHeight = row.get<long long>(15);
+                op->setBlockHeight(blockHeight);
                 result.emplace_back(op);
             }
             return result;
@@ -243,16 +245,17 @@ namespace ledger {
                 auto gasPrice = operation->getGasPrice()->toString(16);
                 auto gasLimit = operation->getGasLimit()->toString(16);
                 auto gasUsed = operation->getUsedGas()->toString(16);
+                auto blockHeight = operation->getBlockHeight().value_or(0);
                 sql << "INSERT INTO erc20_operations VALUES("
                         ":uid, :eth_op_uid, :accout_uid, :op_type, :hash, :nonce, :value, :date, :sender,"
-                        ":receiver, :data, :gas_price, :gas_limit, :gas_used, :status"
+                        ":receiver, :data, :gas_price, :gas_limit, :gas_used, :status, :block_height"
                         ")"
                         , use(erc20OpUid), use(ethOpUid)
                         , use(_accountUid), use(operationType), use(hash)
                         , use(nonce), use(value), use(time)
                         , use(sender), use(receiver), use(data)
                         , use(gasPrice), use(gasLimit), use(gasUsed)
-                        , use(status);
+                        , use(status), use(blockHeight);
             }
         }
 

--- a/core/src/wallet/ethereum/ERC20/ERC20LikeOperation.h
+++ b/core/src/wallet/ethereum/ERC20/ERC20LikeOperation.h
@@ -134,6 +134,11 @@ namespace ledger {
                 _status = status;
                 return *this;
             };
+
+            ERC20LikeOperation &setBlockHeight(int64_t blockHeight) {
+                _blockHeight = blockHeight;
+                return *this;
+            }
             
         private:
             std::string _uid;

--- a/core/src/wallet/ethereum/EthereumLikeWallet.cpp
+++ b/core/src/wallet/ethereum/EthereumLikeWallet.cpp
@@ -158,7 +158,7 @@ namespace ledger {
                 if (path.isHardened(hardenedDepth - 1)) {
                     break;
                 }
-                hardenedDepth --;
+                hardenedDepth--;
             }
             auto lastHardenedScheme = scheme.getSchemeToDepth(hardenedDepth);
             return accountScheme.getPath().getDepth() > lastHardenedScheme.getPath().getDepth() ? accountScheme : lastHardenedScheme;

--- a/core/src/wallet/ethereum/factories/EthereumLikeKeychainFactory.cpp
+++ b/core/src/wallet/ethereum/factories/EthereumLikeKeychainFactory.cpp
@@ -56,10 +56,9 @@ namespace ledger {
                 if (xpub.isFailure()) {
                     throw xpub.getFailure();
                 } else {
-                    auto keychain = std::make_shared<EthereumLikeKeychain>(
+                    return std::make_shared<EthereumLikeKeychain>(
                             configuration, currency, index, xpub.getValue(), accountPreferences
                     );
-                    return keychain;
                 }
 
             } else {

--- a/core/src/wallet/ethereum/keychains/EthereumLikeKeychain.cpp
+++ b/core/src/wallet/ethereum/keychains/EthereumLikeKeychain.cpp
@@ -167,16 +167,20 @@ namespace ledger {
                 auto cacheKey = fmt::format("path:{}", _localPath);
                 _address = getPreferences()->getString(cacheKey, "");
                 if (_address.empty()) {
-                    auto p = getDerivationScheme().getSchemeFrom(DerivationSchemeLevel::NODE).shift(1)
+                    auto nodeScheme = getDerivationScheme()
+                            .getSchemeFrom(DerivationSchemeLevel::NODE);
+                    auto p = nodeScheme.getPath().getDepth() > 0 ? nodeScheme
+                            .shift(1)
                             .setCoinType(getCurrency().bip44CoinType)
-                            .getPath().toString();
+                            .getPath()
+                            .toString() : "";
 
-                    auto localNodeScheme = getDerivationScheme().getSchemeTo(DerivationSchemeLevel::NODE)
+                    auto localNodeScheme = getDerivationScheme()
+                            .getSchemeTo(DerivationSchemeLevel::NODE)
                             .setCoinType(getCurrency().bip44CoinType);
-
                     // If node level is hardened we don't derive according to it since private
                     // derivation are not supported 
-                    auto xpub = localNodeScheme.getPath().isHardened(0) ? std::static_pointer_cast<EthereumLikeExtendedPublicKey>(_xpub)->derive(DerivationPath("")) : std::static_pointer_cast<EthereumLikeExtendedPublicKey>(_xpub)->derive(localNodeScheme.getPath());
+                    auto xpub = localNodeScheme.getPath().getDepth() > 0 && localNodeScheme.getPath().isHardened(0) ? std::static_pointer_cast<EthereumLikeExtendedPublicKey>(_xpub)->derive(DerivationPath("")) : std::static_pointer_cast<EthereumLikeExtendedPublicKey>(_xpub)->derive(localNodeScheme.getPath());
                     auto strScheme = localNodeScheme.getPath().toString();
 
                     _address = xpub->derive(p)->toEIP55();

--- a/core/test/integration/CMakeLists.txt
+++ b/core/test/integration/CMakeLists.txt
@@ -169,6 +169,7 @@ add_test (NAME ledger-core-integration-EthereumMakeTransaction.ParseUnsignedRawT
 
 add_test (NAME ledger-core-integration-EthereumKeychains.KeychainDerivation COMMAND ledger-core-integration-tests --gtest_filter="EthereumKeychains.KeychainDerivation")
 add_test (NAME ledger-core-integration-EthereumKeychains.EthereumAddressValidation COMMAND ledger-core-integration-tests --gtest_filter="EthereumKeychains.EthereumAddressValidation")
+add_test (NAME ledger-core-integration-EthereumKeychains.EthereumEmptyAddressValidation COMMAND ledger-core-integration-tests --gtest_filter="EthereumKeychains.EthereumEmptyAddressValidation")
 add_test (NAME ledger-core-integration-EthereumKeychains.EthereumAddressValidationFromXpub COMMAND ledger-core-integration-tests --gtest_filter="EthereumKeychains.EthereumAddressValidationFromXpub")
 add_test (NAME ledger-core-integration-EthereumKeychains.EthereumChildAddressValidationFromPubKeyAndChainCode COMMAND ledger-core-integration-tests --gtest_filter="EthereumKeychains.EthereumChildAddressValidationFromPubKeyAndChainCode")
 add_test (NAME ledger-core-integration-EthereumKeychains.EthereumExoticDerivationPaths COMMAND ledger-core-integration-tests --gtest_filter="EthereumKeychains.EthereumExoticDerivationPaths")

--- a/core/test/integration/CMakeLists.txt
+++ b/core/test/integration/CMakeLists.txt
@@ -167,6 +167,14 @@ add_test (NAME ledger-core-integration-EthereumLikeWalletSynchronization.XpubSyn
 add_test (NAME ledger-core-integration-EthereumMakeTransaction.CreateTx COMMAND ledger-core-integration-tests --gtest_filter="EthereumMakeTransaction.CreateTx")
 add_test (NAME ledger-core-integration-EthereumMakeTransaction.ParseUnsignedRawTransaction COMMAND ledger-core-integration-tests --gtest_filter="EthereumMakeTransaction.ParseUnsignedRawTransaction")
 
+add_test (NAME ledger-core-integration-EthereumKeychains.KeychainDerivation COMMAND ledger-core-integration-tests --gtest_filter="EthereumKeychains.KeychainDerivation")
+add_test (NAME ledger-core-integration-EthereumKeychains.EthereumAddressValidation COMMAND ledger-core-integration-tests --gtest_filter="EthereumKeychains.EthereumAddressValidation")
+add_test (NAME ledger-core-integration-EthereumKeychains.EthereumAddressValidationFromXpub COMMAND ledger-core-integration-tests --gtest_filter="EthereumKeychains.EthereumAddressValidationFromXpub")
+add_test (NAME ledger-core-integration-EthereumKeychains.EthereumChildAddressValidationFromPubKeyAndChainCode COMMAND ledger-core-integration-tests --gtest_filter="EthereumKeychains.EthereumChildAddressValidationFromPubKeyAndChainCode")
+add_test (NAME ledger-core-integration-EthereumKeychains.EthereumExoticDerivationPaths COMMAND ledger-core-integration-tests --gtest_filter="EthereumKeychains.EthereumExoticDerivationPaths")
+add_test (NAME ledger-core-integration-EthereumKeychains.EthereumAddressValidationFromPubKeyAndChainCode COMMAND ledger-core-integration-tests --gtest_filter="EthereumKeychains.EthereumAddressValidationFromPubKeyAndChainCode")
+add_test (NAME ledger-core-integration-EthereumKeychains.EthereumDerivationSchemes COMMAND ledger-core-integration-tests --gtest_filter="EthereumKeychains.EthereumDerivationSchemes")
+
 add_test (NAME ledger-core-integration-RippleLikeWalletSynchronization.MediumXpubSynchronization COMMAND ledger-core-integration-tests --gtest_filter="RippleLikeWalletSynchronization.MediumXpubSynchronization")
 add_test (NAME ledger-core-integration-RippleLikeWalletSynchronization.EmitNewTransactionAndReceiveOnPool COMMAND ledger-core-integration-tests --gtest_filter="RippleLikeWalletSynchronization.EmitNewTransactionAndReceiveOnPool")
 add_test (NAME ledger-core-integration-RippleLikeWalletSynchronization.EmitNewBlock COMMAND ledger-core-integration-tests --gtest_filter="RippleLikeWalletSynchronization.EmitNewBlock")

--- a/core/test/integration/keychains/ethereum_keychain_test.cpp
+++ b/core/test/integration/keychains/ethereum_keychain_test.cpp
@@ -81,6 +81,11 @@ TEST_F(EthereumKeychains, EthereumAddressValidation) {
 
 }
 
+TEST_F(EthereumKeychains, EthereumEmptyAddressValidation) {
+    auto ethAddress = ledger::core::EthereumLikeAddress::fromEIP55("", ledger::core::currencies::ETHEREUM);
+    EXPECT_EQ(ethAddress->toEIP55(), "0x");
+}
+
 
 TEST_F(EthereumKeychains, EthereumAddressValidationFromXpub) {
     auto extKey = ledger::core::EthereumLikeExtendedPublicKey::fromBase58(ETHEREUM_DATA.currency,


### PR DESCRIPTION
- The next creation infos that wallets were returning were not adapted to exotic derivation schemes supported by Live,
- Add tests for weird derivation schemes