### PR TITLE
Fix remaning issues with Tezos 

### DIFF
--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -249,11 +249,20 @@ namespace ledger {
                                if (request.type != api::TezosOperationTag::OPERATION_TAG_TRANSACTION) {
                                    return Future<BigInt>::successful(BigInt::ZERO);
                                }
+                                // FIXME: this is a workaround by the time the nodes are fixed
                                 // So here we are looking for unallocated accounts
+                                return explorer->getTransactions(std::vector<std::string>{request.toAddress}).map<BigInt>(self->getContext(), [request] (const std::shared_ptr<TezosLikeBlockchainExplorer::TransactionsBulk> &txBulk) {
+                                    // Base unit is uXTZ
+                                    return (txBulk && !txBulk->transactions.empty()) ? BigInt::ZERO : *request.storageLimit * BigInt("1000");
+                                });
+
+                                /*
+                                 * Once /chains/main/blocks/head/context/contracts/<contract_id> fixed we should use this one
                                 return explorer->isAllocated(request.toAddress).map<BigInt>(self->getContext(), [request] (bool isAllocated) -> BigInt {
                                     // Base unit is uXTZ
                                     return isAllocated ? BigInt::ZERO : *request.storageLimit * BigInt("1000");
                                 });
+                                 */
                             };
 
                             return getAllocationFee()

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
@@ -256,7 +256,9 @@ namespace ledger {
             writer.writeByteArray(zarith::zSerializeNumber(bigIntGasLimit.toByteArray()));
 
             // Storage Limit
-            writer.writeByteArray(zarith::zSerializeNumber(_storage->toByteArray()));
+            // No sotrage for reveal
+            auto storage = type == api::TezosOperationTag::OPERATION_TAG_REVEAL ? std::vector<uint8_t>{0} : _storage->toByteArray();
+            writer.writeByteArray(zarith::zSerializeNumber(storage));
 
             switch(type) {
                 case api::TezosOperationTag::OPERATION_TAG_REVEAL: {

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
@@ -163,27 +163,33 @@ namespace ledger {
                 writer.writeByte(static_cast<uint8_t>(api::TezosOperationTag::OPERATION_TAG_GENERIC));
             }
 
+            // Block Hash
+            auto params = _currency.tezosLikeNetworkParameters.value_or(networks::getTezosLikeNetworkParameters("tezos"));
+            auto config = std::make_shared<DynamicObject>();
+            config->putString("networkIdentifier", params.Identifier);
+            auto decoded = Base58::checkAndDecode(_block->getHash(), config);
+            // Remove 2 first bytes (of version)
+            auto blockHash = std::vector<uint8_t>{decoded.getValue().begin() + 2, decoded.getValue().end()};
+            
             // If tx was forged then nothing to do
             if (!_rawTx.empty()) {
-                writer.writeByteArray(_rawTx);
                 // If we need reveal, then we must prepend it
                 if (_needReveal) {
+                    writer.writeByteArray(blockHash);
                     writer.writeByteArray(serializeWithType(api::TezosOperationTag::OPERATION_TAG_REVEAL));
+                    // Remove branch since it's already added
+                    writer.writeByteArray(std::vector<uint8_t>{_rawTx.begin() + blockHash.size(), _rawTx.end()});
+                } else {
+                    writer.writeByteArray(_rawTx);
                 }
+
                 if (!_signature.empty()) {
                     writer.writeByteArray(_signature);
                 }
                 return writer.toByteArray();
             }
 
-            // Block Hash
-            auto params = _currency.tezosLikeNetworkParameters.value_or(networks::getTezosLikeNetworkParameters("tezos"));
-            auto config = std::make_shared<DynamicObject>();
-            config->putString("networkIdentifier", params.Identifier);
-            auto decoded = Base58::checkAndDecode(_block->getHash(), config);
-            auto blockHash = decoded.getValue();
-            // Remove 2 first bytes (of version)
-            writer.writeByteArray(std::vector<uint8_t>{blockHash.begin() + 2, blockHash.end()});
+            writer.writeByteArray(blockHash);
 
             // If we need reveal, then we must prepend it
             if (_needReveal) {

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
@@ -256,7 +256,7 @@ namespace ledger {
             writer.writeByteArray(zarith::zSerializeNumber(bigIntGasLimit.toByteArray()));
 
             // Storage Limit
-            // No sotrage for reveal
+            // No storage for reveal
             auto storage = type == api::TezosOperationTag::OPERATION_TAG_REVEAL ? std::vector<uint8_t>{0} : _storage->toByteArray();
             writer.writeByteArray(zarith::zSerializeNumber(storage));
 


### PR DESCRIPTION
- Fix send from KT when tz parent account in unrevealed: The issue was that we should have prepend the revelation instead of appending it to the send operation.
This was tested with latest CLI of Live: https://tzstats.com/oora48f1jbqPsR6AMe7vM8SopgR9gWwby4aeBQoDGt6zLfY5MFB 🚀 
- Fix check of unallocated accounts: we use to rely on `/chains/main/blocks/head/context/contracts/<contract_id>` which is the right way to do it, but since XTZ nodes are buggy on that same endpoint, I implement a workaround, which is checking if a the account has a tx history,
- Set storage to `0` for reveal operations