### PR TITLE
Fixes on Tezos integration

### DIFF
--- a/core/src/wallet/common/Operation.cpp
+++ b/core/src/wallet/common/Operation.cpp
@@ -35,7 +35,7 @@
 namespace ledger {
     namespace core {
 
-        void Operation::refreshUid() {
+        void Operation::refreshUid(const std::string &additional) {
             if (bitcoinTransaction.nonEmpty()) {
                 uid = OperationDatabaseHelper::createUid(accountUid, bitcoinTransaction.getValue().hash, type);
             } else if (ethereumTransaction.nonEmpty()) {
@@ -43,7 +43,11 @@ namespace ledger {
             } else if (rippleTransaction.nonEmpty()) {
                 uid = OperationDatabaseHelper::createUid(accountUid, rippleTransaction.getValue().hash, type);
             } else if (tezosTransaction.nonEmpty()) {
-                uid = OperationDatabaseHelper::createUid(accountUid, fmt::format("{}+{}", tezosTransaction.getValue().hash, api::to_string(tezosTransaction.getValue().type)), type);
+                auto final = fmt::format("{}+{}", tezosTransaction.getValue().hash, api::to_string(tezosTransaction.getValue().type));
+                if (!additional.empty()){
+                    final = fmt::format("{}+{}", final, additional);
+                }
+                uid = OperationDatabaseHelper::createUid(accountUid, final, type);
             } else {
                 throw Exception(api::ErrorCode::RUNTIME_ERROR, "Cannot refresh uid of an incomplete operation.");
             }

--- a/core/src/wallet/common/Operation.h
+++ b/core/src/wallet/common/Operation.h
@@ -69,7 +69,7 @@ namespace ledger {
             Option<RippleLikeBlockchainExplorerTransaction> rippleTransaction;
             Option<TezosLikeBlockchainExplorerTransaction> tezosTransaction;
 
-            void refreshUid();
+            void refreshUid(const std::string &additional = "");
 
             Operation() = default;
             Operation(Operation const&) = default;

--- a/core/src/wallet/tezos/TezosLikeAccount.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount.cpp
@@ -120,7 +120,7 @@ namespace ledger {
             if (!originatedAccountUid.empty() && !originatedAccountAddress.empty()) {
                 operation.amount = transaction.value;
                 operation.type = transaction.sender == originatedAccountAddress ? api::OperationType::SEND : api::OperationType::RECEIVE;
-                operation.refreshUid();
+                operation.refreshUid(originatedAccountUid);
                 if (OperationDatabaseHelper::putOperation(sql, operation)) {
                     // Update publicKey field for originated account
                     if (transaction.type == api::TezosOperationTag::OPERATION_TAG_REVEAL && transaction.publicKey.hasValue()) {

--- a/core/src/wallet/tezos/explorers/api/TezosLikeTransactionParser.cpp
+++ b/core/src/wallet/tezos/explorers/api/TezosLikeTransactionParser.cpp
@@ -139,6 +139,8 @@ namespace ledger {
                     _transaction->gas_limit = toValue(number, false);
                 } else if (_lastKey == "storage_limit") {
                     _transaction->storage_limit = toValue(number, false);
+                } else if (_lastKey == "burned") {
+                    _transaction->fees = _transaction->fees + toValue(number, true);
                 }
                 return true;
             }
@@ -213,8 +215,8 @@ namespace ledger {
                 } else if (_lastKey == "public_key" ||
                         (_lastKey == "data" && _transaction->type == api::TezosOperationTag::OPERATION_TAG_REVEAL)) {
                     _transaction->publicKey = value;
-                } else if (_lastKey == "burn_tez" || _lastKey == "burned") {
-                    _transaction->fees = _transaction->fees + toValue(value, _lastKey == "burned");
+                } else if (_lastKey == "burn_tez") {
+                    _transaction->fees = _transaction->fees + toValue(value, false);
                 }
                 return true;
             }

--- a/core/test/integration/transactions/tezos_transaction_tests.cpp
+++ b/core/test/integration/transactions/tezos_transaction_tests.cpp
@@ -79,12 +79,13 @@ TEST_F(TezosMakeTransaction, CreateTx) {
     builder->setStorageLimit(std::make_shared<api::BigIntImpl>(BigInt::fromString("1000")));
     // Self-transaction not allowed
     EXPECT_THROW(builder->sendToAddress(api::Amount::fromLong(currency, 220000), "tz1cmN7N6rV9ULVqbL2BxSUZgeL5wnWyoBUE"), Exception);
-    builder->sendToAddress(api::Amount::fromLong(currency, 220000), "tz1TRspM5SeZpaQUhzByXbEvqKF1vnCM2YTK");
+    builder->wipeToAddress("tz1TRspM5SeZpaQUhzByXbEvqKF1vnCM2YTK");
     // TODO: activate when we got URL of our custom explorer
-
     auto f = builder->build();
     auto tx = ::wait(f);
     auto serializedTx = tx->serialize();
+    auto balance = wait(account->getBalance());
+    EXPECT_EQ(balance->toLong(), tx->getValue()->toLong() + tx->getFees()->toLong());
     auto parsedTx = TezosLikeTransactionBuilder::parseRawUnsignedTransaction(wallet->getCurrency(), serializedTx);
     auto serializedParsedTx = parsedTx->serialize();
     EXPECT_EQ(serializedTx, serializedParsedTx);


### PR DESCRIPTION
- Originated accounts: balance and transaction history were messed up after Babylon update, now it is possible to have an operation with same `hash`, `OperationType` and `OperationTag` between Implicit and Originated accounts,
- Send max: was never taken into account