### PR TITLE
Fix double synchronization failure on Tezos

### DIFF
--- a/core/src/wallet/common/AbstractWallet.cpp
+++ b/core/src/wallet/common/AbstractWallet.cpp
@@ -243,7 +243,6 @@ namespace ledger {
         FuturePtr<api::Account> AbstractWallet::getAccount(int32_t index) {
             auto self = shared_from_this();
             return async<std::shared_ptr<api::Account>>([self, index] () -> std::shared_ptr<api::Account> {
-                soci::session sql(self->getDatabase()->getPool());
                 auto it = self->_accounts.find(index);
                 if (it != self->_accounts.end()) {
                     auto ptr = it->second;
@@ -251,6 +250,7 @@ namespace ledger {
                         return ptr;
                 }
 
+                soci::session sql(self->getDatabase()->getPool());
                 if (!AccountDatabaseHelper::accountExists(sql, self->getWalletUid(), index)) {
                     throw make_exception(api::ErrorCode::ACCOUNT_NOT_FOUND, "Account {}, for wallet '{}', doesn't exist", index,  self->getName());
                 }
@@ -343,7 +343,7 @@ namespace ledger {
                 soci::rowset<soci::row> accounts = (sql.prepare << "SELECT idx FROM accounts "
                                                                     "WHERE wallet_uid = :wallet_uid AND created_at >= :date",
                                                                     soci::use(uid), soci::use(date));
-                
+
                 for (auto& account : accounts) {
                     if (account.get_indicator(0) != soci::i_null) {
                         self->_accounts.erase(account.get<int32_t>(0));

--- a/core/src/wallet/tezos/database/TezosLikeAccountDatabaseHelper.cpp
+++ b/core/src/wallet/tezos/database/TezosLikeAccountDatabaseHelper.cpp
@@ -65,8 +65,8 @@ namespace ledger {
                     TezosLikeOriginatedAccountDatabaseEntry originatedEntry;
                     originatedEntry.uid = row.get<std::string>(2);
                     originatedEntry.address = row.get<std::string>(3);
-                    originatedEntry.spendable = row.get<bool>(4);
-                    originatedEntry.delegatable = row.get<bool>(5);
+                    originatedEntry.spendable = static_cast<bool>(row.get<int>(4));
+                    originatedEntry.delegatable = static_cast<bool>(row.get<int>(5));
                     if (row.get_indicator(6) != i_null) {
                         originatedEntry.publicKey = row.get<std::string>(6);
                     }


### PR DESCRIPTION
# Content

`std::bad_cast` due to a `soci` misusage of `row.get<_>` (`bool` is not accepted).

# Mandatory picture of mister animal

![](https://i.pinimg.com/originals/85/03/0d/85030dacda1b1f91b92ff77056b17648.jpg)