### PR TITLE
Fix build env for older Linux distros

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,40 @@
-FROM debian:buster
+FROM debian:stretch
 
 # Install build dependencies
 
+# Enable sourcefiles repositories, for use with apt build-dep
+RUN echo "deb-src http://deb.debian.org/debian stretch main" >> /etc/apt/sources.list \
+  && echo "deb-src http://deb.debian.org/debian-security/ stretch/updates main" >> /etc/apt/sources.list \
+  && echo "deb-src http://deb.debian.org/debian stretch-updates main" >> /etc/apt/sources.list
+
 RUN apt update
-RUN apt install -y cmake
-RUN apt install -y g++
-RUN apt install -y qt5-default
-RUN apt install -y qtbase5-dev
-RUN apt install -y libqt5websockets5-dev
-RUN apt install -y git
-RUN apt install -y curl
-RUN apt install -y zsh
+
+RUN apt install -y \
+  build-essential \
+  qt5-default \
+  qtbase5-dev \
+  libqt5websockets5-dev \
+  git \
+  curl \
+  zsh \
+  gdb \
+  wget
+
+# Dependencies for building cmake
+RUN apt build-dep -y cmake
+
+# Get and build a more up to date version of cmake
+RUN cd /usr/local/src \ 
+  && wget https://cmake.org/files/v3.12/cmake-3.12.4.tar.gz \
+  && tar xf cmake-3.12.4.tar.gz \ 
+  && cd cmake-3.12.4 \
+  && ./bootstrap --system-curl -- -DCMAKE_BUILD_TYPE:STRING=Release \
+  && make -j4 \
+  && make install \
+  && cd .. \
+  && rm -rf cmake*
+
 RUN zsh -c "$(curl -fsSL https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" || true
-RUN apt install -y gdb
 
 # Move library files to the image
 


### PR DESCRIPTION
### Current issue

While the project `README` is boasting [compatibility with Debian stretch](https://github.com/LedgerHQ/lib-ledger-core#libcore), when built with the provided `Dockerfile` the lib gets linked against the very recent glibc 2.28, making it incompatible with Linux distros older than a few month.

### Fix

Don't use `testing` channel Debian for building, but actually use `stretch` as advertised.

##### Caveat
libcore needs a newer `cmake` version than available on stretch repos, so this fetches and builds a compatible version.
##### Caveat of the caveat
The latest (3.14) version of `cmake` complains about some lines in soci's `CMakeLists.txt`. I'd rather not deal with that, and fallbacked to a previous version.

### Result
#### Before
```
$ ldd -v libledger-core.so
<snip>
		libc.so.6 (GLIBC_2.28) => /lib/x86_64-linux-gnu/libc.so.6 😨
<snip>
```

#### After
```
$ ldd -v libledger-core.so
<snip>
        libc.so.6 (GLIBC_2.17) => /lib/x86_64-linux-gnu/libc.so.6 😌
<snip>
```

### Other (failed) attempts
- I tried following [AppImage documentation](https://github.com/AppImage/AppImageKit/wiki/Creating-AppImages#binaries-compiled-on-old-enough-base-system) advice and use [glibc_version_header](https://github.com/wheybags/glibc_version_header) to get the lib to build against an old enough glibc version, even if built on a bleeding edge Linux. But that ended up needing a lot of changes everywhere in the project, so nope.
- I really wanted to use Ubuntu Xenial (16.04) as the base image for the `Dockerfile`, since its glibc version is a tad older than stretch's, and because that version is popular and still officially supported until 2021. But there was so many unfulfilled dependencies requirements that it ended up as a spaghetti, dependencies hell hack and building the docker image was taking hours.

### One more thing
Don't forget to rebuild your docker image.