### PR TITLE
Throw exception if Ripple node does not return tesSUCCESS

### DIFF
--- a/core/src/wallet/ripple/explorers/NodeRippleLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/ripple/explorers/NodeRippleLikeBlockchainExplorer.cpp
@@ -189,7 +189,7 @@ namespace ledger {
         Future<Bytes> NodeRippleLikeBlockchainExplorer::getRawTransaction(const String &transactionHash) {
             NodeRippleLikeBodyRequest bodyRequest;
             bodyRequest.setMethod("tx");
-            bodyRequest.pushParameter("trasnaction", transactionHash);
+            bodyRequest.pushParameter("transaction", transactionHash);
             bodyRequest.pushParameter("binary", "true");
             auto requestBody = bodyRequest.getString();
             std::unordered_map<std::string, std::string> headers{{"Content-Type", "application/json"}};

--- a/core/src/wallet/ripple/explorers/NodeRippleLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/ripple/explorers/NodeRippleLikeBlockchainExplorer.cpp
@@ -154,18 +154,27 @@ namespace ledger {
                             !json["result"].IsObject()) {
                             throw make_exception(api::ErrorCode::HTTP_ERROR, "Failed to broadcast transaction, no (or malformed) field \"result\" in response");
                         }
-                        //Is there an tx_json field ?
+
                         auto resultObj = json["result"].GetObject();
-                        if (!resultObj.HasMember("tx_json") || !resultObj["tx_json"].IsObject()) {
+
+                        if (resultObj.HasMember("engine_result") && resultObj["engine_result"] == "tesSUCCESS") {
+                          // Check presence of tx_json field
+                          if (!resultObj.HasMember("tx_json") || !resultObj["tx_json"].IsObject()) {
                             throw make_exception(api::ErrorCode::HTTP_ERROR, "Failed to broadcast transaction, no (or malformed) field \"tx_json\" in response");
+                          }
+                          auto txnObj = resultObj["tx_json"].GetObject();
+
+                          // Check presence of hash field
+                          if (!txnObj.HasMember("hash") || !txnObj["hash"].IsString()) {
+                            throw make_exception(api::ErrorCode::HTTP_ERROR, "Failed to broadcast transaction, no (or malformed) field \"hash\" in response");
+                          }
+
+                          return txnObj["hash"].GetString();
                         }
 
-                        //Is there an hash field ?
-                        auto jsonObj = resultObj["tx_json"].GetObject();
-                        if (!jsonObj.HasMember("hash") || !jsonObj["hash"].IsString()) {
-                            throw make_exception(api::ErrorCode::HTTP_ERROR, "Failed to broadcast transaction, no (or malformed) field \"hash\" in response");
-                        }
-                        return jsonObj["hash"].GetString();
+                        throw make_exception(api::ErrorCode::HTTP_ERROR,
+                                             "Failed to broadcast transaction: {}",
+                                             resultObj["engine_result"].GetString());
                     });
         }
 


### PR DESCRIPTION
### What is this about?

On broadcasting a transaction, the Ripple node may respond with a transaction hash, even though the `engine_result` key has an error code. See the list of all engine result codes here: https://xrpl.org/transaction-results.html

We could also simply checked if `engine_result` startswith `tes`, but [according to the docs](https://xrpl.org/tes-success.html):
> The code tesSUCCESS is the only code that indicates a transaction succeeded.

Hence, this should be sufficient for now.

**Bonus:** Also fixed a typo that I discovered in the same file. Not sure if the function was used by anyone.

### Cute picture of animal

![](https://media1.tenor.com/images/83ddfb81aa3a3c6ea937abda4584d160/tenor.gif?itemid=8136825)