### PR TITLE
Tezos Fix: revelation of sending account

### DIFF
--- a/core/src/net/HttpClient.cpp
+++ b/core/src/net/HttpClient.cpp
@@ -84,7 +84,8 @@ namespace ledger {
                                               const std::experimental::optional<std::vector<uint8_t >> body,
                                               const std::unordered_map<std::string, std::string> &headers,
                                               const std::string &baseUrl) {
-            auto url = baseUrl.empty() ? _baseUrl : baseUrl;
+            auto url = baseUrl.empty() ? _baseUrl :
+                       baseUrl.back() != '/' ? baseUrl + "/" : baseUrl;
             if (path.front() == '/') {
                 url += std::string(path.data() + 1);
             } else {

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -270,56 +270,56 @@ namespace ledger {
                                         tx->setBalance(*balance);
 
                                         // Check whether we need a reveal operation
-                                        // We assume that accounts are synced
-                                        soci::session sql(self->getWallet()->getDatabase()->getPool());
-                                        // Check if there is a send operation, otherwise we need a reveal
-                                        uint64_t count = 0;
-                                        sql << "SELECT COUNT(*) FROM tezos_transactions WHERE sender = :address", use(senderAddress), into(count);
-                                        tx->reveal(count == 0);
+                                        // Note: we can't rely on DB + sent transactions, because
+                                        // it is possible to have deleted accounts that hit 0 balance
+                                        // during Babylon update (arf ...)
+                                        return explorer->getManagerKey(senderAddress).flatMapPtr<api::TezosLikeTransaction>(self->getContext(), [=] (const std::string &managerKey) {
+                                            tx->reveal(managerKey.empty());
 
-                                        // Check for balance
-                                        // Multiply by 2 fees, since in case of reveal op, we input same fees as the ones used
-                                        // for transaction op
-                                        auto fees = burned +
-                                                    (tx->toReveal() ? *request.fees * BigInt(static_cast<unsigned long long>(2)) : *request.fees);
-                                        auto maxPossibleAmountToSend = *balance - fees;
-                                        auto amountToSend = request.wipe ? BigInt::ZERO : *request.value;
-                                        if (maxPossibleAmountToSend < amountToSend) {
-                                            throw make_exception(api::ErrorCode::NOT_ENOUGH_FUNDS, "Cannot gather enough funds.");
-                                        }
-
-                                        tx->setValue(request.wipe ? std::make_shared<BigInt>(maxPossibleAmountToSend) : request.value);
-                                        // Burned XTZs are not part of the fees
-                                        // And if we have a reveal operation, it will be doubled automatically
-                                        // since we serialize 2 ops with same fees
-                                        tx->setFees(request.fees);
-                                        tx->setGasLimit(request.gasLimit);
-                                        tx->setStorage(request.storageLimit);
-
-                                        tx->setSender(accountAddress);
-                                        tx->setReceiver(TezosLikeAddress::fromBase58(request.toAddress, currency));
-                                        tx->setSigningPubKey(self->getKeychain()->getPublicKey().getValue());
-                                        tx->setManagerAddress(managerAddress);
-                                        tx->setType(request.type);
-                                        const auto counterAddress = protocolUpdate == api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON ?
-                                                                    managerAddress : senderAddress;
-                                        return explorer->getCounter(counterAddress).flatMapPtr<Block>(self->getContext(), [self, tx, explorer] (const std::shared_ptr<BigInt> &counter) {
-                                            if (!counter) {
-                                                throw make_exception(api::ErrorCode::RUNTIME_ERROR, "Failed to retrieve counter from network.");
+                                            // Check for balance
+                                            // Multiply by 2 fees, since in case of reveal op, we input same fees as the ones used
+                                            // for transaction op
+                                            auto fees = burned +
+                                                        (tx->toReveal() ? *request.fees * BigInt(static_cast<unsigned long long>(2)) : *request.fees);
+                                            auto maxPossibleAmountToSend = *balance - fees;
+                                            auto amountToSend = request.wipe ? BigInt::ZERO : *request.value;
+                                            if (maxPossibleAmountToSend < amountToSend) {
+                                                throw make_exception(api::ErrorCode::NOT_ENOUGH_FUNDS, "Cannot gather enough funds.");
                                             }
-                                            // We should increment current counter
-                                            tx->setCounter(std::make_shared<BigInt>(++(*counter)));
-                                            return explorer->getCurrentBlock();
-                                        }).flatMapPtr<api::TezosLikeTransaction>(self->getContext(), [self, explorer, tx, senderAddress] (const std::shared_ptr<Block> &block) {
-                                            tx->setBlockHash(block->hash);
-                                            if (senderAddress.find("KT1") == 0) {
-                                                // HACK: KT Operation we use forge endpoint
-                                                return explorer->forgeKTOperation(tx).mapPtr<api::TezosLikeTransaction>(self->getContext(), [tx] (const std::vector<uint8_t> &rawTx) {
-                                                    tx->setRawTx(rawTx);
-                                                    return tx;
-                                                });
-                                            }
-                                            return FuturePtr<api::TezosLikeTransaction>::successful(tx);
+
+                                            tx->setValue(request.wipe ? std::make_shared<BigInt>(maxPossibleAmountToSend) : request.value);
+                                            // Burned XTZs are not part of the fees
+                                            // And if we have a reveal operation, it will be doubled automatically
+                                            // since we serialize 2 ops with same fees
+                                            tx->setFees(request.fees);
+                                            tx->setGasLimit(request.gasLimit);
+                                            tx->setStorage(request.storageLimit);
+
+                                            tx->setSender(accountAddress);
+                                            tx->setReceiver(TezosLikeAddress::fromBase58(request.toAddress, currency));
+                                            tx->setSigningPubKey(self->getKeychain()->getPublicKey().getValue());
+                                            tx->setManagerAddress(managerAddress);
+                                            tx->setType(request.type);
+                                            const auto counterAddress = protocolUpdate == api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON ?
+                                                                        managerAddress : senderAddress;
+                                            return explorer->getCounter(counterAddress).flatMapPtr<Block>(self->getContext(), [self, tx, explorer] (const std::shared_ptr<BigInt> &counter) {
+                                                if (!counter) {
+                                                    throw make_exception(api::ErrorCode::RUNTIME_ERROR, "Failed to retrieve counter from network.");
+                                                }
+                                                // We should increment current counter
+                                                tx->setCounter(std::make_shared<BigInt>(++(*counter)));
+                                                return explorer->getCurrentBlock();
+                                            }).flatMapPtr<api::TezosLikeTransaction>(self->getContext(), [self, explorer, tx, senderAddress] (const std::shared_ptr<Block> &block) {
+                                                tx->setBlockHash(block->hash);
+                                                if (senderAddress.find("KT1") == 0) {
+                                                    // HACK: KT Operation we use forge endpoint
+                                                    return explorer->forgeKTOperation(tx).mapPtr<api::TezosLikeTransaction>(self->getContext(), [tx] (const std::vector<uint8_t> &rawTx) {
+                                                        tx->setRawTx(rawTx);
+                                                        return tx;
+                                                    });
+                                                }
+                                                return FuturePtr<api::TezosLikeTransaction>::successful(tx);
+                                            });
                                         });
                                     });
                         });

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -243,19 +243,20 @@ namespace ledger {
                                                      "Missing mandatory informations (e.g. gasLimit, gasPrice or value).");
                             }
 
-                            // Check if recepient is revealed or not
+                            // Check if recepient is allocated or not
                             // because if not we have to add additional fees equal to storage_limit (in mXTZ)
-                            auto getRevealFee = [self, explorer, request]() -> Future<BigInt> {
+                            auto getAllocationFee = [self, explorer, request]() -> Future<BigInt> {
                                if (request.type != api::TezosOperationTag::OPERATION_TAG_TRANSACTION) {
                                    return Future<BigInt>::successful(BigInt::ZERO);
                                }
-                                return explorer->getManagerKey(request.toAddress).map<BigInt>(self->getContext(), [request] (const std::string &managerKey) -> BigInt {
+                                // So here we are looking for unallocated accounts
+                                return explorer->isAllocated(request.toAddress).map<BigInt>(self->getContext(), [request] (bool isAllocated) -> BigInt {
                                     // Base unit is uXTZ
-                                    return !managerKey.empty() ? BigInt::ZERO : *request.storageLimit * BigInt("1000");
+                                    return isAllocated ? BigInt::ZERO : *request.storageLimit * BigInt("1000");
                                 });
                             };
 
-                            return getRevealFee()
+                            return getAllocationFee()
                                     .flatMapPtr<api::TezosLikeTransaction>(self->getContext(), [=]
                                             (const BigInt &burned) {
                                         auto managerAddress = self->getKeychain()->getAddress()->toString();
@@ -273,9 +274,20 @@ namespace ledger {
                                         // Note: we can't rely on DB + sent transactions, because
                                         // it is possible to have deleted accounts that hit 0 balance
                                         // during Babylon update (arf ...)
-                                        return explorer->getManagerKey(senderAddress).flatMapPtr<api::TezosLikeTransaction>(self->getContext(), [=] (const std::string &managerKey) {
-                                            tx->reveal(managerKey.empty());
+                                        auto setRevealStatus = [self, explorer, tx, senderAddress]() {
+                                            if (senderAddress.find("KT1") == 0) {
+                                                // No revelation anymore for KT accounts
+                                                tx->reveal(false);
+                                                return Future<Unit>::successful(unit);
+                                            }
+                                            // So here we are looking for unallocated accounts
+                                            return explorer->getManagerKey(senderAddress).map<Unit>(self->getContext(), [tx] (const std::string &managerKey) -> Unit {
+                                                tx->reveal(managerKey.empty());
+                                                return unit;
+                                            });
+                                        };
 
+                                        return setRevealStatus().flatMapPtr<api::TezosLikeTransaction>(self->getContext(), [=] (const Unit &result) {
                                             // Check for balance
                                             // Multiply by 2 fees, since in case of reveal op, we input same fees as the ones used
                                             // for transaction op

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -283,5 +283,12 @@ namespace ledger {
                                                               getRPCNodeEndpoint());
         }
 
+        Future<bool> ExternalTezosLikeBlockchainExplorer::isAllocated(const std::string &address) {
+            return TezosLikeBlockchainExplorer::isAllocated(address,
+                                                            getExplorerContext(),
+                                                            _http,
+                                                            getRPCNodeEndpoint());
+        }
+
     }
 }

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
@@ -101,6 +101,8 @@ namespace ledger {
             Future<std::vector<uint8_t>> forgeKTOperation(const std::shared_ptr<TezosLikeTransactionApi> &tx) override;
 
             Future<std::string> getManagerKey(const std::string &address) override;
+
+            Future<bool> isAllocated(const std::string &address) override;
         private:
             /*
              * Helper to a get specific field's value from given url

--- a/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.cpp
@@ -282,5 +282,12 @@ namespace ledger {
                                                               _http,
                                                               getRPCNodeEndpoint());
         }
+
+        Future<bool> NodeTezosLikeBlockchainExplorer::isAllocated(const std::string &address) {
+            return TezosLikeBlockchainExplorer::isAllocated(address,
+                                                            getExplorerContext(),
+                                                            _http,
+                                                            getRPCNodeEndpoint());
+        }
     }
 }

--- a/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.h
@@ -99,6 +99,8 @@ namespace ledger {
 
             Future<std::string> getManagerKey(const std::string &address) override;
 
+            Future<bool> isAllocated(const std::string &address) override;
+
         private:
             /*
              * Helper to a get specific field's value from given url

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
@@ -135,5 +135,22 @@ namespace ledger {
                         return "";
                     });
         }
+
+        Future<bool> TezosLikeBlockchainExplorer::isAllocated(const std::string &address,
+                                                              const std::shared_ptr<api::ExecutionContext> &context,
+                                                              const std::shared_ptr<HttpClient> &http,
+                                                              const std::string &rpcNode) {
+            const bool parseNumbersAsString = true;
+            std::unordered_map<std::string, std::string> headers{{"Content-Type", "application/json"}};
+            return http->GET(fmt::format("/chains/main/blocks/head/context/contracts/{}", address),
+                             std::unordered_map<std::string, std::string>{},
+                             rpcNode)
+                    .json(parseNumbersAsString)
+                    .map<bool>(context, [](const HttpRequest::JsonResult &result) {
+                       return true;
+                    }).recover(context, [] (const Exception &exception) {
+                        return false;
+                    });
+        }
     }
 }

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
@@ -130,6 +130,9 @@ namespace ledger {
                             return "";
                         }
                         return json.GetString();
+                    }).recover(context, [] (const Exception &exception) {
+                        // for KT we got an 404 instead of just a null value as we would expect
+                        return "";
                     });
         }
     }

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
@@ -144,6 +144,12 @@ namespace ledger {
                                                      const std::shared_ptr<HttpClient> &http,
                                                      const std::string &rpcNode);
 
+            virtual Future<bool> isAllocated(const std::string &address) = 0;
+            static Future<bool> isAllocated(const std::string &address,
+                                            const std::shared_ptr<api::ExecutionContext> &context,
+                                            const std::shared_ptr<HttpClient> &http,
+                                            const std::string &rpcNode);
+
         protected:
             std::string getRPCNodeEndpoint() const {
                 return _rpcNode;


### PR DESCRIPTION
- Check `manager_key` instead of relying on number of outgoing ops from an address to check revelation, because it seems that an account could be revealed, send transactions but still unrevealed (... black magic),
- Introduce concept of `unallocated` accounts to know if we should burn XTZs or not when sending tokens,
- Avoid check of revelation on `KT` accounts, since no revelation is required for KT accounts since Babylon update.