### PR TITLE
Provide the asRippleLikeAccount method on AbstractWallet.

### DIFF
--- a/core/idl/wallet/common/wallet.djinni
+++ b/core/idl/wallet/common/wallet.djinni
@@ -320,12 +320,14 @@ Account = interface +c {
     # Return operation for a specific operation.
     # @param uid, string of operation id
     getOperationPreferences(uid: string): Preferences;
-    # Turn the account into an Bitcoin one, allowing operations to be performerd on the Bitcoin
+    # Turn the account into an Bitcoin one, allowing operations to be performed on the Bitcoin
     # network.
     asBitcoinLikeAccount() : BitcoinLikeAccount;
-    # Turn the account into an Ethereum one, allowing operations to be performerd on the Ethereum
+    # Turn the account into an Ethereum one, allowing operations to be performrd on the Ethereum
     # network.
     asEthereumLikeAccount() : EthereumLikeAccount;
+    # Turn the account into a Ripple one, allowing operations to be performed on the Ripple network.
+    asRippleLikeAccount(): RippleLikeAccount;
     # Check if account is a Bitcoin one.
     # @return bool
     isInstanceOfBitcoinLikeAccount(): bool;

--- a/core/src/api/Account.hpp
+++ b/core/src/api/Account.hpp
@@ -29,6 +29,7 @@ class EventBus;
 class Logger;
 class OperationQuery;
 class Preferences;
+class RippleLikeAccount;
 enum class TimePeriod;
 enum class WalletType;
 
@@ -120,16 +121,19 @@ public:
     virtual std::shared_ptr<Preferences> getOperationPreferences(const std::string & uid) = 0;
 
     /**
-     * Turn the account into an Bitcoin one, allowing operations to be performerd on the Bitcoin
+     * Turn the account into an Bitcoin one, allowing operations to be performed on the Bitcoin
      * network.
      */
     virtual std::shared_ptr<BitcoinLikeAccount> asBitcoinLikeAccount() = 0;
 
     /**
-     * Turn the account into an Ethereum one, allowing operations to be performerd on the Ethereum
+     * Turn the account into an Ethereum one, allowing operations to be performrd on the Ethereum
      * network.
      */
     virtual std::shared_ptr<EthereumLikeAccount> asEthereumLikeAccount() = 0;
+
+    /** Turn the account into a Ripple one, allowing operations to be performed on the Ripple network. */
+    virtual std::shared_ptr<RippleLikeAccount> asRippleLikeAccount() = 0;
 
     /**
      * Check if account is a Bitcoin one.

--- a/core/src/jni/jni/Account.cpp
+++ b/core/src/jni/jni/Account.cpp
@@ -14,6 +14,7 @@
 #include "Marshal.hpp"
 #include "OperationQuery.hpp"
 #include "Preferences.hpp"
+#include "RippleLikeAccount.hpp"
 #include "TimePeriod.hpp"
 #include "WalletType.hpp"
 
@@ -140,6 +141,16 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_Account_00024CppProxy_native_1asE
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::Account>(nativeRef);
         auto r = ref->asEthereumLikeAccount();
         return ::djinni::release(::djinni_generated::EthereumLikeAccount::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
+CJNIEXPORT jobject JNICALL Java_co_ledger_core_Account_00024CppProxy_native_1asRippleLikeAccount(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::Account>(nativeRef);
+        auto r = ref->asRippleLikeAccount();
+        return ::djinni::release(::djinni_generated::RippleLikeAccount::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 

--- a/core/src/wallet/common/AbstractAccount.cpp
+++ b/core/src/wallet/common/AbstractAccount.cpp
@@ -90,8 +90,13 @@ namespace ledger {
         std::shared_ptr<api::BitcoinLikeAccount> AbstractAccount::asBitcoinLikeAccount() {
             return std::dynamic_pointer_cast<api::BitcoinLikeAccount>(shared_from_this());
         }
+
         std::shared_ptr<api::EthereumLikeAccount> AbstractAccount::asEthereumLikeAccount() {
             return std::dynamic_pointer_cast<api::EthereumLikeAccount>(shared_from_this());
+        }
+
+        std::shared_ptr<api::RippleLikeAccount> AbstractAccount::asRippleLikeAccount() {
+            return std::dynamic_pointer_cast<api::RippleLikeAccount>(shared_from_this());
         }
 
         std::shared_ptr<spdlog::logger> AbstractAccount::logger() const {

--- a/core/src/wallet/common/AbstractAccount.hpp
+++ b/core/src/wallet/common/AbstractAccount.hpp
@@ -41,6 +41,7 @@
 #include <api/BlockCallback.hpp>
 #include <api/BitcoinLikeAccount.hpp>
 #include <api/EthereumLikeAccount.hpp>
+#include <api/RippleLikeAccount.hpp>
 #include <api/AddressListCallback.hpp>
 #include <api/Address.hpp>
 #include <api/AmountListCallback.hpp>
@@ -65,6 +66,7 @@ namespace ledger {
             std::shared_ptr<api::Preferences> getOperationPreferences(const std::string &uid) override;
             std::shared_ptr<api::BitcoinLikeAccount> asBitcoinLikeAccount() override;
             std::shared_ptr<api::EthereumLikeAccount> asEthereumLikeAccount() override;
+            std::shared_ptr<api::RippleLikeAccount> asRippleLikeAccount() override;
             virtual std::shared_ptr<Preferences> getOperationExternalPreferences(const std::string &uid);
             virtual std::shared_ptr<Preferences> getOperationInternalPreferences(const std::string &uid);
             virtual std::shared_ptr<Preferences> getInternalPreferences() const;


### PR DESCRIPTION
The IDL interface is also altered to allow bindings to use it.