### PR TITLE
Modify cmake templates

### DIFF
--- a/tools/templates/CMakeLists-project-src.txt.tpl
+++ b/tools/templates/CMakeLists-project-src.txt.tpl
@@ -5,6 +5,8 @@ set(ANDROID_CPP_FEATURES exceptions)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+find_package(ledger-core 0.1.0 REQUIRED)
+
 # Automatically add API files to the library
 file(
     GLOB $project_name-api-sources
@@ -30,8 +32,6 @@ if (TARGET_JNI)
     list(APPEND $project_name-sources ${$project_name-jni-sources})
     add_definitions(-DTARGET_JNI=1)
 endif ()
-
-#link_directories(${CMAKE_BINARY_DIR}/lib)
 
 # Add files to compile to the project
 file(GLOB_RECURSE SRC_FILES *.cpp)
@@ -109,8 +109,7 @@ if(UNIX AND NOT APPLE AND NOT ANDROID)
 endif()
 
 # link the ledger-core library
-target_link_directories($project_name-interface INTERFACE ${CMAKE_SOURCE_DIR}/../ledger-core/build/src)
-target_link_libraries($project_name-interface INTERFACE ledger-core)
+target_link_libraries($project_name-interface INTERFACE Core::ledger-core)
 
 if (TARGET_JNI)
     target_include_directories($project_name-interface INTERFACE ${JNI_INCLUDE_DIRS})
@@ -119,16 +118,5 @@ endif ()
 
 target_include_directories($project_name-interface INTERFACE ${CMAKE_SOURCE_DIR}/inc)
 target_include_directories($project_name-interface INTERFACE ${CMAKE_SOURCE_DIR}/inc/$coin_name/api)
-target_include_directories($project_name-interface INTERFACE "${CMAKE_SOURCE_DIR}/../ledger-core/inc")
-target_include_directories($project_name-interface INTERFACE "${CMAKE_SOURCE_DIR}/../ledger-core/inc/core/api")
-target_include_directories($project_name-interface INTERFACE "${CMAKE_SOURCE_DIR}/lib/bigd")
-target_include_directories($project_name-interface INTERFACE "${CMAKE_SOURCE_DIR}/lib/boost")
-target_include_directories($project_name-interface INTERFACE "${CMAKE_SOURCE_DIR}/lib/cereal")
-target_include_directories($project_name-interface INTERFACE "${CMAKE_SOURCE_DIR}/lib/fmt/include")
-target_include_directories($project_name-interface INTERFACE "${CMAKE_SOURCE_DIR}/lib/leveldb/include")
-target_include_directories($project_name-interface INTERFACE "${CMAKE_SOURCE_DIR}/lib/rapidjson/include")
-target_include_directories($project_name-interface INTERFACE "${CMAKE_SOURCE_DIR}/lib/secp256k1")
-target_include_directories($project_name-interface INTERFACE "${CMAKE_SOURCE_DIR}/lib/soci/core")
-target_include_directories($project_name-interface INTERFACE "${CMAKE_SOURCE_DIR}/lib/spdlog/include")
 
-install(TARGETS $project_name DESTINATION "lib")
+install(TARGETS $project_name DESTINATION lib)

--- a/tools/templates/CMakeLists-project.txt.tpl
+++ b/tools/templates/CMakeLists-project.txt.tpl
@@ -3,7 +3,7 @@ project($project_name)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 option(TARGET_JNI "Indicates wheter or not the toolchain must build for JNI or not" OFF)
-option(BUILD_TESTS "Indicates wheter or not the toolchain must build the test or not" ON)
+option(BUILD_TESTS "Indicates wheter or not the toolchain must build the test or not" OFF)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(UseBackportedModules)
@@ -37,8 +37,6 @@ if(IS_IOS GREATER_EQUAL 0 OR TARGET_JNI OR ANDROID)
     set(BUILD_TESTS OFF CACHE BOOL "Cannot run tests for these options" FORCE)
 endif()
 
-enable_testing()
-
 add_subdirectory(src)
 
 string(FIND "${CMAKE_OSX_SYSROOT}" "iphone" IS_IOS)
@@ -46,7 +44,7 @@ string(FIND "${CMAKE_OSX_SYSROOT}" "iphone" IS_IOS)
 if(IS_IOS LESS 0 AND BUILD_TESTS AND NOT IS_ANDROID)
     message(STATUS "Test are enabled")
     enable_testing()
-    #add_subdirectory(test) TODO: uncomment to enable tests
+    add_subdirectory(test)
 else()
     message(STATUS "Test are disabled")
 endif()


### PR DESCRIPTION
The main goal of this easy-win PR is to modify our current cmake templates used by `lc` tool to use the `lib-core` target in coin project. 

## Mandatory picture of an awesome dog
![awesome_dog](https://user-images.githubusercontent.com/6042495/70540851-4109d900-1b66-11ea-9f8b-aadf80660c85.gif)
