### PR TITLE
Tezos: patch code to support Babylon update

### DIFF
--- a/core/idl/wallet/tezos/tezos_like_wallet.djinni
+++ b/core/idl/wallet/tezos/tezos_like_wallet.djinni
@@ -152,7 +152,8 @@ TezosLikeOriginatedAccount = interface +c {
 }
 
 TezosConfiguration = interface +c {
-  const TEZOS_XPUB_CURVE: string = "TEZOS_XPUB_CURVE";
+  	const TEZOS_XPUB_CURVE: string = "TEZOS_XPUB_CURVE";
+	const TEZOS_PROTOCOL_UPDATE: string = "TEZOS_PROTOCOL_UPDATE";
 }
 
 TezosConfigurationDefaults = interface +c {
@@ -168,4 +169,5 @@ TezosConfigurationDefaults = interface +c {
 	const TEZOS_DEFAULT_FEES: string = "1420";
 	const TEZOS_DEFAULT_GAS_LIMIT: string = "10600";
 	const TEZOS_DEFAULT_STORAGE_LIMIT: string = "300";
+	const TEZOS_PROTOCOL_UPDATE_BABYLON: string = "TEZOS_PROTOCOL_UPDATE_BABYLON";
 }

--- a/core/src/api/TezosConfiguration.cpp
+++ b/core/src/api/TezosConfiguration.cpp
@@ -7,4 +7,6 @@ namespace ledger { namespace core { namespace api {
 
 std::string const TezosConfiguration::TEZOS_XPUB_CURVE = {"TEZOS_XPUB_CURVE"};
 
+std::string const TezosConfiguration::TEZOS_PROTOCOL_UPDATE = {"TEZOS_PROTOCOL_UPDATE"};
+
 } } }  // namespace ledger::core::api

--- a/core/src/api/TezosConfiguration.hpp
+++ b/core/src/api/TezosConfiguration.hpp
@@ -20,6 +20,8 @@ public:
     virtual ~TezosConfiguration() {}
 
     static std::string const TEZOS_XPUB_CURVE;
+
+    static std::string const TEZOS_PROTOCOL_UPDATE;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/TezosConfigurationDefaults.cpp
+++ b/core/src/api/TezosConfigurationDefaults.cpp
@@ -27,4 +27,6 @@ std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_GAS_LIMIT = {"10600"
 
 std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_STORAGE_LIMIT = {"300"};
 
+std::string const TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON = {"TEZOS_PROTOCOL_UPDATE_BABYLON"};
+
 } } }  // namespace ledger::core::api

--- a/core/src/api/TezosConfigurationDefaults.hpp
+++ b/core/src/api/TezosConfigurationDefaults.hpp
@@ -41,6 +41,8 @@ public:
     static std::string const TEZOS_DEFAULT_GAS_LIMIT;
 
     static std::string const TEZOS_DEFAULT_STORAGE_LIMIT;
+
+    static std::string const TEZOS_PROTOCOL_UPDATE_BABYLON;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/net/HttpClient.cpp
+++ b/core/src/net/HttpClient.cpp
@@ -63,7 +63,8 @@ namespace ledger {
             return createRequest(api::HttpMethod::POST,
                                  path,
                                  std::experimental::optional<std::vector<uint8_t>>(body),
-                                 headers);
+                                 headers,
+                                 baseUrl);
         }
 
         HttpClient& HttpClient::addHeader(const std::string &key, const std::string &value) {

--- a/core/src/net/HttpClient.cpp
+++ b/core/src/net/HttpClient.cpp
@@ -43,8 +43,10 @@ namespace ledger {
             }
         }
 
