### PR TITLE
(Re)add Blake 

### DIFF
--- a/ledger-core/inc/core/crypto/DeterministicPublicKey.hpp
+++ b/ledger-core/inc/core/crypto/DeterministicPublicKey.hpp
@@ -53,6 +53,7 @@ namespace ledger {
             std::vector<uint8_t> getUncompressedPublicKey() const;
             std::vector<uint8_t> getPublicKeyHash160() const;
             std::vector<uint8_t> getPublicKeyKeccak256() const;
+            std::vector<uint8_t> getPublicKeyBlake2b(bool isED25519) const;
             std::vector<uint8_t> toByteArray(const std::vector<uint8_t>& version = {}) const;
         public:
 


### PR DESCRIPTION
This PR just adds the missing definition of `getPublicKeyBlake2b`.

## Mandatory picture of a sorry animal
![sorry_dog](https://user-images.githubusercontent.com/6042495/69350347-b2e2b700-0c79-11ea-9901-94d37dad6f9d.gif)
