### PR TITLE
Retrieve cointype from derivation scheme

### DIFF
--- a/core/src/wallet/ethereum/EthereumLikeWallet.cpp
+++ b/core/src/wallet/ethereum/EthereumLikeWallet.cpp
@@ -64,6 +64,7 @@ namespace ledger {
             _observer = observer;
             _keychainFactory = keychainFactory;
             _synchronizerFactory = synchronizer;
+            _coinType = scheme.getCoinType() ? scheme.getCoinType() : network.bip44CoinType;
         }
 
         bool EthereumLikeWallet::isSynchronizing() {
@@ -116,7 +117,7 @@ namespace ledger {
 
             auto self = getSelf();
             auto scheme = getDerivationScheme();
-            scheme.setCoinType(getCurrency().bip44CoinType).setAccountIndex(info.index);
+            scheme.setCoinType(_coinType).setAccountIndex(info.index);
             auto xpubPath = scheme.getSchemeTo(DerivationSchemeLevel::ACCOUNT_INDEX).getPath();
             auto index = info.index;
             return async<std::shared_ptr<api::Account> >([=] () -> std::shared_ptr<api::Account> {
@@ -172,7 +173,7 @@ namespace ledger {
                 api::ExtendedKeyAccountCreationInfo info;
                 info.index = accountIndex;
                 auto scheme = self->getDerivationScheme();
-                scheme.setCoinType(self->getCurrency().bip44CoinType).setAccountIndex(accountIndex);;
+                scheme.setCoinType(self->_coinType).setAccountIndex(accountIndex);
                 auto keychainEngine = self->getConfiguration()->getString(api::Configuration::KEYCHAIN_ENGINE).value_or(api::ConfigurationDefaults::DEFAULT_KEYCHAIN);
                 if (keychainEngine == api::KeychainEngines::BIP32_P2PKH ||
                     keychainEngine == api::KeychainEngines::BIP49_P2SH) {
@@ -212,7 +213,7 @@ namespace ledger {
             EthereumLikeAccountDatabaseEntry entry;
             EthereumLikeAccountDatabaseHelper::queryAccount(sql, accountUid, entry);
             auto scheme = getDerivationScheme();
-            scheme.setCoinType(getCurrency().bip44CoinType).setAccountIndex(entry.index);
+            scheme.setCoinType(_coinType).setAccountIndex(entry.index);
             auto xpubPath = getAccountScheme(scheme).getPath();
             auto keychain = _keychainFactory->restore(entry.index, xpubPath, getConfig(), entry.address,
                                                       getAccountInternalPreferences(entry.index), getCurrency());

--- a/core/src/wallet/ethereum/EthereumLikeWallet.h
+++ b/core/src/wallet/ethereum/EthereumLikeWallet.h
@@ -84,6 +84,7 @@ namespace ledger {
             std::shared_ptr<EthereumLikeKeychainFactory> _keychainFactory;
             EthereumLikeAccountSynchronizerFactory _synchronizerFactory;
             api::EthereumLikeNetworkParameters _network;
+            int _coinType;
         };        
     }
 }

--- a/core/src/wallet/ethereum/keychains/EthereumLikeKeychain.cpp
+++ b/core/src/wallet/ethereum/keychains/EthereumLikeKeychain.cpp
@@ -160,8 +160,9 @@ namespace ledger {
 
             if (_address.empty()) {
 
+                auto coinType = _fullScheme.getCoinType() ? _fullScheme.getCoinType() : getCurrency().bip44CoinType;
                 _localPath = getDerivationScheme()
-                        .setCoinType(getCurrency().bip44CoinType)
+                        .setCoinType(coinType)
                         .getPath().toString();
 
                 auto cacheKey = fmt::format("path:{}", _localPath);
@@ -171,13 +172,13 @@ namespace ledger {
                             .getSchemeFrom(DerivationSchemeLevel::NODE);
                     auto p = nodeScheme.getPath().getDepth() > 0 ? nodeScheme
                             .shift(1)
-                            .setCoinType(getCurrency().bip44CoinType)
+                            .setCoinType(coinType)
                             .getPath()
                             .toString() : "";
 
                     auto localNodeScheme = getDerivationScheme()
                             .getSchemeTo(DerivationSchemeLevel::NODE)
-                            .setCoinType(getCurrency().bip44CoinType);
+                            .setCoinType(coinType);
                     // If node level is hardened we don't derive according to it since private
                     // derivation are not supported 
                     auto xpub = localNodeScheme.getPath().getDepth() > 0 && localNodeScheme.getPath().isHardened(0) ? std::static_pointer_cast<EthereumLikeExtendedPublicKey>(_xpub)->derive(DerivationPath("")) : std::static_pointer_cast<EthereumLikeExtendedPublicKey>(_xpub)->derive(localNodeScheme.getPath());

--- a/core/test/integration/BaseFixture.cpp
+++ b/core/test/integration/BaseFixture.cpp
@@ -82,6 +82,12 @@ api::AccountCreationInfo ETH_KEYS_INFO_LIVE(
         {hex::toByteArray("2a224ce46d853d381a68c6b819dabc7d00b14aaa538b6d472963820a48092cff")}
 );
 
+api::AccountCreationInfo ETC_KEYS_INFO_LIVE(
+        0, {"main"}, {"44'/60'/0'/0/0"},
+        {hex::toByteArray("0408b2ddef4cb4af62412ea70cce188ba1318651bb9c0ad599b2714d245109212fb2c79871ec5d35f479ee502c3d7a927908301823f6152823d37da9bd4cb31de7")},
+        {hex::toByteArray("2a224ce46d853d381a68c6b819dabc7d00b14aaa538b6d472963820a48092cff")}
+);
+
 api::AccountCreationInfo XRP_KEYS_INFO(
         0, {"main"}, {"44'/144'/0'"},
         {hex::toByteArray("024819f9d4bd29318226e3c807cdd2da84161abaf5619c5d2bbfe5be63c74cc9ed")},

--- a/core/test/integration/BaseFixture.h
+++ b/core/test/integration/BaseFixture.h
@@ -79,6 +79,7 @@ extern api::ExtendedKeyAccountCreationInfo ETH_MAIN_XPUB_INFO;
 extern api::AccountCreationInfo ETH_KEYS_INFO;
 extern api::AccountCreationInfo ETH_KEYS_INFO_VAULT;
 extern api::AccountCreationInfo ETH_KEYS_INFO_LIVE;
+extern api::AccountCreationInfo ETC_KEYS_INFO_LIVE;
 extern api::AccountCreationInfo XRP_KEYS_INFO;
 extern const std::string TX_1;
 extern const std::string TX_2;

--- a/core/test/integration/synchronization/ethereum_synchronization.cpp
+++ b/core/test/integration/synchronization/ethereum_synchronization.cpp
@@ -209,3 +209,62 @@ TEST_F(EthereumLikeWalletSynchronization, XpubSynchronization) {
     }
 }
 
+TEST_F(EthereumLikeWalletSynchronization, XpubETCSynchronization) {
+    auto pool = newDefaultPool();
+    {
+        auto configuration = DynamicObject::newInstance();
+        configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"44'/60'/0'/<account>");
+        auto wallet = wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "ethereum_classic", configuration));
+        std::set<std::string> emittedOperations;
+        {
+            auto infos = wait(wallet->getNextAccountCreationInfo());
+            EXPECT_EQ(infos.index, 0);
+
+            infos.publicKeys = ETC_KEYS_INFO_LIVE.publicKeys;
+            infos.chainCodes = ETC_KEYS_INFO_LIVE.chainCodes;
+
+            // Test that the cointype we use is the one set by KEYCHAIN_DERIVATION_SCHEME
+            EXPECT_EQ(infos.derivations[0], "44'/60'/0'/0");
+            auto account = createEthereumLikeAccount(wallet, infos.index, infos);
+
+            auto keychain = account->getRestoreKey();
+
+            auto receiver = make_receiver([&](const std::shared_ptr<api::Event> &event) {
+                if (event->getCode() == api::EventCode::NEW_OPERATION) {
+                    auto uid = event->getPayload()->getString(
+                            api::Account::EV_NEW_OP_UID).value();
+                    EXPECT_EQ(emittedOperations.find(uid), emittedOperations.end());
+                }
+            });
+
+            auto keyStore = account->getRestoreKey();
+
+            pool->getEventBus()->subscribe(dispatcher->getMainExecutionContext(),receiver);
+
+            receiver.reset();
+            receiver = make_receiver([=](const std::shared_ptr<api::Event> &event) {
+                fmt::print("Received event {}\n", api::to_string(event->getCode()));
+                if (event->getCode() == api::EventCode::SYNCHRONIZATION_STARTED)
+                    return;
+                EXPECT_NE(event->getCode(), api::EventCode::SYNCHRONIZATION_FAILED);
+                EXPECT_EQ(event->getCode(),
+                          api::EventCode::SYNCHRONIZATION_SUCCEED);
+
+                auto balance = wait(account->getBalance());
+                cout<<" ETH Balance: "<<balance->toLong()<<endl;
+                dispatcher->stop();
+            });
+
+            auto restoreKey = account->getRestoreKey();
+            account->synchronize()->subscribe(dispatcher->getMainExecutionContext(),receiver);
+
+            dispatcher->waitUntilStopped();
+
+            auto opQuery = account->queryOperations()->complete();
+            auto ops = wait(std::dynamic_pointer_cast<OperationQuery>(account->queryOperations()->complete())->execute());
+            std::cout << "Ops: " << ops.size() << std::endl;
+            EXPECT_EQ(ops[0]->isComplete(), true);
+        }
+    }
+}
+


### PR DESCRIPTION
We always use coinType from currency, now if the derivation scheme is setting the coinType it will be used, if not currency's coinType is used as fallback.
Note: this is needed for Live because they scan ETC accounts with `coinType = 60` which is the one of ETH !
Related to : https://ledgerhq.atlassian.net/browse/LLC-278