### PR TITLE
Fix ops from KT account with an unrevealed manager account

### DIFF
--- a/core/idl/tezos/addresses.djinni
+++ b/core/idl/tezos/addresses.djinni
@@ -3,6 +3,7 @@
 TezosCurve = enum {
 	ed25519;
 	secp256k1;
+	p256;
 }
 
 TezosLikeNetworkParameters = record {

--- a/core/idl/wallet/tezos/tezos_like_wallet.djinni
+++ b/core/idl/wallet/tezos/tezos_like_wallet.djinni
@@ -169,6 +169,7 @@ TezosConfigurationDefaults = interface +c {
 	const TEZOS_OBSERVER_WS_ENDPOINT_S3: string = "wss://s3.tezos.com";
   	const TEZOS_XPUB_CURVE_ED25519: string = "ED25519";
   	const TEZOS_XPUB_CURVE_SECP256K1: string = "SECP256K1";
+	const TEZOS_XPUB_CURVE_P256: string = "P256";
 	# Taken from some existing XTZ wallets
 	# http://tezos.gitlab.io/protocols/005_babylon.html#gas-cost-changes
 	const TEZOS_DEFAULT_FEES: string = "2500";

--- a/core/src/api/TezosConfigurationDefaults.cpp
+++ b/core/src/api/TezosConfigurationDefaults.cpp
@@ -23,6 +23,8 @@ std::string const TezosConfigurationDefaults::TEZOS_XPUB_CURVE_ED25519 = {"ED255
 
 std::string const TezosConfigurationDefaults::TEZOS_XPUB_CURVE_SECP256K1 = {"SECP256K1"};
 
+std::string const TezosConfigurationDefaults::TEZOS_XPUB_CURVE_P256 = {"P256"};
+
 std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_FEES = {"2500"};
 
 std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_GAS_LIMIT = {"18000"};

--- a/core/src/api/TezosConfigurationDefaults.hpp
+++ b/core/src/api/TezosConfigurationDefaults.hpp
@@ -37,6 +37,8 @@ public:
 
     static std::string const TEZOS_XPUB_CURVE_SECP256K1;
 
+    static std::string const TEZOS_XPUB_CURVE_P256;
+
     /**
      * Taken from some existing XTZ wallets
      * http://tezos.gitlab.io/protocols/005_babylon.html#gas-cost-changes

--- a/core/src/api/TezosCurve.cpp
+++ b/core/src/api/TezosCurve.cpp
@@ -10,12 +10,14 @@ std::string to_string(const TezosCurve& tezosCurve) {
     switch (tezosCurve) {
         case TezosCurve::ED25519: return "ED25519";
         case TezosCurve::SECP256K1: return "SECP256K1";
+        case TezosCurve::P256: return "P256";
     };
 };
 template <>
 TezosCurve from_string(const std::string& tezosCurve) {
     if (tezosCurve == "ED25519") return TezosCurve::ED25519;
-    else return TezosCurve::SECP256K1;
+    else if (tezosCurve == "SECP256K1") return TezosCurve::SECP256K1;
+    else return TezosCurve::P256;
 };
 
 std::ostream &operator<<(std::ostream &os, const TezosCurve &o)
@@ -23,6 +25,7 @@ std::ostream &operator<<(std::ostream &os, const TezosCurve &o)
     switch (o) {
         case TezosCurve::ED25519:  return os << "ED25519";
         case TezosCurve::SECP256K1:  return os << "SECP256K1";
+        case TezosCurve::P256:  return os << "P256";
     }
 }
 

--- a/core/src/api/TezosCurve.hpp
+++ b/core/src/api/TezosCurve.hpp
@@ -20,6 +20,7 @@ namespace ledger { namespace core { namespace api {
 enum class TezosCurve : int {
     ED25519,
     SECP256K1,
+    P256,
 };
 LIBCORE_EXPORT  std::string to_string(const TezosCurve& tezosCurve);
 LIBCORE_EXPORT  std::ostream &operator<<(std::ostream &os, const TezosCurve &o);

--- a/core/src/tezos/TezosLikeAddress.cpp
+++ b/core/src/tezos/TezosLikeAddress.cpp
@@ -55,8 +55,8 @@ namespace ledger {
                                            api::TezosCurve curve,
                                            const Option<std::string> &derivationPath) :
                 TezosLikeAddress(currency,
-                                 BLAKE::blake2b(pubKey, 20, static_cast<size_t>(curve != api::TezosCurve::ED25519)),
-                                 version,
+                                 getPublicKeyHash160(pubKey, curve),
+                                 getPrefixFromImplicitVersion(version, curve),
                                  derivationPath)
         {}
         std::vector<uint8_t> TezosLikeAddress::getVersion() {
@@ -118,6 +118,44 @@ namespace ledger {
                 version = std::vector<uint8_t>(value.begin(), value.end() - 20);
             }
             return std::make_shared<ledger::core::TezosLikeAddress>(currency, hash160, version, derivationPath);
+        }
+
+        std::vector<uint8_t> TezosLikeAddress::getPublicKeyHash160(const std::vector<uint8_t> &pubKey,
+                                                                   api::TezosCurve curve) {
+            auto result = vector::concat(
+                    std::vector<uint8_t>{static_cast<uint8_t>(0x02 + (pubKey[64] & 0x01))},
+                    std::vector<uint8_t>{pubKey.begin() + 1, pubKey.begin() + 33}
+            );
+            auto sRes = hex::toString(result);
+            switch (curve) {
+                case api::TezosCurve::ED25519 :
+                    if (pubKey.size() != 33) {
+                        throw Exception(api::ErrorCode::INVALID_ARGUMENT, "Invalid ED25519 public key: should be 33 bytes.");
+                    }
+                    return BLAKE::blake2b(std::vector<uint8_t>{pubKey.begin() + 1, pubKey.end()}, 20);
+                default :
+                    if (pubKey.size() != 65) {
+                        throw Exception(api::ErrorCode::INVALID_ARGUMENT, "Invalid SECP256k1 or P256 public key: should be 65 bytes.");
+                    }
+                    return BLAKE::blake2b(
+                            vector::concat(
+                                    std::vector<uint8_t>{static_cast<uint8_t>(0x02 + (pubKey[64] & 0x01))},
+                                    std::vector<uint8_t>{pubKey.begin() + 1, pubKey.begin() + 33}
+                            ),
+                            20);
+            }
+        }
+
+        std::vector<uint8_t> TezosLikeAddress::getPrefixFromImplicitVersion(const std::vector<uint8_t> &implicitVersion,
+                                                                            api::TezosCurve curve) {
+            return vector::concat(
+                    std::vector<uint8_t>{implicitVersion.begin(), implicitVersion.end() - 1},
+                    std::vector<uint8_t>{static_cast<uint8_t>(implicitVersion.back() + static_cast<uint8_t>(
+                            curve == api::TezosCurve::SECP256K1 ? 2 :
+                            curve == api::TezosCurve::P256 ? 5 :
+                            0)
+                    )}
+            );
         }
     }
 }

--- a/core/src/tezos/TezosLikeAddress.h
+++ b/core/src/tezos/TezosLikeAddress.h
@@ -72,7 +72,9 @@ namespace ledger {
                                                                 const api::Currency &currency,
                                                                 const Option<std::string> &derivationPath = Option<std::string>());
 
+            static std::vector<uint8_t> getPrefixFromImplicitVersion(const std::vector<uint8_t> &implicitVersion, api::TezosCurve curve);
         private:
+            static std::vector<uint8_t> getPublicKeyHash160(const std::vector<uint8_t> &pubKey, api::TezosCurve curve);
             const std::vector<uint8_t> _hash160;
             const std::vector<uint8_t> _version;
             const api::TezosLikeNetworkParameters _params;

--- a/core/src/tezos/TezosLikeExtendedPublicKey.cpp
+++ b/core/src/tezos/TezosLikeExtendedPublicKey.cpp
@@ -98,9 +98,7 @@ namespace ledger {
                                             api::TezosCurve curve)
         {
             auto &params = currency.tezosLikeNetworkParameters.value();
-            DeterministicPublicKey k = curve == api::TezosCurve::ED25519 ?
-                                       DeterministicPublicKey(publicKey, chainCode, 0, 0, 0, params.Identifier) :
-                                       TezosExtendedPublicKey::fromRaw(currency, params, parentPublicKey, publicKey, chainCode, path);
+            DeterministicPublicKey k = DeterministicPublicKey(publicKey, chainCode, 0, 0, 0, params.Identifier);
             return std::make_shared<TezosLikeExtendedPublicKey>(currency, k, curve, DerivationPath(path));
         }
 
@@ -114,14 +112,14 @@ namespace ledger {
                 auto decodeResult = Base58::checkAndDecode(xpubBase58, config);
 
                 BytesReader reader(decodeResult.getValue());
-                auto version = reader.read(4);
+                auto version = reader.read(3);
                 auto publicKey = reader.readUntilEnd();
 
                 DeterministicPublicKey k(publicKey, {}, 0, 0, 0, params.Identifier);
                 return std::make_shared<ledger::core::TezosLikeExtendedPublicKey>(currency, k, api::TezosCurve::ED25519, DerivationPath(path.getValueOr("m")));
             }
             DeterministicPublicKey k = TezosExtendedPublicKey::fromBase58(currency, params, xpubBase58, path);
-            return std::make_shared<ledger::core::TezosLikeExtendedPublicKey>(currency, k, api::TezosCurve::SECP256K1, DerivationPath(path.getValueOr("m")));
+            return std::make_shared<ledger::core::TezosLikeExtendedPublicKey>(currency, k, k.getPublicKey().size() == 33 ? api::TezosCurve::ED25519 : api::TezosCurve::SECP256K1, DerivationPath(path.getValueOr("m")));
         }
 
     }

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -274,14 +274,9 @@ namespace ledger {
                                         // Note: we can't rely on DB + sent transactions, because
                                         // it is possible to have deleted accounts that hit 0 balance
                                         // during Babylon update (arf ...)
-                                        auto setRevealStatus = [self, explorer, tx, senderAddress]() {
-                                            if (senderAddress.find("KT1") == 0) {
-                                                // No revelation anymore for KT accounts
-                                                tx->reveal(false);
-                                                return Future<Unit>::successful(unit);
-                                            }
+                                        auto setRevealStatus = [self, explorer, tx, senderAddress, managerAddress]() {
                                             // So here we are looking for unallocated accounts
-                                            return explorer->getManagerKey(senderAddress).map<Unit>(self->getContext(), [tx] (const std::string &managerKey) -> Unit {
+                                            return explorer->getManagerKey(senderAddress.find("KT1") == 0 ? managerAddress : senderAddress).map<Unit>(self->getContext(), [tx] (const std::string &managerKey) -> Unit {
                                                 tx->reveal(managerKey.empty());
                                                 return unit;
                                             });
@@ -335,7 +330,11 @@ namespace ledger {
                                             }
                                             tx->setReceiver(TezosLikeAddress::fromBase58(request.toAddress, currency), getCurveHelper(receiverCurve));
                                             tx->setSigningPubKey(self->getKeychain()->getPublicKey().getValue());
-                                            tx->setManagerAddress(managerAddress);
+                                            tx->setManagerAddress(managerAddress,
+                                                                  getCurveHelper(
+                                                                          self->getKeychain()->getConfiguration()
+                                                                          ->getString(api::TezosConfiguration::TEZOS_XPUB_CURVE)
+                                                                          .value_or(api::TezosConfigurationDefaults::TEZOS_XPUB_CURVE_ED25519)));
                                             tx->setType(request.type);
                                             const auto counterAddress = protocolUpdate == api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON ?
                                                                         managerAddress : senderAddress;

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
@@ -105,7 +105,7 @@ namespace ledger {
 
             TezosLikeTransactionApi & setBalance(const BigInt &balance);
 
-            TezosLikeTransactionApi & setManagerAddress(const std::string &managerAddress);
+            TezosLikeTransactionApi & setManagerAddress(const std::string &managerAddress, api::TezosCurve curve);
             std::string getManagerAddress() const;
 
             TezosLikeTransactionApi &setRawTx(const std::vector<uint8_t> &rawTx);
@@ -133,6 +133,7 @@ namespace ledger {
             BigInt _balance;
             std::string _protocolUpdate;
             std::string _managerAddress;
+            api::TezosCurve _managerCurve;
             std::vector<uint8_t> _rawTx;
             bool _needReveal;
             int32_t _status;

--- a/core/src/wallet/tezos/keychains/TezosLikeKeychain.cpp
+++ b/core/src/wallet/tezos/keychains/TezosLikeKeychain.cpp
@@ -94,6 +94,8 @@ namespace ledger {
                 curve = api::TezosCurve::ED25519;
             } else if (curveConfig == api::TezosConfigurationDefaults::TEZOS_XPUB_CURVE_SECP256K1) {
                 curve = api::TezosCurve::SECP256K1;
+            } else if (curveConfig == api::TezosConfigurationDefaults::TEZOS_XPUB_CURVE_P256) {
+                curve = api::TezosCurve::P256;
             } else {
                 throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Could not retrieve address from public key : unknown Tezos Curve");
             }

--- a/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.cpp
+++ b/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.cpp
@@ -186,7 +186,7 @@ namespace ledger {
                 auto senderCurveCode = reader.readNextByte();
                 // then hash160 ...
                 senderHash160 = reader.read(20);
-                version = params.ImplicitPrefix;
+                version = TezosLikeAddress::getPrefixFromImplicitVersion(params.ImplicitPrefix, api::TezosCurve(senderCurveCode));
             } else {
                 auto isSenderOriginated = reader.readNextByte();
                 if (isSenderOriginated) {
@@ -194,13 +194,14 @@ namespace ledger {
                     senderHash160 = reader.read(20);
                     // ... and padding
                     reader.readNextByte();
+                    version = params.OriginatedPrefix;
                 } else {
                     // Otherwise first curve code ...
                     auto senderCurveCode = reader.readNextByte();
                     // then hash160 ...
                     senderHash160 = reader.read(20);
+                    version = TezosLikeAddress::getPrefixFromImplicitVersion(params.ImplicitPrefix, api::TezosCurve(senderCurveCode));
                 }
-                version = isSenderOriginated ? params.OriginatedPrefix : params.ImplicitPrefix;
             }
             tx->setSender(std::make_shared<TezosLikeAddress>(currency,
                                                              senderHash160,
@@ -256,13 +257,14 @@ namespace ledger {
                         auto receiverCurveCode = reader.readNextByte();
                         // 20 bytes of publicKey hash
                         receiverHash160 = reader.read(20);
+                        receiverVersion = TezosLikeAddress::getPrefixFromImplicitVersion(params.ImplicitPrefix, api::TezosCurve(receiverCurveCode));
                     } else {
                         // 20 bytes of publicKey hash
                         receiverHash160 = reader.read(20);
                         // Padding
                         reader.readNextByte();
+                        receiverVersion = params.OriginatedPrefix;
                     }
-                    receiverVersion = isReceiverOriginated ? params.OriginatedPrefix : params.ImplicitPrefix;
 
                     tx->setReceiver(std::make_shared<TezosLikeAddress>(currency,
                                                                        receiverHash160,
@@ -307,7 +309,10 @@ namespace ledger {
                         auto delegateHash160 = reader.read(20);
                         tx->setReceiver(std::make_shared<TezosLikeAddress>(currency,
                                                                            delegateHash160,
-                                                                           params.ImplicitPrefix, // can't delegate to originated account (TBC)
+                                                                           TezosLikeAddress::getPrefixFromImplicitVersion(
+                                                                                   params.ImplicitPrefix,
+                                                                                   api::TezosCurve(delegateCurveCode)
+                                                                           ), // can't delegate to originated account (TBC)
                                                                            Option<std::string>()));
                     }
                     break;

--- a/core/test/integration/synchronization/tezos_synchronization.cpp
+++ b/core/test/integration/synchronization/tezos_synchronization.cpp
@@ -54,7 +54,7 @@ TEST_F(TezosLikeWalletSynchronization, MediumXpubSynchronization) {
     {
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"44'/<coin_type>'/<account>'/<node>'/<address>");
-        configuration->putString(api::TezosConfiguration::TEZOS_XPUB_CURVE, api::TezosConfigurationDefaults::TEZOS_XPUB_CURVE_SECP256K1);
+        configuration->putString(api::TezosConfiguration::TEZOS_XPUB_CURVE, api::TezosConfigurationDefaults::TEZOS_XPUB_CURVE_ED25519);
         configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, api::BlockchainExplorerEngines::TZSTATS_API);
         auto wallet = wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "tezos", configuration));
         std::set<std::string> emittedOperations;

--- a/core/test/integration/transactions/tezos_transaction_tests.cpp
+++ b/core/test/integration/transactions/tezos_transaction_tests.cpp
@@ -48,7 +48,7 @@ struct TezosMakeTransaction : public TezosMakeBaseTransaction {
     void SetUpConfig() override {
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, api::BlockchainExplorerEngines::TZSTATS_API);
-        configuration->putString(api::TezosConfiguration::TEZOS_XPUB_CURVE, api::TezosConfigurationDefaults::TEZOS_XPUB_CURVE_SECP256K1);
+        configuration->putString(api::TezosConfiguration::TEZOS_XPUB_CURVE, api::TezosConfigurationDefaults::TEZOS_XPUB_CURVE_ED25519);
         testData.configuration = configuration;
         testData.walletName = "my_wallet";
         testData.currencyName = "tezos";

--- a/core/test/tezos/address_test.cpp
+++ b/core/test/tezos/address_test.cpp
@@ -47,7 +47,7 @@
 using namespace ledger::core::api;
 using namespace ledger::core;
 
-TEST(TezosAddress, AddressFromEd25519PubKey) {
+TEST(TezosAddress, AddressFromBase58Ed25519PubKey) {
     // Decode a pubKey prefixed with edpk
     // 451bde832454ba73e6e0de313fcf5d1565ec51080edc73bb19287b8e0ab2122b
     auto expectedResult = "tz1dtmCcU7Ng29oWrEc5xJcrQfMnKgoqT7mn";
@@ -56,15 +56,27 @@ TEST(TezosAddress, AddressFromEd25519PubKey) {
     EXPECT_EQ(zPub->derive("")->toBase58(), expectedResult);
 }
 
-TEST(TezosAddress, AddressFromEd25519PublicKey) {
+TEST(TezosAddress, AddressFromBase58Ed25519PublicKey) {
     // Decode a pubKey prefixed with edpk
     auto xpub = "edpkuySiX9Qi89G5aRaynPxLMqtrrjsMGZAGCUn7u2kBgYH5uxCwEy";
     auto zPub = ledger::core::TezosLikeExtendedPublicKey::fromBase58(currencies::TEZOS, xpub, Option<std::string>("44'/1729'/0'/0'"));
     EXPECT_EQ(zPub->derive("")->toBase58(), "tz1cmN7N6rV9ULVqbL2BxSUZgeL5wnWyoBUE");
 }
 
+TEST(TezosAddress, AddressFromEd25519PubKey) {
+    std::vector<uint8_t> pubKey = hex::toByteArray("0294e8344ae6df2d3123fa100b5abd40cee339c67838b1c34c4f243cc582f4d2d8");
+    std::vector<uint8_t> chainCode = hex::toByteArray("");
+    auto zPub = ledger::core::TezosLikeExtendedPublicKey::fromRaw(currencies::TEZOS,
+                                                                  optional<std::vector<uint8_t >>(),
+                                                                  pubKey,
+                                                                  chainCode,
+                                                                  "44'/1729'/0'/0'",
+                                                                  api::TezosCurve::ED25519);
+    EXPECT_EQ(zPub->derive("")->toBase58(), "tz1T72nyqnJWwxad6RQnh7imKQz7mzToamWd");
+}
+
 TEST(TezosAddress, AddressFromSecp256k1PubKey) {
-    std::vector<uint8_t> pubKey = hex::toByteArray("02af5696511e23b9e3dc5a527abc6929fae708defb5299f96cfa7dd9f936fe747d");
+    std::vector<uint8_t> pubKey = hex::toByteArray("04cc854703a4397e9a649c6b4c6579973ed6b4ed82b982b0c848373a6c37d7f7bbad1997fb396b4b43b4676aee45cc32a72ff8221702200fc975a4ecc1e94123f4");
     std::vector<uint8_t> chainCode = hex::toByteArray("");
     auto zPub = ledger::core::TezosLikeExtendedPublicKey::fromRaw(currencies::TEZOS,
                                                                   optional<std::vector<uint8_t >>(),
@@ -72,12 +84,25 @@ TEST(TezosAddress, AddressFromSecp256k1PubKey) {
                                                                   chainCode,
                                                                   "44'/1729'/0'/0'",
                                                                   api::TezosCurve::SECP256K1);
-    EXPECT_EQ(zPub->derive("")->toBase58(), "tz1cmN7N6rV9ULVqbL2BxSUZgeL5wnWyoBUE");
+    EXPECT_EQ(zPub->derive("")->toBase58(), "tz2RSZ2uCTovM59DbSan56mFdg943eWvTDH5");
+}
+
+TEST(TezosAddress, AddressFromP256PubKey) {
+    std::vector<uint8_t> pubKey = hex::toByteArray("04b76ff06f214e86bc1e1bf15940a9209d442c5c3ab2b6f259574f3405937295984ff1d400418534b47679dd377720eba32f9dfadab2e4d497e84f96558fd621e7");
+    std::vector<uint8_t> chainCode = hex::toByteArray("");
+    auto zPub = ledger::core::TezosLikeExtendedPublicKey::fromRaw(currencies::TEZOS,
+                                                                  optional<std::vector<uint8_t >>(),
+                                                                  pubKey,
+                                                                  chainCode,
+                                                                  "44'/1729'/0'/0'",
+                                                                  api::TezosCurve::P256);
+    EXPECT_EQ(zPub->derive("")->toBase58(), "tz3VM1H8KUcgw1mE6iQA6UzDfb5r6smV3oWs");
 }
 
 TEST(TezosAddress, XpubFromBase58String) {
     auto addr = "xpub6DECL9NX5hvkRrq98MRvXCjTP8s84NZUFReEVLizQMVH8epXyoMvncB9DG4d8kY94XPVYqFWtUVaaagZkXvje4AUF3qdd71fJc8KyhRRC8V";
-    auto xpub = ledger::core::TezosLikeExtendedPublicKey::fromBase58(currencies::TEZOS, addr,
+    auto xpub = ledger::core::TezosLikeExtendedPublicKey::fromBase58(currencies::TEZOS,
+                                                                     addr,
                                                                      optional<std::string>("44'/1729'/0'"));
     EXPECT_EQ(xpub->toBase58(), addr);
     EXPECT_EQ(xpub->derive("0/0")->toBase58(), "tz1hQ2ZpmNfiUuRf28yUJqNteVwX7fXWbmvk");


### PR DESCRIPTION
After Babylon update, actions from `KT` accounts are actions from `tz` to a smart contract, the thing is that if a `tz` account goes to `0` balance, it gets deallocated, so it needs revelation again (SFYL), so now when we have a `tz` account (that has been emptied at some point) and then we try to make ops from its `KT` account we got stuck because the parent need revelation and from our side we considered that `KT` accounts don't need revelation (after Babylon update).
To sum up, now when we do an op from `KT` account we check revelation status of the manager account.