### PR TITLE
Fix versioning of published JAR

### DIFF
--- a/.circleci/build.sbt
+++ b/.circleci/build.sbt
@@ -2,7 +2,7 @@ name := "scala-lib-core"
 
 organization := "co.ledger"
 
-version := ""
+version := sys.env.getOrElse("JAR_VERSION", "")
 
 scalaVersion := "2.12.8"
 

--- a/.circleci/publish_jar.sh
+++ b/.circleci/publish_jar.sh
@@ -19,11 +19,10 @@ cp .circleci/build.sbt $JAR_BUILD_DIR
 cd $JAR_BUILD_DIR
 if [ -n "$CIRCLE_TAG" ] || [ "$CIRCLE_BRANCH" == "master" -o "$CIRCLE_BRANCH" == "develop" ]; then
 	if [[ $LIB_VERSION == *"-rc-"* ]]; then
-		JAR_VERSION="$LIB_VERSION"-SNAPSHOT
+		export JAR_VERSION="$LIB_VERSION"-SNAPSHOT
 	else
-		JAR_VERSION=$LIB_VERSION
+		export JAR_VERSION=$LIB_VERSION
 	fi
-	sed "s/version := \"\"/version := \""$JAR_VERSION"\"/" build.sbt
 	sbt publish
 fi
 


### PR DESCRIPTION
I don't know why version was not changed inside of the `sbt` file, now we load directly the env variable so it should be fine ! 