### PR TITLE
Implement parsing of DestinationTag during Ripple account synchronization

### DIFF
--- a/core/src/wallet/ripple/explorers/NodeRippleLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/ripple/explorers/NodeRippleLikeBlockchainExplorer.cpp
@@ -157,7 +157,9 @@ namespace ledger {
 
                         auto resultObj = json["result"].GetObject();
 
-                        if (resultObj.HasMember("engine_result") && resultObj["engine_result"] == "tesSUCCESS") {
+                        if (resultObj.HasMember("engine_result") &&
+                            (resultObj["engine_result"] == "tesSUCCESS") ||
+                             resultObj["engine_result"] == "terQUEUED")) {
                           // Check presence of tx_json field
                           if (!resultObj.HasMember("tx_json") || !resultObj["tx_json"].IsObject()) {
                             throw make_exception(api::ErrorCode::HTTP_ERROR, "Failed to broadcast transaction, no (or malformed) field \"tx_json\" in response");
@@ -171,6 +173,7 @@ namespace ledger {
 
                           return txnObj["hash"].GetString();
                         }
+
 
                         throw make_exception(api::ErrorCode::HTTP_ERROR,
                                              "Failed to broadcast transaction: {}",


### PR DESCRIPTION
### What is this about?

We were not parsing `DestinationTag` from Ripple transactions during account sync, and so this information was not stored in the core DB. As a result, the destination tag in the wallet daemon was always `0`.

### Cute picture of animal

![](https://media1.tenor.com/images/447b474f425d43e3a14b588206ef8412/tenor.gif?itemid=14345506)