### PR TITLE
Fix OperationQuery

### DIFF
--- a/core/src/database/query/QueryBuilder.cpp
+++ b/core/src/database/query/QueryBuilder.cpp
@@ -51,11 +51,15 @@ namespace ledger {
                 query << sFilter;
             }
 
-            if (_order.size() > 0) {
+            if (!_order.empty()) {
+                // Add table name in case of _outerJoins to avoid ambiguity
+                // We assume that added order is always on main table
+                const auto specifier = _outerJoins.empty() ? "" :
+                                       fmt::format("{}.", _output.empty() ? _table : _output);
                 query << " ORDER BY ";
                 for (auto it = _order.begin(); it != _order.end(); it++) {
                     auto& order = *it;
-                    query << std::get<0>(order) << (std::get<1>(order) ? " DESC" : " ASC");
+                    query << specifier << std::get<0>(order) << (std::get<1>(order) ? " DESC" : " ASC");
 
                     if (std::distance(it, _order.end()) > 1) {
                         query << ",";

--- a/core/test/integration/synchronization/ethereum_synchronization.cpp
+++ b/core/test/integration/synchronization/ethereum_synchronization.cpp
@@ -33,6 +33,7 @@
 #include <set>
 #include <api/KeychainEngines.hpp>
 #include <api/EthereumLikeTransaction.hpp>
+#include <api/OperationOrderKey.hpp>
 #include <utils/DateUtils.hpp>
 #include <wallet/ethereum/database/EthereumLikeAccountDatabaseHelper.h>
 #include <wallet/ethereum/transaction_builders/EthereumLikeTransactionBuilder.h>
@@ -100,7 +101,10 @@ TEST_F(EthereumLikeWalletSynchronization, MediumXpubSynchronization) {
                     auto transferData = wait(std::dynamic_pointer_cast<ERC20LikeAccount>(erc20Accounts[0])->getTransferToAddressData(amountToSend, "0xabf06640f8ca8fC5e0Ed471b10BeFCDf65A33e43"));
                     EXPECT_GT(transferData.size(), 0);
                     
-                    auto operations = wait(std::dynamic_pointer_cast<OperationQuery>(erc20Accounts[0]->queryOperations()->complete())->execute());
+                    auto operations = wait(std::dynamic_pointer_cast<OperationQuery>(erc20Accounts[0]
+                                                                                             ->queryOperations()
+                                                                                             ->addOrder(api::OperationOrderKey::DATE, true)
+                                                                                             ->complete())->execute());
                     std::cout << "ERC20 Operations: " << operations.size() << std::endl;
                     EXPECT_NE(operations.size(), 0);
 


### PR DESCRIPTION
When having outer joins on tables having name conflicts on column names, then adding order is throwing an error about ambiguity.