### PR TITLE
Fix packaging system of ledger-core. 

### DIFF
--- a/ledger-core/CMakeLists.txt
+++ b/ledger-core/CMakeLists.txt
@@ -54,6 +54,13 @@ else()
 endif()
 
 # Package support
+include(GNUInstallDirs)
+set(ledger-core-pkg-location lib/cmake/ledger-core)
+
+export(PACKAGE ledger-core)
+
+include(CMakePackageConfigHelpers)
+
 install(
     TARGETS
         ledger-core
@@ -79,5 +86,23 @@ install(
 install(
     EXPORT ledger-core
     NAMESPACE Core::
-    DESTINATION ledger-core
+    DESTINATION ${ledger-core-pkg-location}
+)
+
+#configure_file(
+#    ledger-core-config.cmake
+#    ${CMAKE_CURRENT_BINARY_DIR}/ledger-core-config.cmake
+#)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/ledger-core-config-version.cmake"
+    VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(
+    FILES
+    "${CMAKE_SOURCE_DIR}/ledger-core-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/ledger-core-config-version.cmake"
+    DESTINATION ${ledger-core-pkg-location}
 )

--- a/ledger-core/ledger-core-config.cmake
+++ b/ledger-core/ledger-core-config.cmake
@@ -1,0 +1,2 @@
+get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include(${SELF_DIR}/ledger-core.cmake)

--- a/ledger-core/lib/openssl/CMakeLists.txt
+++ b/ledger-core/lib/openssl/CMakeLists.txt
@@ -48,13 +48,15 @@ if(BUILD_TESTS)
 endif()
 # add_subdirectory( apps )
 
-install( FILES e_os2.h DESTINATION include/openssl )
+include(GNUInstallDirs)
 
-install( FILES tools/c_hash tools/c_info tools/c_issuer tools/c_name tools/c_rehash
+install( FILES e_os2.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openssl )
+
+install( FILES tools/c_hash tools/c_info tools/c_issuer tools/c_name tools/c_rehash.in
     FAQ LICENSE PROBLEMS README README.ASN1 README.ENGINE
-    DESTINATION share/openssl )
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/openssl )
 
-install( DIRECTORY doc DESTINATION ./ )
+install( DIRECTORY doc DESTINATION ${CMAKE_INSTALL_DOCDIR}/openssl )
 
 # Generate the package target
 set( CPACK_GENERATOR ZIP TGZ )


### PR DESCRIPTION
# Content

This PR allows `ledger-core` to be found via a `find_package` call. I will enhance it in another PR to take other things into account, such as:

- The build type (debug / releas).
- The target platform (x86, x64, JNI, etc.).
- Tests.

@alekece upon merging this, you can try rebasing and simply remove all `add_subdirectory`, `include_directories` or whatever and simply do this:

```cmake
find_package(ledger-core 0.1.0 REQUIRED)

# …

target_link_directories(your-target ledger-core) # dynamic
target_link_directories(your-target ledger-core-static) # static
# etc.
```

# Mandatory picture of an animal

![](https://phaazon.net/media/uploads/fire_in_the_owl.png)