### PR TITLE
Feature/allow compact eth pub keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
   preferences.
 - Some Windows-related fix (compilers, mostly).
 - [fmt](https://github.com/fmtlib/fmt) is now a submodule of ours.
-- Allow using compact pub keys for ethereum accounts
+- Allow using compact pub keys for ethereum accounts.
 
 ## 2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
   preferences.
 - Some Windows-related fix (compilers, mostly).
 - [fmt](https://github.com/fmtlib/fmt) is now a submodule of ours.
+- Allow using compact pub keys for ethereum accounts
 
 ## 2.6.0
 

--- a/core/src/wallet/ethereum/EthereumLikeWallet.cpp
+++ b/core/src/wallet/ethereum/EthereumLikeWallet.cpp
@@ -85,7 +85,8 @@ namespace ledger {
                     throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Account creation info are inconsistent (size of arrays differs)");
                 api::ExtendedKeyAccountCreationInfo result;
 
-                if (info.chainCodes[0].size() != 32 || (info.publicKeys[0].size() != 65 && info.publicKeys[0].size() != 33))
+                auto pkSize = info.publicKeys[0].size();
+                if (info.chainCodes[0].size() != 32 || pkSize != 65 && pkSize != 33)
                     throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Account creation info are inconsistent (contains invalid public key(s))");
                 DerivationPath occurencePath(info.derivations[0]);
 

--- a/core/src/wallet/ethereum/EthereumLikeWallet.cpp
+++ b/core/src/wallet/ethereum/EthereumLikeWallet.cpp
@@ -85,7 +85,7 @@ namespace ledger {
                     throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Account creation info are inconsistent (size of arrays differs)");
                 api::ExtendedKeyAccountCreationInfo result;
 
-                if (info.chainCodes[0].size() != 32 || info.publicKeys[0].size() != 65)
+                if (info.chainCodes[0].size() != 32 || (info.publicKeys[0].size() != 65 && info.publicKeys[0].size() != 33))
                     throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Account creation info are inconsistent (contains invalid public key(s))");
                 DerivationPath occurencePath(info.derivations[0]);
 


### PR DESCRIPTION
This PR allows using compact (33 bytes) pub keys for ethereum accounts.
The code to handle that was already there, we just needed to extend the size check.