### PR TITLE
Fix tezos: fees calculation in some edge cases

### DIFF
--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -277,5 +277,11 @@ namespace ledger {
                                                                  _http);
         }
 
+        Future<std::string> ExternalTezosLikeBlockchainExplorer::getManagerKey(const std::string &address) {
+            return TezosLikeBlockchainExplorer::getManagerKey(address,
+                                                              getExplorerContext(),
+                                                              _http);
+        }
+
     }
 }

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
@@ -99,6 +99,8 @@ namespace ledger {
             Future<std::shared_ptr<BigInt>> getCounter(const std::string &address) override;
 
             Future<std::vector<uint8_t>> forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) override;
+
+            Future<std::string> getManagerKey(const std::string &address) override;
         private:
             /*
              * Helper to a get specific field's value from given url

--- a/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.cpp
@@ -274,5 +274,11 @@ namespace ledger {
                                                                  getExplorerContext(),
                                                                  _http);
         }
+
+        Future<std::string> NodeTezosLikeBlockchainExplorer::getManagerKey(const std::string &address) {
+            return TezosLikeBlockchainExplorer::getManagerKey(address,
+                                                              getExplorerContext(),
+                                                              _http);
+        }
     }
 }

--- a/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.h
@@ -97,6 +97,8 @@ namespace ledger {
 
             Future<std::vector<uint8_t>> forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) override ;
 
+            Future<std::string> getManagerKey(const std::string &address) override;
+
         private:
             /*
              * Helper to a get specific field's value from given url

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
@@ -108,5 +108,24 @@ namespace ledger {
                         return hex::toByteArray(info);
                     });
         }
+
+        Future<std::string> TezosLikeBlockchainExplorer::getManagerKey(const std::string &address,
+                                                                       const std::shared_ptr<api::ExecutionContext> &context,
+                                                                       const std::shared_ptr<HttpClient> &http) {
+            const bool parseNumbersAsString = true;
+            std::unordered_map<std::string, std::string> headers{{"Content-Type", "application/json"}};
+            return http->GET(fmt::format("/chains/main/blocks/head/context/contracts/{}/manager_key", address),
+                             std::unordered_map<std::string, std::string>{},
+                             rpcNode)
+                    .json(parseNumbersAsString)
+                    .map<std::string>(context, [](const HttpRequest::JsonResult &result) {
+                        auto &json = *std::get<1>(result);
+                        if (!json.IsString()) {
+                            // Possible if address was not revealed yet
+                            return "";
+                        }
+                        return json.GetString();
+                    });
+        }
     }
 }

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
@@ -131,6 +131,13 @@ namespace ledger {
             static Future<std::vector<uint8_t>> forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx,
                                                                  const std::shared_ptr<api::ExecutionContext> &context,
                                                                  const std::shared_ptr<HttpClient> &http);
+
+            virtual Future<std::string> getManagerKey(const std::string &address) = 0;
+            // This a helper to manage legacy KT accounts
+            // WARNING: we will only support removing delegation and transfer from KT to implicit account
+            static Future<std::string> getManagerKey(const std::string &address,
+                                                     const std::shared_ptr<api::ExecutionContext> &context,
+                                                     const std::shared_ptr<HttpClient> &http);
         };
     }
 }

--- a/core/src/wallet/tezos/explorers/api/TezosLikeTransactionParser.cpp
+++ b/core/src/wallet/tezos/explorers/api/TezosLikeTransactionParser.cpp
@@ -181,7 +181,7 @@ namespace ledger {
                 } else if (_lastKey == "sender" ||
                         (currentObject == "src" && _lastKey == "tz")) {
                     _transaction->sender = value;
-                } else if (_lastKey == "receiver" ||
+                } else if (_lastKey == "receiver" || _lastKey == "delegate" ||
                         ((currentObject == "destination" || currentObject == "delegate") && _lastKey == "tz")) {
                     _transaction->receiver = value;
                     if (_lastKey == "receiver" &&


### PR DESCRIPTION
- Fix fees when performing a send max and a reveal at same time,
- Add burned XTZs to fees when sending to unrevealed account (storage limit is considered as mXTZ to burn),
- Fix parser for Tzstats to catch delegators addresses.