### PR TITLE
Tezos: return public key instead of address from getRestoreKey method

### DIFF
--- a/core/src/wallet/tezos/keychains/TezosLikeKeychain.cpp
+++ b/core/src/wallet/tezos/keychains/TezosLikeKeychain.cpp
@@ -76,7 +76,7 @@ namespace ledger {
         }
 
         std::string TezosLikeKeychain::getRestoreKey() const {
-            return _address->toString();
+            return hex::toString(_publicKey.getValueOr(std::vector<uint8_t>()));
         }
 
         bool TezosLikeKeychain::contains(const std::string &address) const {

--- a/core/test/integration/synchronization/tezos_synchronization.cpp
+++ b/core/test/integration/synchronization/tezos_synchronization.cpp
@@ -106,6 +106,7 @@ TEST_F(TezosLikeWalletSynchronization, MediumXpubSynchronization) {
             });
 
             auto restoreKey = account->getRestoreKey();
+            EXPECT_EQ(restoreKey, hex::toString(XTZ_KEYS_INFO.publicKeys[0]));
             account->synchronize()->subscribe(dispatcher->getMainExecutionContext(), receiver);
 
             dispatcher->waitUntilStopped();


### PR DESCRIPTION
The restore key should be the public key since it is the one needed to create account.