### PR TITLE
Tezos: prepend a reveal operation when needed i.e. when account is not revealed yet

### DIFF
--- a/core/idl/wallet/tezos/tezos_like_wallet.djinni
+++ b/core/idl/wallet/tezos/tezos_like_wallet.djinni
@@ -166,8 +166,9 @@ TezosConfigurationDefaults = interface +c {
   	const TEZOS_XPUB_CURVE_ED25519: string = "ED25519";
   	const TEZOS_XPUB_CURVE_SECP256K1: string = "SECP256K1";
 	# Taken from some existing XTZ wallets
+	# http://tezos.gitlab.io/protocols/005_babylon.html#gas-cost-changes
 	const TEZOS_DEFAULT_FEES: string = "2500";
-	const TEZOS_DEFAULT_GAS_LIMIT: string = "10600";
+	const TEZOS_DEFAULT_GAS_LIMIT: string = "18000";
 	const TEZOS_DEFAULT_STORAGE_LIMIT: string = "300";
 	const TEZOS_PROTOCOL_UPDATE_BABYLON: string = "TEZOS_PROTOCOL_UPDATE_BABYLON";
 }

--- a/core/idl/wallet/tezos/tezos_like_wallet.djinni
+++ b/core/idl/wallet/tezos/tezos_like_wallet.djinni
@@ -166,7 +166,7 @@ TezosConfigurationDefaults = interface +c {
   	const TEZOS_XPUB_CURVE_ED25519: string = "ED25519";
   	const TEZOS_XPUB_CURVE_SECP256K1: string = "SECP256K1";
 	# Taken from some existing XTZ wallets
-	const TEZOS_DEFAULT_FEES: string = "1420";
+	const TEZOS_DEFAULT_FEES: string = "2500";
 	const TEZOS_DEFAULT_GAS_LIMIT: string = "10600";
 	const TEZOS_DEFAULT_STORAGE_LIMIT: string = "300";
 	const TEZOS_PROTOCOL_UPDATE_BABYLON: string = "TEZOS_PROTOCOL_UPDATE_BABYLON";

--- a/core/src/api/TezosConfigurationDefaults.cpp
+++ b/core/src/api/TezosConfigurationDefaults.cpp
@@ -21,7 +21,7 @@ std::string const TezosConfigurationDefaults::TEZOS_XPUB_CURVE_ED25519 = {"ED255
 
 std::string const TezosConfigurationDefaults::TEZOS_XPUB_CURVE_SECP256K1 = {"SECP256K1"};
 
-std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_FEES = {"1420"};
+std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_FEES = {"2500"};
 
 std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_GAS_LIMIT = {"10600"};
 

--- a/core/src/api/TezosConfigurationDefaults.cpp
+++ b/core/src/api/TezosConfigurationDefaults.cpp
@@ -23,7 +23,7 @@ std::string const TezosConfigurationDefaults::TEZOS_XPUB_CURVE_SECP256K1 = {"SEC
 
 std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_FEES = {"2500"};
 
-std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_GAS_LIMIT = {"10600"};
+std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_GAS_LIMIT = {"18000"};
 
 std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_STORAGE_LIMIT = {"300"};
 

--- a/core/src/api/TezosConfigurationDefaults.hpp
+++ b/core/src/api/TezosConfigurationDefaults.hpp
@@ -35,7 +35,10 @@ public:
 
     static std::string const TEZOS_XPUB_CURVE_SECP256K1;
 
-    /** Taken from some existing XTZ wallets */
+    /**
+     * Taken from some existing XTZ wallets
+     * http://tezos.gitlab.io/protocols/005_babylon.html#gas-cost-changes
+     */
     static std::string const TEZOS_DEFAULT_FEES;
 
     static std::string const TEZOS_DEFAULT_GAS_LIMIT;

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -282,7 +282,7 @@ namespace ledger {
                                 // Check whether we need a reveal operation
                                 // We assume that accounts are synced
                                 soci::session sql(self->getWallet()->getDatabase()->getPool());
-                                // Check if a there is a send operation, otherwise we need a reveal
+                                // Check if there is a send operation, otherwise we need a reveal
                                 uint64_t count = 0;
                                 sql << "SELECT COUNT(*) FROM tezos_transactions WHERE sender = :address", use(senderAddress), into(count);
                                 tx->reveal(count == 0);

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -278,6 +278,15 @@ namespace ledger {
                                 return explorer->getCurrentBlock();
                             }).flatMapPtr<api::TezosLikeTransaction>(self->getContext(), [self, explorer, tx, senderAddress] (const std::shared_ptr<Block> &block) {
                                 tx->setBlockHash(block->hash);
+
+                                // Check whether we need a reveal operation
+                                // We assume that accounts are synced
+                                soci::session sql(self->getWallet()->getDatabase()->getPool());
+                                // Check if a there is a send operation, otherwise we need a reveal
+                                uint64_t count = 0;
+                                sql << "SELECT COUNT(*) FROM tezos_transactions WHERE sender = :address", use(senderAddress), into(count);
+                                tx->reveal(count == 0);
+
                                 if (tx->getType() == api::TezosOperationTag::OPERATION_TAG_ORIGINATION) {
                                     std::vector<TezosLikeKeychain::Address> listAddresses{self->_keychain->getAddress()};
                                     return explorer->getBalance(listAddresses).mapPtr<api::TezosLikeTransaction>(self->getContext(), [tx] (const std::shared_ptr<BigInt> &balance) {

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
@@ -63,6 +63,7 @@ namespace ledger {
             std::shared_ptr<api::Amount> getValue() override;
 
             std::vector<uint8_t> serialize() override;
+            std::vector<uint8_t> serializeWithType(api::TezosOperationTag type);
 
             std::chrono::system_clock::time_point getDate() override;
 
@@ -106,6 +107,9 @@ namespace ledger {
             std::string getManagerAddress() const;
 
             TezosLikeTransactionApi &setRawTx(const std::vector<uint8_t> &rawTx);
+
+            TezosLikeTransactionApi &reveal(bool needReveal);
+            bool toReveal() const;
         private:
             std::chrono::system_clock::time_point _time;
             std::shared_ptr<TezosLikeBlockApi> _block;
@@ -128,6 +132,7 @@ namespace ledger {
             std::string _protocolUpdate;
             std::string _managerAddress;
             std::vector<uint8_t> _rawTx;
+            bool _needReveal;
         };
     }
 }

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
@@ -73,7 +73,10 @@ namespace ledger {
                 default:
                     throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Only supported operations from originated accounts: Transaction & (Remove) of delegation.");
             }
-            //
+
+            // Increment counter if needs revelation
+            // Arf BigInts ...
+            auto counter = tx->toReveal() ? (BigInt(tx->getCounter()->toString(10)) + BigInt(1)).toString() : tx->getCounter()->toString(10);
             auto bodyString = fmt::format("{{\"branch\":\"{}\","
                                                   "\"contents\":[{{\"kind\":\"transaction\","
                                                   "\"fee\":\"{}\",\"gas_limit\":\"{}\",\"storage_limit\":\"{}\","
@@ -87,7 +90,7 @@ namespace ledger {
                                           tx->getSender()->toBase58(),
                                           params,
                                           tx->getManagerAddress(),
-                                          tx->getCounter()->toString(10)
+                                          counter
             );
             const bool parseNumbersAsString = true;
             std::unordered_map<std::string, std::string> headers{{"Content-Type", "application/json"}};


### PR DESCRIPTION
- We assume that accounts are synced before doing a send transaction,
- We consider an address not revealed if does not have any send transaction,
- When constructing a reveal operation we reuse same parameters as the ones used for Transaction, 
- We should have a better way to detect whether the pubKey is `ED25519` or `SECP256K1`,
- I bumped also fees because after Babylon update it seems that Gas Price went up (please refer to : http://tezos.gitlab.io/protocols/005_babylon.html#gas-cost-changes)

I tested with Live 🚀 : https://tzstats.com/oomRrbFEDLiGKt1EkStyqJsMcyFj67VoHsjDNBe9Ha3WfGdGb4R