### PR TITLE
Tezos: RPC node support

### DIFF
--- a/core/idl/wallet/configuration.djinni
+++ b/core/idl/wallet/configuration.djinni
@@ -5,6 +5,7 @@ BlockchainExplorerEngines = interface +c {
     const RIPPLE_NODE: string = "RIPPLE_NODE";
     const TEZOS_NODE: string = "TEZOS_NODE";
     const TZSTATS_API: string = "TZSTATS_API";
+    const TZSTATS_RPC_NODE: string = "TZSTATS_RPC_NODE";
 }
 
 # Available API to use with observers.

--- a/core/idl/wallet/tezos/tezos_like_wallet.djinni
+++ b/core/idl/wallet/tezos/tezos_like_wallet.djinni
@@ -152,7 +152,8 @@ TezosLikeOriginatedAccount = interface +c {
 }
 
 TezosConfiguration = interface +c {
-  const TEZOS_XPUB_CURVE: string = "TEZOS_XPUB_CURVE";
+  	const TEZOS_XPUB_CURVE: string = "TEZOS_XPUB_CURVE";
+	const TEZOS_PROTOCOL_UPDATE: string = "TEZOS_PROTOCOL_UPDATE";
 }
 
 TezosConfigurationDefaults = interface +c {
@@ -168,4 +169,5 @@ TezosConfigurationDefaults = interface +c {
 	const TEZOS_DEFAULT_FEES: string = "1420";
 	const TEZOS_DEFAULT_GAS_LIMIT: string = "10600";
 	const TEZOS_DEFAULT_STORAGE_LIMIT: string = "300";
+	const TEZOS_PROTOCOL_UPDATE_BABYLON: string = "TEZOS_PROTOCOL_UPDATE_BABYLON";
 }

--- a/core/idl/wallet/tezos/tezos_like_wallet.djinni
+++ b/core/idl/wallet/tezos/tezos_like_wallet.djinni
@@ -160,6 +160,7 @@ TezosConfigurationDefaults = interface +c {
 	const TEZOS_DEFAULT_API_ENDPOINT: string = "https://explorers.api.live.ledger.com";
 	const TEZOS_DEFAULT_API_VERSION: string = "v3";
 	const TZSTATS_API_ENDPOINT: string = "https://api.tzstats.com/explorer";
+	const TEZOS_RPC_ENDPOINT: string = "https://mainnet.tezrpc.me";
 	const TEZOS_OBSERVER_NODE_ENDPOINT_S3: string = "https://s3.tezos.com";
 	const TEZOS_OBSERVER_WS_ENDPOINT_S2: string = "wss://s2.tezos.com";
 	const TEZOS_OBSERVER_WS_ENDPOINT_S3: string = "wss://s3.tezos.com";

--- a/core/src/api/BlockchainExplorerEngines.cpp
+++ b/core/src/api/BlockchainExplorerEngines.cpp
@@ -15,4 +15,6 @@ std::string const BlockchainExplorerEngines::TEZOS_NODE = {"TEZOS_NODE"};
 
 std::string const BlockchainExplorerEngines::TZSTATS_API = {"TZSTATS_API"};
 
+std::string const BlockchainExplorerEngines::TZSTATS_RPC_NODE = {"TZSTATS_RPC_NODE"};
+
 } } }  // namespace ledger::core::api

--- a/core/src/api/BlockchainExplorerEngines.hpp
+++ b/core/src/api/BlockchainExplorerEngines.hpp
@@ -29,6 +29,8 @@ public:
     static std::string const TEZOS_NODE;
 
     static std::string const TZSTATS_API;
+
+    static std::string const TZSTATS_RPC_NODE;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/TezosConfiguration.cpp
+++ b/core/src/api/TezosConfiguration.cpp
@@ -7,4 +7,6 @@ namespace ledger { namespace core { namespace api {
 
 std::string const TezosConfiguration::TEZOS_XPUB_CURVE = {"TEZOS_XPUB_CURVE"};
 
+std::string const TezosConfiguration::TEZOS_PROTOCOL_UPDATE = {"TEZOS_PROTOCOL_UPDATE"};
+
 } } }  // namespace ledger::core::api

--- a/core/src/api/TezosConfiguration.hpp
+++ b/core/src/api/TezosConfiguration.hpp
@@ -20,6 +20,8 @@ public:
     virtual ~TezosConfiguration() {}
 
     static std::string const TEZOS_XPUB_CURVE;
+
+    static std::string const TEZOS_PROTOCOL_UPDATE;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/TezosConfigurationDefaults.cpp
+++ b/core/src/api/TezosConfigurationDefaults.cpp
@@ -11,6 +11,8 @@ std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_API_VERSION = {"v3"}
 
 std::string const TezosConfigurationDefaults::TZSTATS_API_ENDPOINT = {"https://api.tzstats.com/explorer"};
 
+std::string const TezosConfigurationDefaults::TEZOS_RPC_ENDPOINT = {"https://mainnet.tezrpc.me"};
+
 std::string const TezosConfigurationDefaults::TEZOS_OBSERVER_NODE_ENDPOINT_S3 = {"https://s3.tezos.com"};
 
 std::string const TezosConfigurationDefaults::TEZOS_OBSERVER_WS_ENDPOINT_S2 = {"wss://s2.tezos.com"};

--- a/core/src/api/TezosConfigurationDefaults.cpp
+++ b/core/src/api/TezosConfigurationDefaults.cpp
@@ -27,4 +27,6 @@ std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_GAS_LIMIT = {"10600"
 
 std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_STORAGE_LIMIT = {"300"};
 
+std::string const TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON = {"TEZOS_PROTOCOL_UPDATE_BABYLON"};
+
 } } }  // namespace ledger::core::api

