### PR TITLE
Change Migration.* templates

### DIFF
--- a/tools/templates/Migrations.cpp
+++ b/tools/templates/Migrations.cpp
@@ -2,8 +2,8 @@
 
 namespace ledger {
     namespace core {
-        int constexpr $project_nameMigration::coinID;
-        uint32_t constexpr $project_nameMigration::currentVersion;
+        int constexpr $project_nameMigration::COIN_ID;
+        uint32_t constexpr $project_nameMigration::CURRENT_VERSION;
 
         template <> void migrate<1, $project_nameMigration>(soci::session& sql) {
         }

--- a/tools/templates/Migrations.hpp
+++ b/tools/templates/Migrations.hpp
@@ -6,8 +6,8 @@ namespace ledger {
     namespace core {
         /// Tag type.
         struct $project_nameMigration {
-          static int constexpr coinID = 99999; // TODO: edit
-          static uint32_t constexpr currentVersion = 1; // TODO: edit
+          static int constexpr COIN_ID = 99999; // TODO: edit
+          static uint32_t constexpr CURRENT_VERSION = 1; // TODO: edit
         };
 
         // migrations


### PR DESCRIPTION
The purpose of this PR is to rename some static variable names to match our current coin segregation.

## Mandatory picture of a evil hamster
![evil_hamster](https://user-images.githubusercontent.com/6042495/70545243-8c73b580-1b6d-11ea-896e-83da4721d40e.gif)
