### PR TITLE
Add Terracoin support

### DIFF
--- a/core/src/wallet/bitcoin/networks.cpp
+++ b/core/src/wallet/bitcoin/networks.cpp
@@ -411,6 +411,21 @@ namespace ledger {
                             {}
                     );
                     return STAKENET;
+                } else if (networkName == "terracoin") {
+                    static const api::BitcoinLikeNetworkParameters TERRACOIN(
+                            "trc",
+                            {0x00},
+                            {0x05},
+                            {0x04, 0x88, 0xB2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "DarkCoin Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return TERRACOIN;
                 }
 
                 throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "No network parameters set for {}", networkName);
@@ -459,7 +474,8 @@ namespace ledger {
                 getNetworkParameters("pivx"),
                 getNetworkParameters("clubcoin"),
                 getNetworkParameters("decred"),
-                getNetworkParameters("stakenet")
+                getNetworkParameters("stakenet"),
+                getNetworkParameters("terracoin")
             });
         }
     }

--- a/core/src/wallet/currencies.cpp
+++ b/core/src/wallet/currencies.cpp
@@ -239,6 +239,14 @@ namespace ledger {
                             .unit("satoshi", 0, "satoshi")
                             .unit("stakenet", 8, "XSN");
 
+            const api::Currency TERRACOIN =
+                    Currency("terracoin")
+                            .forkOfBitcoin(networks::getNetworkParameters("terracoin"))
+                            .bip44(83)
+                            .paymentUri("stakenet")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("terracoin", 8, "TRC");
+
             //Reference for ETH coinTypes: https://github.com/LedgerHQ/ledger-live-common/blob/b0196ae9031447f41f8e641f0ec5d3e2b72be83c/src/data/cryptocurrencies.js
             const api::Currency ETHEREUM =
                     Currency("ethereum")
@@ -305,6 +313,7 @@ namespace ledger {
                 CLUBCOIN,
                 DECRED,
                 STAKENET,
+		TERRACOIN,
                 ETHEREUM,
                 ETHEREUM_ROPSTEN,
                 ETHEREUM_CLASSIC,


### PR DESCRIPTION
Adding Terracoin support to the core lib.

I'm just finishing up the app-btc additions but this is required so it's usable.
https://github.com/LedgerHQ/ledger-app-btc/pull/118

Let me know if I missed anything or would like anything else reviews sot hat we can make TRC use on ledger official.