--- a/core/src/api/TezosConfigurationDefaults.hpp
+++ b/core/src/api/TezosConfigurationDefaults.hpp
@@ -41,6 +41,8 @@ public:
     static std::string const TEZOS_DEFAULT_GAS_LIMIT;
 
     static std::string const TEZOS_DEFAULT_STORAGE_LIMIT;
+
+    static std::string const TEZOS_PROTOCOL_UPDATE_BABYLON;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/TezosConfigurationDefaults.hpp
+++ b/core/src/api/TezosConfigurationDefaults.hpp
@@ -25,6 +25,8 @@ public:
 
     static std::string const TZSTATS_API_ENDPOINT;
 
+    static std::string const TEZOS_RPC_ENDPOINT;
+
     static std::string const TEZOS_OBSERVER_NODE_ENDPOINT_S3;
 
     static std::string const TEZOS_OBSERVER_WS_ENDPOINT_S2;

--- a/core/src/net/HttpClient.cpp
+++ b/core/src/net/HttpClient.cpp
@@ -63,7 +63,8 @@ namespace ledger {
             return createRequest(api::HttpMethod::POST,
                                  path,
                                  std::experimental::optional<std::vector<uint8_t>>(body),
-                                 headers);
+                                 headers,
+                                 baseUrl);
         }
 
         HttpClient& HttpClient::addHeader(const std::string &key, const std::string &value) {

--- a/core/src/net/HttpClient.cpp
+++ b/core/src/net/HttpClient.cpp
@@ -43,8 +43,10 @@ namespace ledger {
             }
         }
 