-        HttpRequest HttpClient::GET(const std::string &path, const std::unordered_map<std::string, std::string> &headers) {
-            return createRequest(api::HttpMethod::GET, path, std::experimental::optional<std::vector<uint8_t>>(), headers);
+        HttpRequest HttpClient::GET(const std::string &path,
+                                    const std::unordered_map<std::string, std::string> &headers,
+                                    const std::string &baseUrl) {
+            return createRequest(api::HttpMethod::GET, path, std::experimental::optional<std::vector<uint8_t>>(), headers, baseUrl);
         }
 
         HttpRequest HttpClient::PUT(const std::string &path, const std::vector<uint8_t> &body,

--- a/core/src/net/HttpClient.hpp
+++ b/core/src/net/HttpClient.hpp
@@ -131,7 +131,9 @@ namespace ledger {
                        const std::shared_ptr<api::HttpClient> &client,
                        const std::shared_ptr<api::ExecutionContext> &context
             );
-            HttpRequest GET(const std::string& path, const std::unordered_map<std::string, std::string>& headers = {});
+            HttpRequest GET(const std::string& path,
+                            const std::unordered_map<std::string, std::string>& headers = {},
+                            const std::string &baseUrl = "");
             HttpRequest PUT(const std::string& path, const std::vector<uint8_t> &body, const std::unordered_map<std::string, std::string>& headers = {});
             HttpRequest DEL(const std::string& path, const std::unordered_map<std::string, std::string>& headers = {});
             HttpRequest POST(const std::string& path,

--- a/core/src/wallet/tezos/api_impl/TezosLikeOperation.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeOperation.cpp
@@ -36,7 +36,9 @@ namespace ledger {
     namespace core {
 
         TezosLikeOperation::TezosLikeOperation(const std::shared_ptr<OperationApi>& baseOp) {
-            _transaction = std::make_shared<TezosLikeTransactionApi>(baseOp);
+            // Since this patch is temporary, we can live with this
+            // Plus, this transactions are used in "read-only" mode
+            _transaction = std::make_shared<TezosLikeTransactionApi>(baseOp, "");
         }
         std::shared_ptr<api::TezosLikeTransaction> TezosLikeOperation::getTransaction() {
             return _transaction;

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
@@ -219,18 +219,13 @@ namespace ledger {
                     writer.writeByteArray(zarith::zSerializeNumber(bigIntValue.toByteArray()));
 
                     // Set Receiver
-                    if (isBabylonActivated) {
-                        auto receiverContractID = vector::concat({static_cast<uint8_t>(_receiverCurve)}, _receiver->getHash160());
-                        writer.writeByteArray(receiverContractID);
-                    } else {
-                        // Originated
-                        auto isReceiverOriginated = _receiver->toBase58().find("KT1") == 0;
-                        writer.writeByte(static_cast<uint8_t>(isReceiverOriginated));
-                        auto receiverContractID = isReceiverOriginated ?
-                                                  vector::concat(_receiver->getHash160(), {0x00}) :
-                                                  vector::concat({static_cast<uint8_t>(_receiverCurve)}, _receiver->getHash160());
-                        writer.writeByteArray(receiverContractID);
-                    }
+                    // Originated
+                    auto isReceiverOriginated = _receiver->toBase58().find("KT1") == 0;
+                    writer.writeByte(static_cast<uint8_t>(isReceiverOriginated));
+                    auto receiverContractID = isReceiverOriginated ?
+                                              vector::concat(_receiver->getHash160(), {0x00}) :
+                                              vector::concat({static_cast<uint8_t>(_receiverCurve)}, _receiver->getHash160());
+                    writer.writeByteArray(receiverContractID);
 
 
                     // Additional parameters

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
@@ -44,17 +44,20 @@
 #include <bytes/zarith/zarith.h>
 #include <api/TezosCurve.hpp>
 #include <tezos/TezosLikeExtendedPublicKey.h>
-
+#include <api/TezosConfigurationDefaults.hpp>
 namespace ledger {
     namespace core {
 
-        TezosLikeTransactionApi::TezosLikeTransactionApi(const api::Currency &currency) {
-            _currency = currency;
+        TezosLikeTransactionApi::TezosLikeTransactionApi(const api::Currency &currency,
+                                                         const std::string &protocolUpdate) :
+                _currency(currency),
+                _protocolUpdate(protocolUpdate){
             _block = std::make_shared<TezosLikeBlockApi>(Block{});
             _type = api::TezosOperationTag::OPERATION_TAG_TRANSACTION;
         }
 
-        TezosLikeTransactionApi::TezosLikeTransactionApi(const std::shared_ptr<OperationApi> &operation) {
+        TezosLikeTransactionApi::TezosLikeTransactionApi(const std::shared_ptr<OperationApi> &operation,
+                                                         const std::string &protocolUpdate) {
             auto &tx = operation->getBackend().tezosTransaction.getValue();
             _time = tx.receivedAt;
 
@@ -143,6 +146,7 @@ namespace ledger {
 
         // Reference: https://www.ocamlpro.com/2018/11/21/an-introduction-to-tezos-rpcs-signing-operations/
         std::vector<uint8_t> TezosLikeTransactionApi::serialize() {
+            auto isBabylonActivated = _protocolUpdate == api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON;
             BytesWriter writer;
 
             // Watermark: Generic-Operation
@@ -159,17 +163,23 @@ namespace ledger {
             // Remove 2 first bytes (of version)
             writer.writeByteArray(std::vector<uint8_t>{blockHash.begin() + 2, blockHash.end()});
 
+            auto offset = static_cast<uint8_t>(isBabylonActivated ? 100 : 0);
             // Operation Tag
-            writer.writeByte(static_cast<uint8_t>(_type));
+            writer.writeByte(static_cast<uint8_t>(_type) + offset);
 
             // Set Sender
-            // Originated
-            auto isSenderOriginated = _sender->toBase58().find("KT1") == 0;
-            writer.writeByte(static_cast<uint8_t>(isSenderOriginated));
-            auto senderContractID = isSenderOriginated ?
-                                    vector::concat(_sender->getHash160(), {0x00}) :
-                                    vector::concat({static_cast<uint8_t>(_senderCurve)}, _sender->getHash160());
-            writer.writeByteArray(senderContractID);
+            if (isBabylonActivated) {
+                auto senderContractID = vector::concat({static_cast<uint8_t>(_senderCurve)}, _sender->getHash160());
+                writer.writeByteArray(senderContractID);
+            } else {
+                // Originated
+                auto isSenderOriginated = _sender->toBase58().find("KT1") == 0;
+                writer.writeByte(static_cast<uint8_t>(isSenderOriginated));
+                auto senderContractID = isSenderOriginated ?
+                                        vector::concat(_sender->getHash160(), {0x00}) :
+                                        vector::concat({static_cast<uint8_t>(_senderCurve)}, _sender->getHash160());
+                writer.writeByteArray(senderContractID);
+            }
 
 
             // Fee
@@ -209,21 +219,29 @@ namespace ledger {
                     writer.writeByteArray(zarith::zSerializeNumber(bigIntValue.toByteArray()));
 
                     // Set Receiver
-                    // Originated
-                    auto isReceiverOriginated = _receiver->toBase58().find("KT1") == 0;
-                    writer.writeByte(static_cast<uint8_t>(isReceiverOriginated));
-                    auto receiverContractID = isReceiverOriginated ?
-                                              vector::concat(_receiver->getHash160(), {0x00}) :
-                                              vector::concat({static_cast<uint8_t>(_receiverCurve)}, _receiver->getHash160());
-                    writer.writeByteArray(receiverContractID);
+                    if (isBabylonActivated) {
+                        auto receiverContractID = vector::concat({static_cast<uint8_t>(_receiverCurve)}, _receiver->getHash160());
+                        writer.writeByteArray(receiverContractID);
+                    } else {
+                        // Originated
+                        auto isReceiverOriginated = _receiver->toBase58().find("KT1") == 0;
+                        writer.writeByte(static_cast<uint8_t>(isReceiverOriginated));
+                        auto receiverContractID = isReceiverOriginated ?
+                                                  vector::concat(_receiver->getHash160(), {0x00}) :
+                                                  vector::concat({static_cast<uint8_t>(_receiverCurve)}, _receiver->getHash160());
+                        writer.writeByteArray(receiverContractID);
+                    }
+
 
                     // Additional parameters
                     writer.writeByte(0x00);
                     break;
                 }
                 case api::TezosOperationTag::OPERATION_TAG_ORIGINATION: {
-                    writer.writeByte(static_cast<uint8_t >(_senderCurve));
-                    writer.writeByteArray(_sender->getHash160());
+                    if (!isBabylonActivated) {
+                        writer.writeByte(static_cast<uint8_t >(_senderCurve));
+                        writer.writeByteArray(_sender->getHash160());
+                    }
                     // Balance
                     writer.writeByteArray(zarith::zSerializeNumber(_balance.toByteArray()));
                     // Is spendable ?

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
@@ -45,9 +45,11 @@ namespace ledger {
         // Reference: https://github.com/obsidiansystems/ledger-app-tezos/blob/9a0c8cc546677147b93935e0b0c96925244baf64/src/types.h
         class TezosLikeTransactionApi : public api::TezosLikeTransaction {
         public:
-            explicit TezosLikeTransactionApi(const api::Currency &currency);
+            explicit TezosLikeTransactionApi(const api::Currency &currency,
+                                             const std::string &protocolUpdate);
 
-            explicit TezosLikeTransactionApi(const std::shared_ptr<OperationApi> &operation);
+            explicit TezosLikeTransactionApi(const std::shared_ptr<OperationApi> &operation,
+                                             const std::string &protocolUpdate);
 
             api::TezosOperationTag getType() override;
 
@@ -120,6 +122,7 @@ namespace ledger {
             api::TezosOperationTag _type;
             std::string _revealedPubKey;
             BigInt _balance;
+            std::string _protocolUpdate;
         };
     }
 }

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
@@ -111,7 +111,8 @@ namespace ledger {
             getHelper(const std::string &url,
                       const std::string &field,
                       const std::unordered_map<std::string, std::string> &params = std::unordered_map<std::string, std::string>(),
-                      const std::string &fallbackValue = "");
+                      const std::string &fallbackValue = "",
+                      const std::string &forceUrl = "");
 
             api::TezosLikeNetworkParameters _parameters;
             std::unordered_map<std::string, uint64_t> _sessions;

--- a/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.cpp
+++ b/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.cpp
@@ -34,6 +34,7 @@
 #include <wallet/tezos/api_impl/TezosLikeTransactionApi.h>
 #include <bytes/zarith/zarith.h>
 #include <math/Base58.hpp>
+#include <api/TezosConfigurationDefaults.hpp>
 #include <api/TezosOperationTag.hpp>
 #include <api/TezosCurve.hpp>
 
@@ -46,7 +47,8 @@ namespace ledger {
                 const api::Currency &currency,
                 const std::shared_ptr<TezosLikeBlockchainExplorer> &explorer,
                 const std::shared_ptr<spdlog::logger> &logger,
-                const TezosLikeTransactionBuildFunction &buildFunction) :
+                const TezosLikeTransactionBuildFunction &buildFunction,
+                const std::string &protocolUpdate) :
                 _senderAddress(senderAddress), _context(context),
                 _currency(currency), _explorer(explorer),
                 _build(buildFunction), _logger(logger){
@@ -125,22 +127,36 @@ namespace ledger {
         std::shared_ptr<api::TezosLikeTransaction>
         api::TezosLikeTransactionBuilder::parseRawUnsignedTransaction(const api::Currency &currency,
                                                                       const std::vector<uint8_t> &rawTransaction) {
-            return ::ledger::core::TezosLikeTransactionBuilder::parseRawTransaction(currency, rawTransaction, false);
+            // Since this patch is temporary, we can live with this
+            // This method is not used yet anywhere internally or externally (except for tests)
+            return ::ledger::core::TezosLikeTransactionBuilder::parseRawTransaction(currency,
+                                                                                    rawTransaction,
+                                                                                    false,
+                                                                                    ""
+            );
         }
 
         std::shared_ptr<api::TezosLikeTransaction>
         api::TezosLikeTransactionBuilder::parseRawSignedTransaction(const api::Currency &currency,
                                                                     const std::vector<uint8_t> &rawTransaction) {
-            return ::ledger::core::TezosLikeTransactionBuilder::parseRawTransaction(currency, rawTransaction, true);
+            // Since this patch is temporary, we can live with this
+            // This method is not used yet anywhere internally or externally (except for tests)
+            return ::ledger::core::TezosLikeTransactionBuilder::parseRawTransaction(currency,
+                                                                                    rawTransaction,
+                                                                                    true,
+                                                                                    ""
+            );
         }
 
         // Reference: https://www.ocamlpro.com/2018/11/21/an-introduction-to-tezos-rpcs-signing-operations/
         std::shared_ptr<api::TezosLikeTransaction>
         TezosLikeTransactionBuilder::parseRawTransaction(const api::Currency &currency,
                                                          const std::vector<uint8_t> &rawTransaction,
-                                                         bool isSigned) {
+                                                         bool isSigned,
+                                                         const std::string &protocolUpdate) {
+            auto isBabylonActivated = protocolUpdate == api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON;
             auto params = currency.tezosLikeNetworkParameters.value();
-            auto tx = std::make_shared<TezosLikeTransactionApi>(currency);
+            auto tx = std::make_shared<TezosLikeTransactionApi>(currency, protocolUpdate);
             BytesReader reader(rawTransaction);
             if (!isSigned) {
                 // Watermark: Generic-Operation
@@ -160,25 +176,35 @@ namespace ledger {
             auto OpTag = reader.readNextByte();
             tx->setType(static_cast<api::TezosOperationTag>(OpTag));
 
+
+            // sender hash160
+            std::vector<uint8_t> senderHash160, version;
             // Get Sender
             // Originated
-            auto isSenderOriginated = reader.readNextByte();
-            // sender hash160
-            std::vector<uint8_t> senderHash160;
-            if (isSenderOriginated) {
-                // Then we read 20 bytes of publicKey hash
-                senderHash160 = reader.read(20);
-                // ... and padding
-                reader.readNextByte();
-            } else {
-                // Otherwise first curve code ...
+            if (isBabylonActivated) {
+                // First curve code ...
                 auto senderCurveCode = reader.readNextByte();
                 // then hash160 ...
                 senderHash160 = reader.read(20);
+                version = params.ImplicitPrefix;
+            } else {
+                auto isSenderOriginated = reader.readNextByte();
+                if (isSenderOriginated) {
+                    // Then we read 20 bytes of publicKey hash
+                    senderHash160 = reader.read(20);
+                    // ... and padding
+                    reader.readNextByte();
+                } else {
+                    // Otherwise first curve code ...
+                    auto senderCurveCode = reader.readNextByte();
+                    // then hash160 ...
+                    senderHash160 = reader.read(20);
+                }
+                version = isSenderOriginated ? params.OriginatedPrefix : params.ImplicitPrefix;
             }
             tx->setSender(std::make_shared<TezosLikeAddress>(currency,
                                                              senderHash160,
-                                                             isSenderOriginated ? params.OriginatedPrefix : params.ImplicitPrefix,
+                                                             version,
                                                              Option<std::string>()));
 
             // Fee
@@ -193,7 +219,9 @@ namespace ledger {
             // Storage Limit
             tx->setStorage(std::make_shared<BigInt>(BigInt::fromHex(hex::toString(zarith::zParse(reader)))));
 
-            switch (OpTag) {
+            // Offset introduced by Babylon
+            auto offset = static_cast<uint8_t>(isBabylonActivated ? 100 : 0);
+            switch (OpTag - offset) {
                 case static_cast<uint8_t>(api::TezosOperationTag::OPERATION_TAG_REVEAL): {
                     auto curveCode = reader.readNextByte();
                     std::vector<uint8_t> pubKey;
@@ -219,23 +247,33 @@ namespace ledger {
 
                     // Get Receiver
                     // Originated
-                    auto isReceiverOriginated = reader.readNextByte();
-                    std::vector<uint8_t> receiverHash160;
-                    if (!isReceiverOriginated) {
+                    std::vector<uint8_t> receiverHash160, receiverVersion;
+                    if (isBabylonActivated) {
                         // Curve code
                         auto receiverCurveCode = reader.readNextByte();
                         // 20 bytes of publicKey hash
                         receiverHash160 = reader.read(20);
+                        receiverVersion = params.ImplicitPrefix;
                     } else {
-                        // 20 bytes of publicKey hash
-                        receiverHash160 = reader.read(20);
-                        // Padding
-                        reader.readNextByte();
+                        auto isReceiverOriginated = reader.readNextByte();
+
+                        if (!isReceiverOriginated) {
+                            // Curve code
+                            auto receiverCurveCode = reader.readNextByte();
+                            // 20 bytes of publicKey hash
+                            receiverHash160 = reader.read(20);
+                        } else {
+                            // 20 bytes of publicKey hash
+                            receiverHash160 = reader.read(20);
+                            // Padding
+                            reader.readNextByte();
+                        }
+                        receiverVersion = isReceiverOriginated ? params.OriginatedPrefix : params.ImplicitPrefix;
                     }
 
                     tx->setReceiver(std::make_shared<TezosLikeAddress>(currency,
                                                                        receiverHash160,
-                                                                       isReceiverOriginated ? params.OriginatedPrefix : params.ImplicitPrefix,
+                                                                       receiverVersion,
                                                                        Option<std::string>()));
 
                     // Additional parameters
@@ -252,11 +290,13 @@ namespace ledger {
                                                                        std::vector<uint8_t>(),
                                                                        std::vector<uint8_t>(),
                                                                        Option<std::string>()));
-                    auto managerCurveCode = reader.readNextByte();
-                    // manager hash160
-                    auto managerHash160 = reader.read(20);
-                    if (managerHash160 != senderHash160) {
-                        throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Origination error: Manager is diffrent from sender");
+                    if (!isBabylonActivated) {
+                        auto managerCurveCode = reader.readNextByte();
+                        // manager hash160
+                        auto managerHash160 = reader.read(20);
+                        if (managerHash160 != senderHash160) {
+                            throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Origination error: Manager is different from sender");
+                        }
                     }
                     // Balance
                     tx->setBalance(BigInt::fromHex(hex::toString(zarith::zParse(reader))));

--- a/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.cpp
+++ b/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.cpp
@@ -248,28 +248,21 @@ namespace ledger {
                     // Get Receiver
                     // Originated
                     std::vector<uint8_t> receiverHash160, receiverVersion;
-                    if (isBabylonActivated) {
+
+                    auto isReceiverOriginated = reader.readNextByte();
+
+                    if (!isReceiverOriginated) {
                         // Curve code
                         auto receiverCurveCode = reader.readNextByte();
                         // 20 bytes of publicKey hash
                         receiverHash160 = reader.read(20);
-                        receiverVersion = params.ImplicitPrefix;
                     } else {
-                        auto isReceiverOriginated = reader.readNextByte();
-
-                        if (!isReceiverOriginated) {
-                            // Curve code
-                            auto receiverCurveCode = reader.readNextByte();
-                            // 20 bytes of publicKey hash
-                            receiverHash160 = reader.read(20);
-                        } else {
-                            // 20 bytes of publicKey hash
-                            receiverHash160 = reader.read(20);
-                            // Padding
-                            reader.readNextByte();
-                        }
-                        receiverVersion = isReceiverOriginated ? params.OriginatedPrefix : params.ImplicitPrefix;
+                        // 20 bytes of publicKey hash
+                        receiverHash160 = reader.read(20);
+                        // Padding
+                        reader.readNextByte();
                     }
+                    receiverVersion = isReceiverOriginated ? params.OriginatedPrefix : params.ImplicitPrefix;
 
                     tx->setReceiver(std::make_shared<TezosLikeAddress>(currency,
                                                                        receiverHash160,

--- a/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.h
+++ b/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.h
@@ -75,7 +75,8 @@ namespace ledger {
                                                  const api::Currency &params,
                                                  const std::shared_ptr<TezosLikeBlockchainExplorer> &explorer,
                                                  const std::shared_ptr<spdlog::logger> &logger,
-                                                 const TezosLikeTransactionBuildFunction &buildFunction);
+                                                 const TezosLikeTransactionBuildFunction &buildFunction,
+                                                 const std::string &protocolUpdate = "");
 
             TezosLikeTransactionBuilder(const TezosLikeTransactionBuilder &cpy);
 
@@ -105,7 +106,8 @@ namespace ledger {
 
             static std::shared_ptr<api::TezosLikeTransaction> parseRawTransaction(const api::Currency &currency,
                                                                                   const std::vector<uint8_t> &rawTransaction,
-                                                                                  bool isSigned);
+                                                                                  bool isSigned,
+                                                                                  const std::string &protocolUpdate);
 
         private:
             api::Currency _currency;


### PR DESCRIPTION
This PR is meant to support Babylon update, thanks to the configuration we can switch between former protocol and the one with Babylon update. 
It is meant also to be easy to review so we can later on get rid of support of old protocol.

Removed HODL tag because I tested with `ledger-live` CLI and it's working 🚀 :
[opGvkEh34g7i3fEbErgdfePgy3F3grZHwZJoT9zuwf6xfHKEkfv](https://tzstats.com/operation/opGvkEh34g7i3fEbErgdfePgy3F3grZHwZJoT9zuwf6xfHKEkfv)