### PR TITLE
Tezos: fix operations on originated accounts

### DIFF
--- a/core/src/wallet/common/api_impl/OperationApi.cpp
+++ b/core/src/wallet/common/api_impl/OperationApi.cpp
@@ -30,14 +30,12 @@
  */
 #include "OperationApi.h"
 #include <wallet/common/Amount.h>
-#include "../AbstractAccount.hpp"
-#include <wallet/common/Amount.h>
+#include <wallet/common/AbstractAccount.hpp>
 #include <wallet/bitcoin/api_impl/BitcoinLikeOperation.h>
 #include <wallet/ethereum/api_impl/EthereumLikeOperation.h>
 #include <wallet/ripple/api_impl/RippleLikeOperation.h>
 #include <wallet/tezos/api_impl/TezosLikeOperation.h>
 #include <api/WalletType.hpp>
-
 
 namespace ledger {
     namespace core {
@@ -70,7 +68,7 @@ namespace ledger {
             return _backend.recipients;
         }
 
-        Operation &OperationApi::getBackend() {
+        ledger::core::Operation &OperationApi::getBackend() {
             return _backend;
         }
 

--- a/core/src/wallet/common/api_impl/OperationApi.h
+++ b/core/src/wallet/common/api_impl/OperationApi.h
@@ -32,7 +32,7 @@
 #define LEDGER_CORE_OPERATIONAPI_H
 
 #include <api/Operation.hpp>
-#include "../Operation.h"
+#include <wallet/common/Operation.h>
 #include <api/Currency.hpp>
 
 namespace ledger {

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -208,7 +208,7 @@ namespace ledger {
                                       })
                     .recoverWith(getContext(), [] (const Exception &e) {
                         // Avoid fmt error because of JSON string
-                        auto error = "Failed to broadcast raw transaction, reason " + e.getMessage();
+                        const auto error = "Failed to broadcast raw transaction, reason " + e.getMessage();
                         return Future<std::string>::failure(
                                 Exception(api::ErrorCode::INCOMPLETE_TRANSACTION, error)
                         );
@@ -246,8 +246,8 @@ namespace ledger {
                 tx->setSigningPubKey(self->getKeychain()->getPublicKey().getValue());
                 tx->setManagerAddress(managerAddress);
                 tx->setType(request.type);
-                auto counterAddress = protocolUpdate == api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON ?
-                                      managerAddress : senderAddress;
+                const auto counterAddress = protocolUpdate == api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON ?
+                                            managerAddress : senderAddress;
                 return explorer->getCounter(counterAddress).flatMapPtr<Block>(self->getContext(), [self, tx, explorer] (const std::shared_ptr<BigInt> &counter) {
                     if (!counter) {
                         throw make_exception(api::ErrorCode::RUNTIME_ERROR, "Failed to retrieve counter from network.");

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -55,6 +55,7 @@
 #include <collections/vector.hpp>
 #include <database/query/ConditionQueryFilter.h>
 #include <api/TezosConfiguration.hpp>
+#include <api/TezosConfigurationDefaults.hpp>
 
 using namespace soci;
 
@@ -206,11 +207,10 @@ namespace ledger {
                                           return seq.str();
                                       })
                     .recoverWith(getContext(), [] (const Exception &e) {
+                        // Avoid fmt error because of JSON string
+                        auto error = "Failed to broadcast raw transaction, reason " + e.getMessage();
                         return Future<std::string>::failure(
-                                make_exception(
-                                        api::ErrorCode::INCOMPLETE_TRANSACTION,
-                                        fmt::format("Failed to broadcast raw transaction, reason {}", e.getMessage())
-                                )
+                                Exception(api::ErrorCode::INCOMPLETE_TRANSACTION, error)
                         );
                     })
                     .callback(getContext(), callback);
@@ -228,8 +228,9 @@ namespace ledger {
         std::shared_ptr<api::TezosLikeTransactionBuilder> TezosLikeAccount::buildTransaction(const std::string &senderAddress) {
             auto self = std::dynamic_pointer_cast<TezosLikeAccount>(shared_from_this());
             auto buildFunction = [self, senderAddress](const TezosLikeTransactionBuildRequest &request,
-                                        const std::shared_ptr<TezosLikeBlockchainExplorer> &explorer) -> Future<std::shared_ptr<api::TezosLikeTransaction>> {
+                                                       const std::shared_ptr<TezosLikeBlockchainExplorer> &explorer) {
                 auto currency = self->getWallet()->getCurrency();
+                auto managerAddress = self->getKeychain()->getAddress()->toString();
                 auto protocolUpdate = self->getWallet()
                         ->getConfiguration()
                         ->getString(api::TezosConfiguration::TEZOS_PROTOCOL_UPDATE)
@@ -243,20 +244,29 @@ namespace ledger {
                 tx->setSender(accountAddress);
                 tx->setReceiver(TezosLikeAddress::fromBase58(request.toAddress, currency));
                 tx->setSigningPubKey(self->getKeychain()->getPublicKey().getValue());
+                tx->setManagerAddress(managerAddress);
                 tx->setType(request.type);
-                return explorer->getCounter(senderAddress).flatMapPtr<Block>(self->getContext(), [self, tx, explorer] (const std::shared_ptr<BigInt> &counter) {
+                auto counterAddress = protocolUpdate == api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON ?
+                                      managerAddress : senderAddress;
+                return explorer->getCounter(counterAddress).flatMapPtr<Block>(self->getContext(), [self, tx, explorer] (const std::shared_ptr<BigInt> &counter) {
                     if (!counter) {
                         throw make_exception(api::ErrorCode::RUNTIME_ERROR, "Failed to retrieve counter from network.");
                     }
                     // We should increment current counter
                     tx->setCounter(std::make_shared<BigInt>(++(*counter)));
                     return explorer->getCurrentBlock();
-                }).flatMapPtr<api::TezosLikeTransaction>(self->getContext(), [self, explorer, tx] (const std::shared_ptr<Block> &block) {
+                }).flatMapPtr<api::TezosLikeTransaction>(self->getContext(), [self, explorer, tx, senderAddress] (const std::shared_ptr<Block> &block) {
                     tx->setBlockHash(block->hash);
                     if (tx->getType() == api::TezosOperationTag::OPERATION_TAG_ORIGINATION) {
                         std::vector<TezosLikeKeychain::Address> listAddresses{self->_keychain->getAddress()};
                         return explorer->getBalance(listAddresses).mapPtr<api::TezosLikeTransaction>(self->getContext(), [tx] (const std::shared_ptr<BigInt> &balance) {
                             tx->setBalance(*balance);
+                            return tx;
+                        });
+                    } else if (senderAddress.find("KT1") == 0) {
+                        // HACK: KT Operation we use forge endpoint
+                        return explorer->forgeKTOperation(tx).mapPtr<api::TezosLikeTransaction>(self->getContext(), [tx] (const std::vector<uint8_t> &rawTx) {
+                            tx->setRawTx(rawTx);
                             return tx;
                         });
                     }

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
@@ -30,7 +30,6 @@
 
 
 #include "TezosLikeTransactionApi.h"
-#include "TezosLikeTransactionApi.h"
 #include <wallet/common/Amount.h>
 #include <wallet/common/AbstractAccount.hpp>
 #include <wallet/common/AbstractWallet.hpp>
@@ -148,10 +147,18 @@ namespace ledger {
         std::vector<uint8_t> TezosLikeTransactionApi::serialize() {
             auto isBabylonActivated = _protocolUpdate == api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON;
             BytesWriter writer;
-
             // Watermark: Generic-Operation
             if (_signature.empty()) {
                 writer.writeByte(static_cast<uint8_t>(api::TezosOperationTag::OPERATION_TAG_GENERIC));
+            }
+
+            // If tx was forged then nothing to do
+            if (!_rawTx.empty()) {
+                writer.writeByteArray(_rawTx);
+                if (!_signature.empty()) {
+                    writer.writeByteArray(_signature);
+                }
+                return writer.toByteArray();
             }
 
             // Block Hash
@@ -350,6 +357,20 @@ namespace ledger {
 
         TezosLikeTransactionApi & TezosLikeTransactionApi::setBalance(const BigInt &balance) {
             _balance = balance;
+            return *this;
+        }
+
+        TezosLikeTransactionApi & TezosLikeTransactionApi::setManagerAddress(const std::string &managerAddress) {
+            _managerAddress = managerAddress;
+            return *this;
+        }
+
+        std::string TezosLikeTransactionApi::getManagerAddress() {
+            return _managerAddress;
+        }
+
+        TezosLikeTransactionApi & TezosLikeTransactionApi::setRawTx(const std::vector<uint8_t> &rawTx) {
+            _rawTx = rawTx;
             return *this;
         }
     }

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
@@ -365,7 +365,7 @@ namespace ledger {
             return *this;
         }
 
-        std::string TezosLikeTransactionApi::getManagerAddress() {
+        std::string TezosLikeTransactionApi::getManagerAddress() const {
             return _managerAddress;
         }
 

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
@@ -103,7 +103,7 @@ namespace ledger {
             TezosLikeTransactionApi & setBalance(const BigInt &balance);
 
             TezosLikeTransactionApi & setManagerAddress(const std::string &managerAddress);
-            std::string getManagerAddress();
+            std::string getManagerAddress() const;
 
             TezosLikeTransactionApi &setRawTx(const std::vector<uint8_t> &rawTx);
         private:

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
@@ -34,7 +34,6 @@
 
 #include <wallet/common/api_impl/OperationApi.h>
 #include <wallet/tezos/api_impl/TezosLikeBlockApi.h>
-
 #include <api/TezosLikeTransaction.hpp>
 #include <api/Amount.hpp>
 #include <api/Currency.hpp>
@@ -103,6 +102,10 @@ namespace ledger {
 
             TezosLikeTransactionApi & setBalance(const BigInt &balance);
 
+            TezosLikeTransactionApi & setManagerAddress(const std::string &managerAddress);
+            std::string getManagerAddress();
+
+            TezosLikeTransactionApi &setRawTx(const std::vector<uint8_t> &rawTx);
         private:
             std::chrono::system_clock::time_point _time;
             std::shared_ptr<TezosLikeBlockApi> _block;
@@ -123,6 +126,8 @@ namespace ledger {
             std::string _revealedPubKey;
             BigInt _balance;
             std::string _protocolUpdate;
+            std::string _managerAddress;
+            std::vector<uint8_t> _rawTx;
         };
     }
 }

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -270,5 +270,12 @@ namespace ledger {
                              rpcNode
             );
         }
+
+        Future<std::vector<uint8_t>> ExternalTezosLikeBlockchainExplorer::forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) {
+            return TezosLikeBlockchainExplorer::forgeKTOperation(tx,
+                                                                 getExplorerContext(),
+                                                                 _http);
+        }
+
     }
 }

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
@@ -98,6 +98,7 @@ namespace ledger {
 
             Future<std::shared_ptr<BigInt>> getCounter(const std::string &address) override;
 
+            Future<std::vector<uint8_t>> forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) override;
         private:
             /*
              * Helper to a get specific field's value from given url

--- a/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.cpp
@@ -268,5 +268,11 @@ namespace ledger {
                              std::unordered_map<std::string, std::string>{{"token", address}}
             );
         }
+
+        Future<std::vector<uint8_t>> NodeTezosLikeBlockchainExplorer::forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) {
+            return TezosLikeBlockchainExplorer::forgeKTOperation(tx,
+                                                                 getExplorerContext(),
+                                                                 _http);
+        }
     }
 }

--- a/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.h
@@ -95,6 +95,8 @@ namespace ledger {
 
             Future<std::shared_ptr<BigInt>> getCounter(const std::string &address) override;
 
+            Future<std::vector<uint8_t>> forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) override ;
+
         private:
             /*
              * Helper to a get specific field's value from given url

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
@@ -101,7 +101,7 @@ namespace ledger {
             }
 
         };
-
+        class TezosLikeTransactionApi;
         class TezosLikeBlockchainExplorer : public ConfigurationMatchable,
                                             public AbstractBlockchainExplorer<TezosLikeBlockchainExplorerTransaction> {
         public:
@@ -124,6 +124,13 @@ namespace ledger {
 
             virtual Future<std::shared_ptr<BigInt>>
             getCounter(const std::string &address) = 0;
+
+            virtual Future<std::vector<uint8_t>> forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) = 0;
+            // This a helper to manage legacy KT accounts
+            // WARNING: we will only support removing delegation and transfer from KT to implicit account
+            static Future<std::vector<uint8_t>> forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx,
+                                                                 const std::shared_ptr<api::ExecutionContext> &context,
+                                                                 const std::shared_ptr<HttpClient> &http);
         };
     }
 }

--- a/core/test/integration/transactions/tezos_transaction_tests.cpp
+++ b/core/test/integration/transactions/tezos_transaction_tests.cpp
@@ -34,6 +34,7 @@
 #include <api/TezosLikeOriginatedAccount.hpp>
 #include <api/TezosConfiguration.hpp>
 #include <api/TezosConfigurationDefaults.hpp>
+#include <api/BlockchainExplorerEngines.hpp>
 #include "transaction_test_helper.h"
 #include <utils/hex.h>
 #include <utils/DateUtils.hpp>
@@ -46,6 +47,7 @@ using namespace std;
 struct TezosMakeTransaction : public TezosMakeBaseTransaction {
     void SetUpConfig() override {
         auto configuration = DynamicObject::newInstance();
+        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, api::BlockchainExplorerEngines::TZSTATS_API);
         configuration->putString(api::TezosConfiguration::TEZOS_XPUB_CURVE, api::TezosConfigurationDefaults::TEZOS_XPUB_CURVE_SECP256K1);
         testData.configuration = configuration;
         testData.walletName = "my_wallet";
@@ -79,14 +81,14 @@ TEST_F(TezosMakeTransaction, CreateTx) {
     EXPECT_THROW(builder->sendToAddress(api::Amount::fromLong(currency, 220000), "tz1cmN7N6rV9ULVqbL2BxSUZgeL5wnWyoBUE"), Exception);
     builder->sendToAddress(api::Amount::fromLong(currency, 220000), "tz1TRspM5SeZpaQUhzByXbEvqKF1vnCM2YTK");
     // TODO: activate when we got URL of our custom explorer
-    /*
+
     auto f = builder->build();
     auto tx = ::wait(f);
     auto serializedTx = tx->serialize();
     auto parsedTx = TezosLikeTransactionBuilder::parseRawUnsignedTransaction(wallet->getCurrency(), serializedTx);
     auto serializedParsedTx = parsedTx->serialize();
     EXPECT_EQ(serializedTx, serializedParsedTx);
-    */
+
     auto date = "2000-03-27T09:10:22Z";
     auto formatedDate = DateUtils::fromJSON(date);
 
@@ -112,16 +114,14 @@ TEST_F(TezosMakeTransaction, CreateTx) {
     txBuilder->setGasLimit(api::Amount::fromLong(currency, 10000));
     txBuilder->setStorageLimit(std::make_shared<api::BigIntImpl>(BigInt::fromString("1000")));
     txBuilder->sendToAddress(api::Amount::fromLong(currency, 220000), "tz1cmN7N6rV9ULVqbL2BxSUZgeL5wnWyoBUE");
-    // TODO: activate when we got URL of our custom explorer
-    /*
     auto originatedTx = ::wait(txBuilder->build());
     EXPECT_EQ(originatedTx->getSender()->toBase58(), "KT1JLbEZuWFhEyHXtKsvbCNZABXGehkjVyCd");
     EXPECT_EQ(originatedTx->getReceiver()->toBase58(), "tz1cmN7N6rV9ULVqbL2BxSUZgeL5wnWyoBUE");
 
     auto serializedOriginatedTx = originatedTx->serialize();
-    auto parsedOriginatedTx = TezosLikeTransactionBuilder::parseRawUnsignedTransaction(wallet->getCurrency(), serializedOriginatedTx);
-    EXPECT_EQ(serializedOriginatedTx, parsedOriginatedTx->serialize());
-    */
+    // Remains deactivated because we don't parse KT Txs after Babylon Update
+    //auto parsedOriginatedTx = TezosLikeTransactionBuilder::parseRawUnsignedTransaction(wallet->getCurrency(), serializedOriginatedTx);
+    //EXPECT_EQ(serializedOriginatedTx, parsedOriginatedTx->serialize());
     //Delete wallet
     auto walletCode = wait(pool->eraseDataSince(formatedDate));
     EXPECT_EQ(walletCode, api::ErrorCode::FUTURE_WAS_SUCCESSFULL);


### PR DESCRIPTION
This a patch to allow actions from originated account.
We rely on RPC call not to make serialization more complex than it is and also because those accounts are considered as legacy.
This PR was tested with Live and it's working : https://tzstats.com/KT1PTC8w6Mk6MSnx56TzMRx4Z8weLLq3oGgP