-        HttpRequest HttpClient::GET(const std::string &path, const std::unordered_map<std::string, std::string> &headers) {
-            return createRequest(api::HttpMethod::GET, path, std::experimental::optional<std::vector<uint8_t>>(), headers);
+        HttpRequest HttpClient::GET(const std::string &path,
+                                    const std::unordered_map<std::string, std::string> &headers,
+                                    const std::string &baseUrl) {
+            return createRequest(api::HttpMethod::GET, path, std::experimental::optional<std::vector<uint8_t>>(), headers, baseUrl);
         }
 
         HttpRequest HttpClient::PUT(const std::string &path, const std::vector<uint8_t> &body,

--- a/core/src/net/HttpClient.hpp
+++ b/core/src/net/HttpClient.hpp
@@ -131,7 +131,9 @@ namespace ledger {
                        const std::shared_ptr<api::HttpClient> &client,
                        const std::shared_ptr<api::ExecutionContext> &context
             );
-            HttpRequest GET(const std::string& path, const std::unordered_map<std::string, std::string>& headers = {});
+            HttpRequest GET(const std::string& path,
+                            const std::unordered_map<std::string, std::string>& headers = {},
+                            const std::string &baseUrl = "");
             HttpRequest PUT(const std::string& path, const std::vector<uint8_t> &body, const std::unordered_map<std::string, std::string>& headers = {});
             HttpRequest DEL(const std::string& path, const std::unordered_map<std::string, std::string>& headers = {});
             HttpRequest POST(const std::string& path,

--- a/core/src/wallet/tezos/api_impl/TezosLikeOperation.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeOperation.cpp
@@ -36,7 +36,9 @@ namespace ledger {
     namespace core {
 
         TezosLikeOperation::TezosLikeOperation(const std::shared_ptr<OperationApi>& baseOp) {
-            _transaction = std::make_shared<TezosLikeTransactionApi>(baseOp);
+            // Since this patch is temporary, we can live with this
+            // Plus, this transactions are used in "read-only" mode
+            _transaction = std::make_shared<TezosLikeTransactionApi>(baseOp, "");
         }
         std::shared_ptr<api::TezosLikeTransaction> TezosLikeOperation::getTransaction() {
             return _transaction;

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
@@ -219,18 +219,13 @@ namespace ledger {
                     writer.writeByteArray(zarith::zSerializeNumber(bigIntValue.toByteArray()));
 
                     // Set Receiver
-                    if (isBabylonActivated) {
-                        auto receiverContractID = vector::concat({static_cast<uint8_t>(_receiverCurve)}, _receiver->getHash160());
-                        writer.writeByteArray(receiverContractID);
-                    } else {
-                        // Originated
-                        auto isReceiverOriginated = _receiver->toBase58().find("KT1") == 0;
-                        writer.writeByte(static_cast<uint8_t>(isReceiverOriginated));
-                        auto receiverContractID = isReceiverOriginated ?
-                                                  vector::concat(_receiver->getHash160(), {0x00}) :
-                                                  vector::concat({static_cast<uint8_t>(_receiverCurve)}, _receiver->getHash160());
-                        writer.writeByteArray(receiverContractID);
-                    }
+                    // Originated
+                    auto isReceiverOriginated = _receiver->toBase58().find("KT1") == 0;
+                    writer.writeByte(static_cast<uint8_t>(isReceiverOriginated));
+                    auto receiverContractID = isReceiverOriginated ?
+                                              vector::concat(_receiver->getHash160(), {0x00}) :
+                                              vector::concat({static_cast<uint8_t>(_receiverCurve)}, _receiver->getHash160());
+                    writer.writeByteArray(receiverContractID);
 
 
                     // Additional parameters

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
@@ -44,17 +44,20 @@
 #include <bytes/zarith/zarith.h>
 #include <api/TezosCurve.hpp>
 #include <tezos/TezosLikeExtendedPublicKey.h>
-
+#include <api/TezosConfigurationDefaults.hpp>
 namespace ledger {
     namespace core {
 
-        TezosLikeTransactionApi::TezosLikeTransactionApi(const api::Currency &currency) {
-            _currency = currency;
+        TezosLikeTransactionApi::TezosLikeTransactionApi(const api::Currency &currency,
+                                                         const std::string &protocolUpdate) :
+                _currency(currency),
+                _protocolUpdate(protocolUpdate){
             _block = std::make_shared<TezosLikeBlockApi>(Block{});
             _type = api::TezosOperationTag::OPERATION_TAG_TRANSACTION;
         }
 
-        TezosLikeTransactionApi::TezosLikeTransactionApi(const std::shared_ptr<OperationApi> &operation) {
+        TezosLikeTransactionApi::TezosLikeTransactionApi(const std::shared_ptr<OperationApi> &operation,
+                                                         const std::string &protocolUpdate) {
             auto &tx = operation->getBackend().tezosTransaction.getValue();
             _time = tx.receivedAt;
 
@@ -143,6 +146,7 @@ namespace ledger {
 
         // Reference: https://www.ocamlpro.com/2018/11/21/an-introduction-to-tezos-rpcs-signing-operations/
         std::vector<uint8_t> TezosLikeTransactionApi::serialize() {
+            auto isBabylonActivated = _protocolUpdate == api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON;
             BytesWriter writer;
 
             // Watermark: Generic-Operation
@@ -159,17 +163,23 @@ namespace ledger {
             // Remove 2 first bytes (of version)
             writer.writeByteArray(std::vector<uint8_t>{blockHash.begin() + 2, blockHash.end()});
 
+            auto offset = static_cast<uint8_t>(isBabylonActivated ? 100 : 0);
             // Operation Tag
-            writer.writeByte(static_cast<uint8_t>(_type));
+            writer.writeByte(static_cast<uint8_t>(_type) + offset);
 
             // Set Sender
-            // Originated
-            auto isSenderOriginated = _sender->toBase58().find("KT1") == 0;
-            writer.writeByte(static_cast<uint8_t>(isSenderOriginated));
-            auto senderContractID = isSenderOriginated ?
-                                    vector::concat(_sender->getHash160(), {0x00}) :
-                                    vector::concat({static_cast<uint8_t>(_senderCurve)}, _sender->getHash160());
-            writer.writeByteArray(senderContractID);
+            if (isBabylonActivated) {
+                auto senderContractID = vector::concat({static_cast<uint8_t>(_senderCurve)}, _sender->getHash160());
+                writer.writeByteArray(senderContractID);
+            } else {
+                // Originated
+                auto isSenderOriginated = _sender->toBase58().find("KT1") == 0;
+                writer.writeByte(static_cast<uint8_t>(isSenderOriginated));
+                auto senderContractID = isSenderOriginated ?
+                                        vector::concat(_sender->getHash160(), {0x00}) :
+                                        vector::concat({static_cast<uint8_t>(_senderCurve)}, _sender->getHash160());
+                writer.writeByteArray(senderContractID);
+            }
 
 
             // Fee
@@ -209,21 +219,29 @@ namespace ledger {
                     writer.writeByteArray(zarith::zSerializeNumber(bigIntValue.toByteArray()));
 
                     // Set Receiver
-                    // Originated
-                    auto isReceiverOriginated = _receiver->toBase58().find("KT1") == 0;
-                    writer.writeByte(static_cast<uint8_t>(isReceiverOriginated));
-                    auto receiverContractID = isReceiverOriginated ?
-                                              vector::concat(_receiver->getHash160(), {0x00}) :
-                                              vector::concat({static_cast<uint8_t>(_receiverCurve)}, _receiver->getHash160());
-                    writer.writeByteArray(receiverContractID);
+                    if (isBabylonActivated) {
+                        auto receiverContractID = vector::concat({static_cast<uint8_t>(_receiverCurve)}, _receiver->getHash160());
+                        writer.writeByteArray(receiverContractID);
+                    } else {
+                        // Originated
+                        auto isReceiverOriginated = _receiver->toBase58().find("KT1") == 0;
+                        writer.writeByte(static_cast<uint8_t>(isReceiverOriginated));
+                        auto receiverContractID = isReceiverOriginated ?
+                                                  vector::concat(_receiver->getHash160(), {0x00}) :
+                                                  vector::concat({static_cast<uint8_t>(_receiverCurve)}, _receiver->getHash160());
+                        writer.writeByteArray(receiverContractID);
+                    }
+
 
                     // Additional parameters
                     writer.writeByte(0x00);
                     break;
                 }
                 case api::TezosOperationTag::OPERATION_TAG_ORIGINATION: {
-                    writer.writeByte(static_cast<uint8_t >(_senderCurve));
-                    writer.writeByteArray(_sender->getHash160());
+                    if (!isBabylonActivated) {
+                        writer.writeByte(static_cast<uint8_t >(_senderCurve));
+                        writer.writeByteArray(_sender->getHash160());
+                    }
                     // Balance
                     writer.writeByteArray(zarith::zSerializeNumber(_balance.toByteArray()));
                     // Is spendable ?

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
@@ -45,9 +45,11 @@ namespace ledger {
         // Reference: https://github.com/obsidiansystems/ledger-app-tezos/blob/9a0c8cc546677147b93935e0b0c96925244baf64/src/types.h
         class TezosLikeTransactionApi : public api::TezosLikeTransaction {
         public:
-            explicit TezosLikeTransactionApi(const api::Currency &currency);
+            explicit TezosLikeTransactionApi(const api::Currency &currency,
+                                             const std::string &protocolUpdate);
 
-            explicit TezosLikeTransactionApi(const std::shared_ptr<OperationApi> &operation);
+            explicit TezosLikeTransactionApi(const std::shared_ptr<OperationApi> &operation,
+                                             const std::string &protocolUpdate);
 
             api::TezosOperationTag getType() override;
 
@@ -120,6 +122,7 @@ namespace ledger {
             api::TezosOperationTag _type;
             std::string _revealedPubKey;
             BigInt _balance;
+            std::string _protocolUpdate;
         };
     }
 }

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
@@ -111,7 +111,8 @@ namespace ledger {
             getHelper(const std::string &url,
                       const std::string &field,
                       const std::unordered_map<std::string, std::string> &params = std::unordered_map<std::string, std::string>(),
-                      const std::string &fallbackValue = "");
+                      const std::string &fallbackValue = "",
+                      const std::string &forceUrl = "");
 
             api::TezosLikeNetworkParameters _parameters;
             std::unordered_map<std::string, uint64_t> _sessions;

--- a/core/src/wallet/tezos/explorers/RpcNodeTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/RpcNodeTezosLikeBlockchainExplorer.cpp
@@ -1,0 +1,235 @@
+/*
+ *
+ * RpcNodeTezosLikeBlockchainExplorer
+ *
+ * Created by El Khalil Bellakrid on 22/10/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+
+#include "RpcNodeTezosLikeBlockchainExplorer.h"
+#include <api/TezosConfigurationDefaults.hpp>
+#include <api/Configuration.hpp>
+#include <rapidjson/document.h>
+#include <api/BigInt.hpp>
+
+namespace ledger {
+    namespace core {
+        RpcNodeTezosLikeBlockchainExplorer::RpcNodeTezosLikeBlockchainExplorer(
+                const std::shared_ptr<api::ExecutionContext> &context,
+                const std::shared_ptr<HttpClient> &http,
+                const api::TezosLikeNetworkParameters &parameters,
+                const std::shared_ptr<api::DynamicObject> &configuration) :
+                DedicatedContext(context),
+                TezosLikeBlockchainExplorer(configuration, {api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT}) {
+            _http = http;
+            _parameters = parameters;
+        }
+
+
+        Future<std::shared_ptr<BigInt>>
+        RpcNodeTezosLikeBlockchainExplorer::getBalance(const std::vector<TezosLikeKeychain::Address> &addresses) {
+            auto size = addresses.size();
+            if (size != 1) {
+                throw make_exception(api::ErrorCode::INVALID_ARGUMENT,
+                                     "Can only get balance of 1 address from Tezos Node, but got {} addresses",
+                                     addresses.size());
+            }
+            return getHelper(fmt::format("chains/main/blocks/head/context/contracts/{}/balance", addresses[0]->toString()),
+                             "",
+                             std::unordered_map<std::string, std::string>{},
+                             "0"
+            );
+        }
+
+        Future<std::shared_ptr<BigInt>>
+        RpcNodeTezosLikeBlockchainExplorer::getFees() {
+            return FuturePtr<BigInt>::successful(
+                    std::make_shared<BigInt>(api::TezosConfigurationDefaults::TEZOS_DEFAULT_FEES)
+            );
+        }
+
+        Future<String>
+        RpcNodeTezosLikeBlockchainExplorer::pushLedgerApiTransaction(const std::vector<uint8_t> &transaction) {
+            std::stringstream body;
+            body << '"' << hex::toString(transaction) << '"';
+            auto bodyString = body.str();
+            return _http->POST("injection/operation?chain=main",
+                               std::vector<uint8_t>(bodyString.begin(), bodyString.end()))
+                    .json().template map<String>(getExplorerContext(),
+                                                 [](const HttpRequest::JsonResult &result) -> String {
+                                                     auto &json = *std::get<1>(result);
+                                                     if (!json.IsString()) {
+                                                         throw make_exception(api::ErrorCode::HTTP_ERROR,
+                                                                              "Failed to parse broadcast transaction response, missing transaction hash");
+                                                     }
+                                                     return json.GetString();
+                                                 });
+        }
+
+        Future<void *> RpcNodeTezosLikeBlockchainExplorer::startSession() {
+            return Future<void *>::successful(new std::string());
+        }
+
+        Future<Unit> RpcNodeTezosLikeBlockchainExplorer::killSession(void *session) {
+            return Future<Unit>::successful(unit);
+        }
+
+        Future<Bytes> RpcNodeTezosLikeBlockchainExplorer::getRawTransaction(const String &transactionHash) {
+            // WARNING: not implemented
+            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING,
+                                 "Endpoint to get raw transactions is not implemented.");
+        }
+
+        Future<String> RpcNodeTezosLikeBlockchainExplorer::pushTransaction(const std::vector<uint8_t> &transaction) {
+            return pushLedgerApiTransaction(transaction);
+        }
+
+        FuturePtr<TezosLikeBlockchainExplorer::TransactionsBulk>
+        RpcNodeTezosLikeBlockchainExplorer::getTransactions(const std::vector<std::string> &addresses,
+                                                             Option<std::string> fromBlockHash,
+                                                             Option<void *> session) {
+            if (addresses.size() != 1) {
+                throw make_exception(api::ErrorCode::INVALID_ARGUMENT,
+                                     "Can only get transactions for 1 address from Tezos Node, but got {} addresses",
+                                     addresses.size());
+            }
+            using EitherTransactionsBulk = Either<Exception, std::shared_ptr<TransactionsBulk>>;
+            return _http->GET(fmt::format("/operations/{}", addresses[0]),
+                              std::unordered_map<std::string, std::string>{},
+                              "https://mystique.tzkt.io/v3/")
+                    .template json<TransactionsBulk, Exception>(
+                            LedgerApiParser<TransactionsBulk, TezosLikeTransactionsBulkParser>())
+                    .template mapPtr<TransactionsBulk>(getExplorerContext(),
+                                                       [](const EitherTransactionsBulk &result) {
+                                                           if (result.isLeft()) {
+                                                               // Because it fails when there are no ops
+                                                               return std::make_shared<TransactionsBulk>();
+                                                           } else {
+                                                               return result.getRight();
+                                                           }
+                                                       });
+        }
+
+        FuturePtr<Block> RpcNodeTezosLikeBlockchainExplorer::getCurrentBlock() const {
+            return _http->GET("chains/main/blocks/head")
+                    .template json<Block, Exception>(LedgerApiParser<Block, TezosLikeBlockParser>())
+                    .template mapPtr<Block>(getExplorerContext(),
+                                            [](const Either<Exception, std::shared_ptr<Block>> &result) {
+                                                if (result.isLeft()) {
+                                                    throw result.getLeft();
+                                                } else {
+                                                    return result.getRight();
+                                                }
+                                            });
+        }
+
+        FuturePtr<TezosLikeBlockchainExplorerTransaction>
+        RpcNodeTezosLikeBlockchainExplorer::getTransactionByHash(const String &transactionHash) const {
+            return getLedgerApiTransactionByHash(transactionHash);
+        }
+
+        Future<int64_t> RpcNodeTezosLikeBlockchainExplorer::getTimestamp() const {
+            return getLedgerApiTimestamp();
+        }
+
+        std::shared_ptr<api::ExecutionContext> RpcNodeTezosLikeBlockchainExplorer::getExplorerContext() const {
+            return _executionContext;
+        }
+
+        api::TezosLikeNetworkParameters RpcNodeTezosLikeBlockchainExplorer::getNetworkParameters() const {
+            return _parameters;
+        }
+
+        std::string RpcNodeTezosLikeBlockchainExplorer::getExplorerVersion() const {
+            return "";
+        }
+
+        Future<std::shared_ptr<BigInt>>
+        RpcNodeTezosLikeBlockchainExplorer::getHelper(const std::string &url,
+                                                       const std::string &field,
+                                                       const std::unordered_map<std::string, std::string> &params,
+                                                       const std::string &fallbackValue) {
+            const bool parseNumbersAsString = true;
+            auto networkId = getNetworkParameters().Identifier;
+
+            std::string p, separator = "?";
+            for (auto &param : params) {
+                p += fmt::format("{}{}={}", separator, param.first, param.second);
+                separator = "&";
+            }
+
+            return _http->GET(url + p,
+                              std::unordered_map<std::string, std::string>())
+                    .json(parseNumbersAsString)
+                    .mapPtr<BigInt>(getContext(),
+                                    [field, networkId, fallbackValue](const HttpRequest::JsonResult &result) {
+                                        auto &json = *std::get<1>(result);
+                                        if ((!json.IsObject() ||
+                                             !json.HasMember(field.c_str()) ||
+                                             !json[field.c_str()].IsString()) && !json.IsString()) {
+                                            throw make_exception(api::ErrorCode::HTTP_ERROR,
+                                                                 fmt::format("Failed to get {} for {}", field,
+                                                                             networkId));
+                                        }
+                                        std::string value = json.IsString() ? json.GetString() : json[field.c_str()].GetString();
+                                        if (value == "0" && !fallbackValue.empty()) {
+                                            value = fallbackValue;
+                                        } else if (value.find('.') != std::string::npos) {
+                                            value = api::BigInt::fromDecimalString(value, 6, ".")->toString(10);
+                                        }
+                                        return std::make_shared<BigInt>(value);
+                                    })
+                    .recover(getContext(), [fallbackValue] (const Exception &exception) {
+                        return std::make_shared<BigInt>(!fallbackValue.empty() ? fallbackValue : "0");
+                    });
+        }
+
+        Future<std::shared_ptr<BigInt>>
+        RpcNodeTezosLikeBlockchainExplorer::getEstimatedGasLimit(const std::string &address) {
+            return FuturePtr<BigInt>::successful(
+                    std::make_shared<BigInt>(api::TezosConfigurationDefaults::TEZOS_DEFAULT_GAS_LIMIT)
+            );
+        }
+
+        Future<std::shared_ptr<BigInt>>
+        RpcNodeTezosLikeBlockchainExplorer::getStorage(const std::string &address) {
+            return getHelper(fmt::format("chains/main/blocks/head/context/contracts/{}/storage", address),
+                             "",
+                             std::unordered_map<std::string, std::string>{},
+                             api::TezosConfigurationDefaults::TEZOS_DEFAULT_STORAGE_LIMIT
+            );
+        }
+
+        Future<std::shared_ptr<BigInt>>
+        RpcNodeTezosLikeBlockchainExplorer::getCounter(const std::string &address) {
+            return getHelper(fmt::format("chains/main/blocks/head/context/contracts/{}/counter", address),
+                             "",
+                             std::unordered_map<std::string, std::string>{},
+                             "0"
+            );
+        }
+    }
+}

--- a/core/src/wallet/tezos/explorers/RpcNodeTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/RpcNodeTezosLikeBlockchainExplorer.h
@@ -1,0 +1,118 @@
+/*
+ *
+ * RpcNodeTezosLikeBlockchainExplorer
+ *
+ * Created by El Khalil Bellakrid on 22/10/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+#pragma once
+#include <wallet/common/explorers/AbstractLedgerApiBlockchainExplorer.h>
+#include <wallet/tezos/explorers/TezosLikeBlockchainExplorer.h>
+#include <wallet/tezos/explorers/api/TezosLikeTransactionsParser.h>
+#include <wallet/tezos/explorers/api/TezosLikeTransactionsBulkParser.h>
+#include <wallet/tezos/explorers/api/TezosLikeBlockParser.h>
+#include <api/TezosLikeNetworkParameters.hpp>
+
+namespace ledger {
+    namespace core {
+        using RpcNodeBlockchainExplorer = AbstractLedgerApiBlockchainExplorer<
+                TezosLikeBlockchainExplorerTransaction,
+                TezosLikeBlockchainExplorer::TransactionsBulk,
+                TezosLikeTransactionsParser,
+                TezosLikeTransactionsBulkParser,
+                TezosLikeBlockParser,
+                api::TezosLikeNetworkParameters>;
+
+        class RpcNodeTezosLikeBlockchainExplorer : public TezosLikeBlockchainExplorer,
+                                                   public RpcNodeBlockchainExplorer,
+                                                   public DedicatedContext,
+                                                   public std::enable_shared_from_this<RpcNodeTezosLikeBlockchainExplorer> {
+        public:
+            RpcNodeTezosLikeBlockchainExplorer(const std::shared_ptr<api::ExecutionContext> &context,
+                                               const std::shared_ptr<HttpClient> &http,
+                                               const api::TezosLikeNetworkParameters &parameters,
+                                               const std::shared_ptr<api::DynamicObject> &configuration);
+
+            Future<std::shared_ptr<BigInt>>
+            getBalance(const std::vector<TezosLikeKeychain::Address> &addresses) override;
+
+            Future<std::shared_ptr<BigInt>>
+            getFees() override;
+
+            Future<String> pushLedgerApiTransaction(const std::vector<uint8_t> &transaction) override;
+
+            Future<void *> startSession() override;
+
+            Future<Unit> killSession(void *session) override;
+
+            Future<Bytes> getRawTransaction(const String &transactionHash) override;
+
+            Future<String> pushTransaction(const std::vector<uint8_t> &transaction) override;
+
+            FuturePtr<TezosLikeBlockchainExplorer::TransactionsBulk>
+            getTransactions(const std::vector<std::string> &addresses,
+                            Option<std::string> fromBlockHash = Option<std::string>(),
+                            Option<void *> session = Option<void *>()) override;
+
+            FuturePtr<Block> getCurrentBlock() const override;
+
+            FuturePtr<TezosLikeBlockchainExplorerTransaction>
+            getTransactionByHash(const String &transactionHash) const override;
+
+            Future<int64_t> getTimestamp() const override;
+
+            std::shared_ptr<api::ExecutionContext> getExplorerContext() const override;
+
+            api::TezosLikeNetworkParameters getNetworkParameters() const override;
+
+            std::string getExplorerVersion() const override;
+
+            Future<std::shared_ptr<BigInt>>
+            getEstimatedGasLimit(const std::string &address) override;
+
+            Future<std::shared_ptr<BigInt>>
+            getStorage(const std::string &address) override;
+
+            Future<std::shared_ptr<BigInt>> getCounter(const std::string &address) override;
+
+        private:
+            /*
+             * Helper to a get specific field's value from given url
+             * WARNING: this is only useful for fields with an integer (decimal representation) value (with a string type)
+             * @param url : base url to fetch the value on,
+             * @param field: name of field we are interested into,
+             * @param params: additional params to query value of field
+             * @return BigInt representing the value of targetted field
+             */
+            Future<std::shared_ptr<BigInt>>
+            getHelper(const std::string &url,
+                      const std::string &field,
+                      const std::unordered_map<std::string, std::string> &params = std::unordered_map<std::string, std::string>(),
+                      const std::string &fallbackValue = "");
+
+            api::TezosLikeNetworkParameters _parameters;
+        };
+    }
+}

--- a/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.cpp
+++ b/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.cpp
@@ -34,6 +34,7 @@
 #include <wallet/tezos/api_impl/TezosLikeTransactionApi.h>
 #include <bytes/zarith/zarith.h>
 #include <math/Base58.hpp>
+#include <api/TezosConfigurationDefaults.hpp>
 #include <api/TezosOperationTag.hpp>
 #include <api/TezosCurve.hpp>
 
@@ -46,7 +47,8 @@ namespace ledger {
                 const api::Currency &currency,
                 const std::shared_ptr<TezosLikeBlockchainExplorer> &explorer,
                 const std::shared_ptr<spdlog::logger> &logger,
-                const TezosLikeTransactionBuildFunction &buildFunction) :
+                const TezosLikeTransactionBuildFunction &buildFunction,
+                const std::string &protocolUpdate) :
                 _senderAddress(senderAddress), _context(context),
                 _currency(currency), _explorer(explorer),
                 _build(buildFunction), _logger(logger){
@@ -125,22 +127,36 @@ namespace ledger {
         std::shared_ptr<api::TezosLikeTransaction>
         api::TezosLikeTransactionBuilder::parseRawUnsignedTransaction(const api::Currency &currency,
                                                                       const std::vector<uint8_t> &rawTransaction) {
-            return ::ledger::core::TezosLikeTransactionBuilder::parseRawTransaction(currency, rawTransaction, false);
+            // Since this patch is temporary, we can live with this
+            // This method is not used yet anywhere internally or externally (except for tests)
+            return ::ledger::core::TezosLikeTransactionBuilder::parseRawTransaction(currency,
+                                                                                    rawTransaction,
+                                                                                    false,
+                                                                                    ""
+            );
         }
 
         std::shared_ptr<api::TezosLikeTransaction>
         api::TezosLikeTransactionBuilder::parseRawSignedTransaction(const api::Currency &currency,
                                                                     const std::vector<uint8_t> &rawTransaction) {
-            return ::ledger::core::TezosLikeTransactionBuilder::parseRawTransaction(currency, rawTransaction, true);
+            // Since this patch is temporary, we can live with this
+            // This method is not used yet anywhere internally or externally (except for tests)
+            return ::ledger::core::TezosLikeTransactionBuilder::parseRawTransaction(currency,
+                                                                                    rawTransaction,
+                                                                                    true,
+                                                                                    ""
+            );
         }
 
         // Reference: https://www.ocamlpro.com/2018/11/21/an-introduction-to-tezos-rpcs-signing-operations/
         std::shared_ptr<api::TezosLikeTransaction>
         TezosLikeTransactionBuilder::parseRawTransaction(const api::Currency &currency,
                                                          const std::vector<uint8_t> &rawTransaction,
-                                                         bool isSigned) {
+                                                         bool isSigned,
+                                                         const std::string &protocolUpdate) {
+            auto isBabylonActivated = protocolUpdate == api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON;
             auto params = currency.tezosLikeNetworkParameters.value();
-            auto tx = std::make_shared<TezosLikeTransactionApi>(currency);
+            auto tx = std::make_shared<TezosLikeTransactionApi>(currency, protocolUpdate);
             BytesReader reader(rawTransaction);
             if (!isSigned) {
                 // Watermark: Generic-Operation
@@ -160,25 +176,35 @@ namespace ledger {
             auto OpTag = reader.readNextByte();
             tx->setType(static_cast<api::TezosOperationTag>(OpTag));
 
+
+            // sender hash160
+            std::vector<uint8_t> senderHash160, version;
             // Get Sender
             // Originated
-            auto isSenderOriginated = reader.readNextByte();
-            // sender hash160
-            std::vector<uint8_t> senderHash160;
-            if (isSenderOriginated) {
-                // Then we read 20 bytes of publicKey hash
-                senderHash160 = reader.read(20);
-                // ... and padding
-                reader.readNextByte();
-            } else {
-                // Otherwise first curve code ...
+            if (isBabylonActivated) {
+                // First curve code ...
                 auto senderCurveCode = reader.readNextByte();
                 // then hash160 ...
                 senderHash160 = reader.read(20);
+                version = params.ImplicitPrefix;
+            } else {
+                auto isSenderOriginated = reader.readNextByte();
+                if (isSenderOriginated) {
+                    // Then we read 20 bytes of publicKey hash
+                    senderHash160 = reader.read(20);
+                    // ... and padding
+                    reader.readNextByte();
+                } else {
+                    // Otherwise first curve code ...
+                    auto senderCurveCode = reader.readNextByte();
+                    // then hash160 ...
+                    senderHash160 = reader.read(20);
+                }
+                version = isSenderOriginated ? params.OriginatedPrefix : params.ImplicitPrefix;
             }
             tx->setSender(std::make_shared<TezosLikeAddress>(currency,
                                                              senderHash160,
-                                                             isSenderOriginated ? params.OriginatedPrefix : params.ImplicitPrefix,
+                                                             version,
                                                              Option<std::string>()));
 
             // Fee
@@ -193,7 +219,9 @@ namespace ledger {
             // Storage Limit
             tx->setStorage(std::make_shared<BigInt>(BigInt::fromHex(hex::toString(zarith::zParse(reader)))));
 
-            switch (OpTag) {
+            // Offset introduced by Babylon
+            auto offset = static_cast<uint8_t>(isBabylonActivated ? 100 : 0);
+            switch (OpTag - offset) {
                 case static_cast<uint8_t>(api::TezosOperationTag::OPERATION_TAG_REVEAL): {
                     auto curveCode = reader.readNextByte();
                     std::vector<uint8_t> pubKey;
@@ -219,23 +247,33 @@ namespace ledger {
 
                     // Get Receiver
                     // Originated
-                    auto isReceiverOriginated = reader.readNextByte();
-                    std::vector<uint8_t> receiverHash160;
-                    if (!isReceiverOriginated) {
+                    std::vector<uint8_t> receiverHash160, receiverVersion;
+                    if (isBabylonActivated) {
                         // Curve code
                         auto receiverCurveCode = reader.readNextByte();
                         // 20 bytes of publicKey hash
                         receiverHash160 = reader.read(20);
+                        receiverVersion = params.ImplicitPrefix;
                     } else {
-                        // 20 bytes of publicKey hash
-                        receiverHash160 = reader.read(20);
-                        // Padding
-                        reader.readNextByte();
+                        auto isReceiverOriginated = reader.readNextByte();
+
+                        if (!isReceiverOriginated) {
+                            // Curve code
+                            auto receiverCurveCode = reader.readNextByte();
+                            // 20 bytes of publicKey hash
+                            receiverHash160 = reader.read(20);
+                        } else {
+                            // 20 bytes of publicKey hash
+                            receiverHash160 = reader.read(20);
+                            // Padding
+                            reader.readNextByte();
+                        }
+                        receiverVersion = isReceiverOriginated ? params.OriginatedPrefix : params.ImplicitPrefix;
                     }
 
                     tx->setReceiver(std::make_shared<TezosLikeAddress>(currency,
                                                                        receiverHash160,
-                                                                       isReceiverOriginated ? params.OriginatedPrefix : params.ImplicitPrefix,
+                                                                       receiverVersion,
                                                                        Option<std::string>()));
 
                     // Additional parameters
@@ -252,11 +290,13 @@ namespace ledger {
                                                                        std::vector<uint8_t>(),
                                                                        std::vector<uint8_t>(),
                                                                        Option<std::string>()));
-                    auto managerCurveCode = reader.readNextByte();
-                    // manager hash160
-                    auto managerHash160 = reader.read(20);
-                    if (managerHash160 != senderHash160) {
-                        throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Origination error: Manager is diffrent from sender");
+                    if (!isBabylonActivated) {
+                        auto managerCurveCode = reader.readNextByte();
+                        // manager hash160
+                        auto managerHash160 = reader.read(20);
+                        if (managerHash160 != senderHash160) {
+                            throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Origination error: Manager is different from sender");
+                        }
                     }
                     // Balance
                     tx->setBalance(BigInt::fromHex(hex::toString(zarith::zParse(reader))));

--- a/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.cpp
+++ b/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.cpp
@@ -248,28 +248,21 @@ namespace ledger {
                     // Get Receiver
                     // Originated
                     std::vector<uint8_t> receiverHash160, receiverVersion;
-                    if (isBabylonActivated) {
+
+                    auto isReceiverOriginated = reader.readNextByte();
+
+                    if (!isReceiverOriginated) {
                         // Curve code
                         auto receiverCurveCode = reader.readNextByte();
                         // 20 bytes of publicKey hash
                         receiverHash160 = reader.read(20);
-                        receiverVersion = params.ImplicitPrefix;
                     } else {
-                        auto isReceiverOriginated = reader.readNextByte();
-
-                        if (!isReceiverOriginated) {
-                            // Curve code
-                            auto receiverCurveCode = reader.readNextByte();
-                            // 20 bytes of publicKey hash
-                            receiverHash160 = reader.read(20);
-                        } else {
-                            // 20 bytes of publicKey hash
-                            receiverHash160 = reader.read(20);
-                            // Padding
-                            reader.readNextByte();
-                        }
-                        receiverVersion = isReceiverOriginated ? params.OriginatedPrefix : params.ImplicitPrefix;
+                        // 20 bytes of publicKey hash
+                        receiverHash160 = reader.read(20);
+                        // Padding
+                        reader.readNextByte();
                     }
+                    receiverVersion = isReceiverOriginated ? params.OriginatedPrefix : params.ImplicitPrefix;
 
                     tx->setReceiver(std::make_shared<TezosLikeAddress>(currency,
                                                                        receiverHash160,

--- a/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.h
+++ b/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.h
@@ -75,7 +75,8 @@ namespace ledger {
                                                  const api::Currency &params,
                                                  const std::shared_ptr<TezosLikeBlockchainExplorer> &explorer,
                                                  const std::shared_ptr<spdlog::logger> &logger,
-                                                 const TezosLikeTransactionBuildFunction &buildFunction);
+                                                 const TezosLikeTransactionBuildFunction &buildFunction,
+                                                 const std::string &protocolUpdate = "");
 
             TezosLikeTransactionBuilder(const TezosLikeTransactionBuilder &cpy);
 
@@ -105,7 +106,8 @@ namespace ledger {
 
             static std::shared_ptr<api::TezosLikeTransaction> parseRawTransaction(const api::Currency &currency,
                                                                                   const std::vector<uint8_t> &rawTransaction,
-                                                                                  bool isSigned);
+                                                                                  bool isSigned,
+                                                                                  const std::string &protocolUpdate);
 
         private:
             api::Currency _currency;

--- a/core/test/integration/synchronization/tezos_synchronization.cpp
+++ b/core/test/integration/synchronization/tezos_synchronization.cpp
@@ -55,7 +55,7 @@ TEST_F(TezosLikeWalletSynchronization, MediumXpubSynchronization) {
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"44'/<coin_type>'/<account>'/<node>'/<address>");
         configuration->putString(api::TezosConfiguration::TEZOS_XPUB_CURVE, api::TezosConfigurationDefaults::TEZOS_XPUB_CURVE_SECP256K1);
-        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, api::BlockchainExplorerEngines::TZSTATS_API);
+        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, api::BlockchainExplorerEngines::TZSTATS_RPC_NODE);
         auto wallet = wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "tezos", configuration));
         std::set<std::string> emittedOperations;
         {


### PR DESCRIPTION
Since we have issues with Tzstats & `node 8` we might use this fallback instead.
To query operations by address we rely on https://mystique.tzkt.io/ which seems to be fine with `node 8`, but unfortunately it does only return `Transaction` and `Delegation` operations, so as a consequence we won't have originated accounts. Mystique seems also to return data with some missing informations (e.g. blockhash ...), please refer to: https://mystique.tzkt.io/v3/operations/tz1iJuhk6v4A6wPbi1uLNy33ZuKu5JgHN1ye
We use the main RPC node but this would work with any RPC node it only needs `TEZOS_RPC_ENDPOINT` to be override through the wallet configuration.

**DRAFT**: Currently this PR will remain draft for 2 reasons:
- Wait for https://github.com/LedgerHQ/lib-ledger-core/pull/359 to be merged,
- Check if, as a fallback solution, it is ok to not have originated accounts and missing informations (missing blockhash will probably need some tweaks from our side too) 