### PR TITLE
Tezos: fix tx pagination

### DIFF
--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -160,11 +160,12 @@ namespace ledger {
                             LedgerApiParser<TransactionsBulk,
                             TezosLikeTransactionsBulkParser>())
                     .template mapPtr<TransactionsBulk>(getExplorerContext(),
-                                                           [](const EitherTransactionsBulk &result) {
+                                                           [limit](const EitherTransactionsBulk &result) {
                                                                if (result.isLeft()) {
                                                                    // Because it fails when there are no ops
                                                                    return std::make_shared<TransactionsBulk>();
                                                                } else {
+                                                                   result.getRight()->hasNext = result.getRight()->transactions.size() == limit;
                                                                    return result.getRight();
                                                                }
                                                            });


### PR DESCRIPTION
So I was supporting pagination thanks to the session mechanism but I forgot to tweak the `TransactionsBulk`'s `hasNext` value to force discovery.
I tested with this account `tz1ZCaJwLm6AYMUa8b8MXRvvmtgCCW44d8Qd` which has more than `100` of operation and it was working.