### PR TITLE
Build Android x86 32bit binaries in addition to x86_64

### DIFF
--- a/.circleci/build_lib.sh
+++ b/.circleci/build_lib.sh
@@ -68,8 +68,10 @@ function command_android {
     export TOOLCHAIN_NAME='android-ndk-r18b-api-21-armeabi-v7a-clang-libcxx'
   elif [ "$ARCH" == "arm64-v8a" ]; then
     export TOOLCHAIN_NAME='android-ndk-r18b-api-21-arm64-v8a-clang-libcxx'
-  else
+  elif [ "$ARCH" == "x86_64" ]; then
     export TOOLCHAIN_NAME='android-ndk-r18b-api-21-x86-64-clang-libcxx'
+  else
+      export TOOLCHAIN_NAME='android-ndk-r18b-api-21-x86-clang-libcxx'
   fi
   #This is useful for SQLCipher/config.guess
   export LIBC=gnu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,14 @@ jobs:
           command: |
             . .circleci/copy_artifacts.sh android
       - run:
+          name: Build_Library_android_x86_64
+          command: |
+            . .circleci/build_lib.sh android x86_64
+      - run:
+          name: Copy_Artifacts_Android_x86_64
+          command: |
+            . .circleci/copy_artifacts.sh android x86_64
+      - run:
           name: Build_Library_android_armeabi-v7a
           command: |
             . .circleci/build_lib.sh android armeabi-v7a

--- a/.circleci/copy_artifacts.sh
+++ b/.circleci/copy_artifacts.sh
@@ -34,7 +34,7 @@ if [ "$TARGET" == "ios" ]; then
 		PATH_TO_LIB=../lib-ledger-core-build/core/src/Release-iphonesimulator
 	fi
 elif [ "$TARGET" == "android" ]; then
-	if [ "$ARCH" == "armeabi-v7a" -o "$ARCH" == "arm64-v8a" ]; then
+	if [ "$ARCH" == "armeabi-v7a" -o "$ARCH" == "arm64-v8a" -o "$ARCH" == "x86_64" ]; then
 		export BUILD_TYPE=android/${ARCH}
 	else
 		export BUILD_TYPE=android/x86


### PR DESCRIPTION
#223 brought Android x86_64 binaries, but didn't keep 32bit ones.

But from [Google Play announcement](https://android-developers.googleblog.com/2019/01/get-your-apps-ready-for-64-bit.html):
> apps using native code must provide a 64-bit version (in addition to the 32-bit version)

Also Android expects 32bit x86 libs to be in the `x86` folder (and x86_64 libs to be in a `x86_64` folder).

This should fix both issues, but I wasn't able to test.