### PR TITLE
Bitcoin SegWit fee fix

### DIFF
--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp
@@ -210,7 +210,7 @@ namespace ledger {
 
         api::EstimatedSize
         BitcoinLikeTransactionApi::estimateSize(std::size_t inputCount, std::size_t outputCount, bool hasTimestamp,
-                                                bool useSegwit, bool isNativeSegwit = false) {
+                                                bool useSegwit, bool isNativeSegwit) {
             // TODO Handle outputs and input for multisig P2SH
             size_t maxSize, minSize, fixedSize = 0;
 

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp
@@ -210,7 +210,7 @@ namespace ledger {
 
         api::EstimatedSize
         BitcoinLikeTransactionApi::estimateSize(std::size_t inputCount, std::size_t outputCount, bool hasTimestamp,
-                                                bool useSegwit) {
+                                                bool useSegwit, bool isNativeSegwit = false) {
             // TODO Handle outputs and input for multisig P2SH
             size_t maxSize, minSize, fixedSize = 0;
 
@@ -223,10 +223,15 @@ namespace ledger {
             fixedSize += 4; // Timelock
 
             if (useSegwit) {
-                fixedSize += 2; // Flag and marker size (one byte each)
-                size_t noWitness = fixedSize + 59 * inputCount + 34 * outputCount;
-                size_t minWitness = noWitness + (106 * inputCount);
-                size_t maxWitness = noWitness + (108 * inputCount);
+                // Native Segwit: 32 PrevTxHash + 4 Index + 1 null byte + 4 sequence
+                // P2SH: 32 PrevTxHash + 4 Index + 23 scriptPubKey + 4 sequence
+                size_t inputSize = isNativeSegwit ? 41 : 63;
+                size_t noWitness = fixedSize + inputSize * inputCount + 34 * outputCount;
+                
+                // Include flag and marker size (one byte each)
+                size_t minWitness = noWitness + (106 * inputCount) + 2;
+                size_t maxWitness = noWitness + (108 * inputCount) + 2;
+                
                 minSize = (noWitness * 3 + minWitness) / 4;
                 maxSize = (noWitness * 3 + maxWitness) / 4;
             } else {

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp
@@ -222,25 +222,16 @@ namespace ledger {
             fixedSize += BytesWriter().writeVarInt(outputCount).toByteArray().size(); // Number of outputs
             fixedSize += 4; // Timelock
 
-            minSize = fixedSize;
-            maxSize = fixedSize;
-
-            // Outputs size
-            minSize += 32 * outputCount;
-            maxSize += 34 * outputCount;
-
-            fixedSize = fixedSize + (34 * outputCount);
             if (useSegwit) {
                 fixedSize += 2; // Flag and marker size (one byte each)
-                size_t noWitness, maxWitness, minWitness = 0;
-                noWitness = fixedSize + (59 * inputCount);
-                minWitness = noWitness + (106 * inputCount);
-                maxWitness = noWitness + (108 * inputCount);
-                minSize += (noWitness * 3 + minWitness) / 4;
-                maxSize += (noWitness * 3 + maxWitness) / 4;
+                size_t noWitness = fixedSize + 59 * inputCount + 34 * outputCount;
+                size_t minWitness = noWitness + (106 * inputCount);
+                size_t maxWitness = noWitness + (108 * inputCount);
+                minSize = (noWitness * 3 + minWitness) / 4;
+                maxSize = (noWitness * 3 + maxWitness) / 4;
             } else {
-                minSize += 146 * inputCount;
-                maxSize += 148 * inputCount;
+                minSize = fixedSize + 146 * inputCount + 32 * outputCount;
+                maxSize = fixedSize + 148 * inputCount + 34 * outputCount;
             }
             return api::EstimatedSize(static_cast<int32_t>(minSize), static_cast<int32_t>(maxSize));
         }

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h
@@ -136,7 +136,7 @@ namespace ledger {
                                                    std::size_t outputCount,
                                                    bool hasTimestamp,
                                                    bool useSegwit,
-                                                   bool isNativeSegwit
+                                                   bool isNativeSegwit = false
             );
 
         private:

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h
@@ -135,7 +135,8 @@ namespace ledger {
             static api::EstimatedSize estimateSize(std::size_t inputCount,
                                                    std::size_t outputCount,
                                                    bool hasTimestamp,
-                                                   bool useSegwit
+                                                   bool useSegwit,
+                                                   bool isNativeSegwit
             );
 
         private:


### PR DESCRIPTION
The `estimateSize` function is not implemented correctly which causes SegWit transaction fees to be too high. See: https://github.com/LedgerHQ/ledger-live-desktop/issues/1714 and https://github.com/LedgerHQ/ledger-live-desktop/issues/2001

This pull request fixes the wrong calculation. I do recommend to re-evaluate the min/max estimation parameters, because the max estimate is a bit below the https://blockstream.info virtual size calculation of a real transaction.

It is also not clear if the `marker` and `flag` should be moved from the `noWitness` to `minWitness` and `maxWitness`. https://bitcoincore.org/en/segwit_wallet_dev/#transaction-fee-estimation suggests it should be moved and Electrum also adds it to the witness data. I have left it as it was for now.