### PR TITLE
Fix Bech32: fix transaction build

### DIFF
--- a/core/src/bitcoin/BitcoinLikeAddress.cpp
+++ b/core/src/bitcoin/BitcoinLikeAddress.cpp
@@ -152,6 +152,10 @@ namespace ledger {
         }
 
         std::string BitcoinLikeAddress::toString() {
+            return getStringAddress();
+        }
+
+        std::string BitcoinLikeAddress::getStringAddress() const {
             if (_keychainEngine == api::KeychainEngines::BIP173_P2WPKH || _keychainEngine == api::KeychainEngines::BIP173_P2WSH) {
                 return toBech32();
             }

--- a/core/src/bitcoin/BitcoinLikeAddress.hpp
+++ b/core/src/bitcoin/BitcoinLikeAddress.hpp
@@ -61,6 +61,7 @@ namespace ledger {
             virtual optional<std::string> getDerivationPath() override;
 
             std::string toString() override;
+            std::string getStringAddress() const;
 
             static std::shared_ptr<AbstractAddress> parse(const std::string& address, const api::Currency& currency,
                                                           const Option<std::string>& derivationPath = Option<std::string>());

--- a/core/src/wallet/bitcoin/keychains/BitcoinLikeKeychain.hpp
+++ b/core/src/wallet/bitcoin/keychains/BitcoinLikeKeychain.hpp
@@ -75,7 +75,6 @@ namespace ledger {
 
             virtual Option<KeyPurpose> getAddressPurpose(const std::string& address) const = 0;
             virtual Option<std::string> getAddressDerivationPath(const std::string& address) const = 0;
-            virtual Option<std::string> getHash160DerivationPath(const std::vector<uint8_t>& hash160) const = 0;
             virtual bool isEmpty() const = 0;
 
             int getAccountIndex() const;

--- a/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.cpp
+++ b/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.cpp
@@ -227,13 +227,6 @@ namespace ledger {
             return Option<std::vector<uint8_t>>(_xpub->derivePublicKey(path));
         }
 
-        Option<std::string>
-        CommonBitcoinLikeKeychains::getHash160DerivationPath(const std::vector<uint8_t> &hash160) const {
-            const auto& params = getCurrency().bitcoinLikeNetworkParameters.value();
-            BitcoinLikeAddress address(getCurrency(), hash160, _keychainEngine);
-            return getAddressDerivationPath(address.toBase58());
-        }
-
         BitcoinLikeKeychain::Address CommonBitcoinLikeKeychains::derive(KeyPurpose purpose, off_t index) {
             auto currency = getCurrency();
             auto iPurpose = (purpose == KeyPurpose::RECEIVE) ? 0 : 1;

--- a/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.hpp
+++ b/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.hpp
@@ -85,8 +85,6 @@ namespace ledger {
 
             Option<std::vector<uint8_t>> getPublicKey(const std::string &address) const override;
 
-            Option<std::string> getHash160DerivationPath(const std::vector<uint8_t> &hash160) const override;
-
         protected:
             std::shared_ptr<api::BitcoinLikeExtendedPublicKey> _internalNodeXpub;
             std::shared_ptr<api::BitcoinLikeExtendedPublicKey> _publicNodeXpub;

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeUtxoPicker.cpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeUtxoPicker.cpp
@@ -93,7 +93,7 @@ namespace ledger {
                 }
                 auto script = std::dynamic_pointer_cast<BitcoinLikeScriptApi>(std::get<1>(output))->getScript();
                 auto address = script.parseAddress(getCurrency()).map<std::string>([] (const BitcoinLikeAddress& addr) {
-                    return addr.toBase58();
+                    return addr.getStringAddress();
                 });
                 BitcoinLikeBlockchainExplorerOutput out;
                 out.index = static_cast<uint64_t>(outputIndex);
@@ -109,7 +109,7 @@ namespace ledger {
                 } else {
                     auto addressFromScript = script.parseAddress(getCurrency());
                     if (addressFromScript.nonEmpty())
-                        out.address = addressFromScript.getValue().toBase58();
+                        out.address = addressFromScript.getValue().toString();
                 }
                 outputIndex += 1;
                 buddy->transaction->addOutput(std::make_shared<BitcoinLikeOutputApi>(out, getCurrency(), derivationPath));

--- a/core/test/integration/synchronization/synchronization_tests.cpp
+++ b/core/test/integration/synchronization/synchronization_tests.cpp
@@ -70,6 +70,15 @@ TEST_F(BitcoinLikeWalletSynchronization, MediumXpubSynchronization) {
                 EXPECT_NE(event->getCode(), api::EventCode::SYNCHRONIZATION_FAILED);
                 EXPECT_EQ(event->getCode(),
                           api::EventCode::SYNCHRONIZATION_SUCCEED_ON_PREVIOUSLY_EMPTY_ACCOUNT);
+                auto balance = wait(account->getBalance())->toString();
+                auto destination = "bc1qh4kl0a0a3d7su8udc2rn62f8w939prqpl34z86";
+                auto txBuilder = account->buildTransaction(false);
+                auto tx = wait(std::dynamic_pointer_cast<BitcoinLikeTransactionBuilder>(txBuilder->sendToAddress(api::Amount::fromLong(wallet->getCurrency(), 2000), destination)
+                                                                                                    ->pickInputs(api::BitcoinLikePickingStrategy::DEEP_OUTPUTS_FIRST, 0xFFFFFFFF)
+                                                                                                    ->setFeesPerByte(api::Amount::fromLong(wallet->getCurrency(), 50)))
+                                       ->build());
+                EXPECT_EQ(tx->getOutputs()[0]->getAddress().value_or(""), destination);
+
                 dispatcher->stop();
             });
 


### PR DESCRIPTION
Call `toString` method instead of `toBase58` to cover native segwit transaction build.
This is related to : https://ledgerhq.atlassian.net/browse/LLC-276