### PR TITLE
Fix secp256k1 point construction.

### DIFF
--- a/core/src/crypto/SECP256k1Point.cpp
+++ b/core/src/crypto/SECP256k1Point.cpp
@@ -39,7 +39,7 @@ namespace ledger {
 
         SECP256k1Point::SECP256k1Point(const std::vector<uint8_t> &p) : SECP256k1Point() {
             _pubKey = new secp256k1_pubkey();
-            if (secp256k1_ec_pubkey_parse(_context, _pubKey, p.data(), p.size()) == -1)
+            if (secp256k1_ec_pubkey_parse(_context, _pubKey, p.data(), p.size()) == 0)
                 throw make_exception(api::ErrorCode::RUNTIME_ERROR, "Unable to parse secp256k1 point");
         }
 


### PR DESCRIPTION
We were not testing the return of secp256k1_ec_pubkey_parse correctly.

Relates to LLC-347.