### PR TITLE
Add support for XRP sequence when converting an Operation into a RippleLikeTransactionApi.

### DIFF
--- a/core/src/database/DatabaseSessionPool.hpp
+++ b/core/src/database/DatabaseSessionPool.hpp
@@ -59,7 +59,7 @@ namespace ledger {
                 const std::string &password = ""
             );
 
-            static const int CURRENT_DATABASE_SCHEME_VERSION = 13;
+            static const int CURRENT_DATABASE_SCHEME_VERSION = 14;
 
             void performDatabaseMigration();
             void performDatabaseRollback();

--- a/core/src/database/migrations.cpp
+++ b/core/src/database/migrations.cpp
@@ -667,5 +667,12 @@ namespace ledger {
 
         template <> void rollback<13>(soci::session& sql) {
         }
+
+        template <> void migrate<14>(soci::session& sql) {
+            sql << "ALTER TABLE ripple_transactions ADD COLUMN sequence BIGINT";
+        }
+
+        template <> void rollback<14>(soci::session& sql) {
+        }
     }
 }

--- a/core/src/database/migrations.hpp
+++ b/core/src/database/migrations.hpp
@@ -149,6 +149,10 @@ namespace ledger {
         // Add block height to outputs
         template <> void migrate<13>(soci::session& sql);
         template <> void rollback<13>(soci::session& sql);
+
+        // Add XRP sequence
+        template <> void migrate<14>(soci::session& sql);
+        template <> void rollback<14>(soci::session& sql);
     }
 }
 

--- a/core/src/wallet/ripple/api_impl/RippleLikeTransactionApi.cpp
+++ b/core/src/wallet/ripple/api_impl/RippleLikeTransactionApi.cpp
@@ -100,6 +100,7 @@ namespace ledger {
             _receiver = RippleLikeAddress::fromBase58(tx.receiver, _currency);
             _sender = RippleLikeAddress::fromBase58(tx.sender, _currency);
 
+            _sequence = std::make_shared<api::BigIntImpl>(tx.sequence);
         }
 
         std::string RippleLikeTransactionApi::getHash() {

--- a/core/src/wallet/ripple/database/RippleLikeTransactionDatabaseHelper.cpp
+++ b/core/src/wallet/ripple/database/RippleLikeTransactionDatabaseHelper.cpp
@@ -48,7 +48,7 @@ namespace ledger {
             rowset<row> rows = (sql.prepare << "SELECT  tx.hash, tx.value, tx.time, "
                     " tx.sender, tx.receiver, tx.fees, tx.confirmations, "
                     "block.height, block.hash, block.time, block.currency_name, "
-                    "memo.data, memo.fmt, memo.ty "
+                    "memo.data, memo.fmt, memo.ty, tx.sequence "
                     "FROM ripple_transactions AS tx "
                     "LEFT JOIN blocks AS block ON tx.block_uid = block.uid "
                     "LEFT JOIN ripple_memos AS memo ON memo.transaction_uid = tx.transaction_uid "
@@ -91,6 +91,8 @@ namespace ledger {
                         row.get<std::string>(13)
                 ));
             }
+
+            tx.sequence = BigInt(row.get<std::string>(14));
 
             return true;
         }

--- a/core/src/wallet/ripple/explorers/RippleLikeBlockchainExplorer.h
+++ b/core/src/wallet/ripple/explorers/RippleLikeBlockchainExplorer.h
@@ -57,6 +57,7 @@ namespace ledger {
             std::chrono::system_clock::time_point receivedAt;
             BigInt value;
             BigInt fees;
+            BigInt sequence;
             std::string receiver;
             std::string sender;
             Option<Block> block;
@@ -73,6 +74,7 @@ namespace ledger {
                 this->receivedAt = cpy.receivedAt;
                 this->confirmations = cpy.confirmations;
                 this->fees = cpy.fees;
+                this->sequence = cpy.sequence;
                 this->receiver = cpy.receiver;
                 this->sender = cpy.sender;
                 this->value = cpy.value;

--- a/core/src/wallet/ripple/explorers/api/RippleLikeTransactionParser.cpp
+++ b/core/src/wallet/ripple/explorers/api/RippleLikeTransactionParser.cpp
@@ -172,6 +172,8 @@ namespace ledger {
                 } else if (_lastKey == "Fee") {
                     BigInt valueBigInt = BigInt::fromString(value);
                     _transaction->fees = value;
+                } else if (_lastKey == "Sequence") {
+                    _transaction->sequence = BigInt::fromString(value);
                 } else if (_lastKey == "MemoData" && !_transaction->memos.empty()) {
                     _transaction->memos.back().data = value;
                 } else if (_lastKey == "MemoFormat" && !_transaction->memos.empty()) {

--- a/core/test/integration/synchronization/ripple_synchronization.cpp
+++ b/core/test/integration/synchronization/ripple_synchronization.cpp
@@ -37,6 +37,9 @@
 #include <wallet/ripple/transaction_builders/RippleLikeTransactionBuilder.h>
 #include <iostream>
 #include <api/BlockchainExplorerEngines.hpp>
+#include <api/RippleLikeOperation.hpp>
+#include <api/RippleLikeTransaction.hpp>
+
 using namespace std;
 
 class RippleLikeWalletSynchronization : public BaseFixture {
@@ -95,6 +98,12 @@ TEST_F(RippleLikeWalletSynchronization, MediumXpubSynchronization) {
             auto ops = wait(
                     std::dynamic_pointer_cast<OperationQuery>(account->queryOperations()->complete())->execute());
             std::cout << "Ops: " << ops.size() << std::endl;
+
+            for (auto const& op : ops) {
+                auto xrpOp = op->asRippleLikeOperation();
+                EXPECT_FALSE(xrpOp == nullptr);
+                EXPECT_FALSE(xrpOp->getTransaction()->getSequence() == nullptr);
+            }
 
             auto block = wait(account->getLastBlock());
             auto blockHash = block.blockHash;


### PR DESCRIPTION
# Content

That should fix the `nullptr` exception @meriadec saw.

Relates to LLC-349.

# Weird picture of an animal

![](https://phaazon.net/media/uploads/doing_everything_we_can.jpg)