### PR TITLE
Tezos fees fixes

### DIFF
--- a/core/idl/wallet/tezos/tezos_like_wallet.djinni
+++ b/core/idl/wallet/tezos/tezos_like_wallet.djinni
@@ -172,7 +172,7 @@ TezosConfigurationDefaults = interface +c {
 	const TEZOS_XPUB_CURVE_P256: string = "P256";
 	# Taken from some existing XTZ wallets
 	# http://tezos.gitlab.io/protocols/005_babylon.html#gas-cost-changes
-	const TEZOS_DEFAULT_FEES: string = "2500";
+	const TEZOS_DEFAULT_FEES: string = "5000";
 	const TEZOS_DEFAULT_GAS_LIMIT: string = "18000";
 	const TEZOS_DEFAULT_STORAGE_LIMIT: string = "300";
 	const TEZOS_PROTOCOL_UPDATE_BABYLON: string = "TEZOS_PROTOCOL_UPDATE_BABYLON";

--- a/core/idl/wallet/tezos/tezos_like_wallet.djinni
+++ b/core/idl/wallet/tezos/tezos_like_wallet.djinni
@@ -173,6 +173,7 @@ TezosConfigurationDefaults = interface +c {
 	# Taken from some existing XTZ wallets
 	# http://tezos.gitlab.io/protocols/005_babylon.html#gas-cost-changes
 	const TEZOS_DEFAULT_FEES: string = "5000";
+	const TEZOS_DEFAULT_MAX_FEES: string = "30000";
 	const TEZOS_DEFAULT_GAS_LIMIT: string = "18000";
 	const TEZOS_DEFAULT_STORAGE_LIMIT: string = "300";
 	const TEZOS_PROTOCOL_UPDATE_BABYLON: string = "TEZOS_PROTOCOL_UPDATE_BABYLON";

--- a/core/src/api/TezosConfigurationDefaults.cpp
+++ b/core/src/api/TezosConfigurationDefaults.cpp
@@ -25,7 +25,7 @@ std::string const TezosConfigurationDefaults::TEZOS_XPUB_CURVE_SECP256K1 = {"SEC
 
 std::string const TezosConfigurationDefaults::TEZOS_XPUB_CURVE_P256 = {"P256"};
 
-std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_FEES = {"2500"};
+std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_FEES = {"5000"};
 
 std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_GAS_LIMIT = {"18000"};
 

--- a/core/src/api/TezosConfigurationDefaults.cpp
+++ b/core/src/api/TezosConfigurationDefaults.cpp
@@ -27,6 +27,8 @@ std::string const TezosConfigurationDefaults::TEZOS_XPUB_CURVE_P256 = {"P256"};
 
 std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_FEES = {"5000"};
 
+std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_MAX_FEES = {"30000"};
+
 std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_GAS_LIMIT = {"18000"};
 
 std::string const TezosConfigurationDefaults::TEZOS_DEFAULT_STORAGE_LIMIT = {"300"};

--- a/core/src/api/TezosConfigurationDefaults.hpp
+++ b/core/src/api/TezosConfigurationDefaults.hpp
@@ -45,6 +45,8 @@ public:
      */
     static std::string const TEZOS_DEFAULT_FEES;
 
+    static std::string const TEZOS_DEFAULT_MAX_FEES;
+
     static std::string const TEZOS_DEFAULT_GAS_LIMIT;
 
     static std::string const TEZOS_DEFAULT_STORAGE_LIMIT;

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -297,6 +297,10 @@ namespace ledger {
                                             // for transaction op
                                             auto fees = burned +
                                                         (tx->toReveal() ? *request.fees * BigInt(static_cast<unsigned long long>(2)) : *request.fees);
+                                            // If sender is KT account then the managing account is paying the fees ...
+                                            if (senderAddress.find("KT1") == 0) {
+                                                fees = fees - *request.fees;
+                                            }
                                             auto maxPossibleAmountToSend = *balance - fees;
                                             auto amountToSend = request.wipe ? BigInt::ZERO : *request.value;
                                             if (maxPossibleAmountToSend < amountToSend) {

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -88,9 +88,7 @@ namespace ledger {
                         }
                         // Since nodes are giving some awkward values, we set a threshold to avoid having really fees
                         // Factor for threshold is inspired from other XTZ wallets
-                        return std::stoi(fees) > 6 * std::stoi(api::TezosConfigurationDefaults::TEZOS_DEFAULT_FEES) ?
-                        std::make_shared<BigInt>(6 * std::stoi(api::TezosConfigurationDefaults::TEZOS_DEFAULT_FEES)) :
-                        std::make_shared<BigInt>(fees);
+                        return std::make_shared<BigInt>(std::min(std::stoi(fees), std::stoi(api::TezosConfigurationDefaults::TEZOS_DEFAULT_MAX_FEES)));
                     });
         }
 

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -86,7 +86,11 @@ namespace ledger {
                         } else if (fees.find('.') != std::string::npos) {
                             fees = api::BigInt::fromDecimalString(fees, 6, ".")->toString(10);
                         }
-                        return std::make_shared<BigInt>(fees);
+                        // Since nodes are giving some awkward values, we set a threshold to avoid having really fees
+                        // Factor for threshold is inspired from other XTZ wallets
+                        return std::stoi(fees) > 6 * std::stoi(api::TezosConfigurationDefaults::TEZOS_DEFAULT_FEES) ?
+                        std::make_shared<BigInt>(6 * std::stoi(api::TezosConfigurationDefaults::TEZOS_DEFAULT_FEES)) :
+                        std::make_shared<BigInt>(fees);
                     });
         }
 


### PR DESCRIPTION
So this PR is fixing tweaking fees:
- `KT` accounts and send max: remove fees from max spendable amount when sending from KT, since fees are paid by the parent `tz` account (interaction with smart contract),
- After some feedbacks from Live:

1. it seems that `2500` was low as default fees, so I bumped it to `5000` (from what I observed from some other XTZ wallets),
2. The nodes are really fluctuating between fees of values that are crazy high, so to avoid that we fix a threshold of `6*default_fees` i.e. `30000` (again from other XTZ wallets). 