### PR TITLE
Fix encryption of plain database

### DIFF
--- a/core/src/database/SQLite3Backend.cpp
+++ b/core/src/database/SQLite3Backend.cpp
@@ -29,7 +29,6 @@
  *
  */
 #include "SQLite3Backend.hpp"
-#include <soci-sqlite3.h>
 #include <utils/Exception.hpp>
 
 using namespace soci;
@@ -69,13 +68,13 @@ namespace ledger {
                 throw make_exception(api::ErrorCode::DATABASE_EXCEPTION, "Database should be initiated before changing password.");
             }
 
-            std::string db_params;
+            auto db_params = fmt::format("dbname=\"{}\" ", _dbResolvedPath) + fmt::format("key=\"{}\" ", oldPassword);
             if (!newPassword.empty()) {
                 // change password if a new password is provided
-                db_params = fmt::format("dbname=\"{}\" ", _dbResolvedPath) + fmt::format("key=\"{}\" ", oldPassword) + fmt::format("new_key=\"{}\" ", newPassword);
+                db_params += fmt::format("new_key=\"{}\" ", newPassword);
             } else {
                 // otherwise, decrypt the database back to plain text by providing an empty new key
-                db_params = fmt::format("dbname=\"{}\" ", _dbResolvedPath) + fmt::format("key=\"{}\" ", oldPassword) + "disable_encryption=\"true\" ";
+                db_params += "disable_encryption=\"true\" ";
             }
 
             session.close();

--- a/core/src/database/SQLite3Backend.hpp
+++ b/core/src/database/SQLite3Backend.hpp
@@ -33,6 +33,7 @@
 
 #include "DatabaseBackend.hpp"
 #include <memory>
+#include <soci-sqlite3.h>
 
 namespace ledger {
  namespace core {

--- a/core/test/integration/CMakeLists.txt
+++ b/core/test/integration/CMakeLists.txt
@@ -53,6 +53,7 @@ add_test (NAME ledger-core-integration-AccountBlockchainObservationTests.AutoRec
 add_test (NAME ledger-core-integration-AccountBlockchainObservationTests.EmitNewBlock COMMAND ledger-core-integration-tests --gtest_filter="AccountBlockchainObservationTests.EmitNewBlock")
 add_test (NAME ledger-core-integration-AccountCreationTest.CreateBitcoinAccountWithInfo COMMAND ledger-core-integration-tests --gtest_filter="AccountCreationTest.CreateBitcoinAccountWithInfo")
 add_test (NAME ledger-core-integration-AccountCreationTest.CreateBitcoinAccountWithInfoOnExistingWallet COMMAND ledger-core-integration-tests --gtest_filter="AccountCreationTest.CreateBitcoinAccountWithInfoOnExistingWallet")
+add_test (NAME ledger-core-integration-AccountCreationTest.ChangePassword COMMAND ledger-core-integration-tests --gtest_filter="AccountCreationTest.ChangePassword")
 add_test (NAME ledger-core-integration-AccountInfoTests.FirstAccountInfo COMMAND ledger-core-integration-tests --gtest_filter="AccountInfoTests.FirstAccountInfo")
 add_test (NAME ledger-core-integration-AccountInfoTests.AnotherAccountInfo COMMAND ledger-core-integration-tests --gtest_filter="AccountInfoTests.AnotherAccountInfo")
 add_test (NAME ledger-core-integration-AccountsPublicInterfaceTest.GetAddressOnEmptyAccount COMMAND ledger-core-integration-tests --gtest_filter="AccountsPublicInterfaceTest.GetAddressOnEmptyAccount")

--- a/core/test/integration/account_creation_tests.cpp
+++ b/core/test/integration/account_creation_tests.cpp
@@ -67,7 +67,7 @@ TEST_F(AccountCreationTest, ChangePassword) {
         EXPECT_EQ(address, "1DDBzjLyAmDr4qLRC2T2WJ831cxBM5v7G7");
     }
 
-    pool->changePassword(oldPassword, newPassword);
+    wait(pool->changePassword(oldPassword, newPassword));
     {
         auto wallet = wait(pool->getWallet("my_wallet"));
         auto account = std::dynamic_pointer_cast<BitcoinLikeAccount>(wait(wallet->getAccount(0)));


### PR DESCRIPTION
It seems that opening an existing DB with `sqlite_key_v2` does not rewrite it with encryption ... 
So we are forced to go through `sqlcipher_export` ...
Now test `AccountCreationTest.ChangePassword` is producing an enrypted database !
Related issue: https://ledgerhq.atlassian.net/browse/LLC-232