### PR TITLE
Prevent BitcoinLike UTXO picker from using tx<Dust

### DIFF
--- a/core/test/integration/CMakeLists.txt
+++ b/core/test/integration/CMakeLists.txt
@@ -133,6 +133,7 @@ add_test (NAME ledger-core-integration-BitcoinMakeP2PKHTransaction.CreateStandar
 add_test (NAME ledger-core-integration-BitcoinMakeP2PKHTransaction.CreateStandardP2PKHWithOneOutputAndFakeSignature COMMAND ledger-core-integration-tests --gtest_filter=BitcoinMakeP2PKHTransaction.CreateStandardP2PKHWithOneOutputAndFakeSignature)
 add_test (NAME ledger-core-integration-BitcoinMakeP2PKHTransaction.CreateStandardP2PKHWithMultipleInputs COMMAND ledger-core-integration-tests --gtest_filter=BitcoinMakeP2PKHTransaction.CreateStandardP2PKHWithMultipleInputs)
 add_test (NAME ledger-core-integration-BitcoinMakeP2PKHTransaction.Toto COMMAND ledger-core-integration-tests --gtest_filter=BitcoinMakeP2PKHTransaction.Toto)
+add_test (NAME ledger-core-integration-BitcoinStardustTransaction.FilterDustUtxo COMMAND ledger-core-integration-tests --gtest_filter=BitcoinStardustTransaction.FilterDustUtxo)
 add_test (NAME ledger-core-integration-BCHMakeP2SHTransaction.CreateStandardP2SHWithOneOutput COMMAND ledger-core-integration-tests --gtest_filter=BCHMakeP2SHTransaction.CreateStandardP2SHWithOneOutput)
 add_test (NAME ledger-core-integration-ZCASHMakeP2SHTransaction.CreateStandardP2SHWithOneOutput COMMAND ledger-core-integration-tests --gtest_filter=ZCASHMakeP2SHTransaction.CreateStandardP2SHWithOneOutput)
 add_test (NAME ledger-core-integration-ZCASHMakeP2SHTransaction.ParseSignedRawTransaction COMMAND ledger-core-integration-tests --gtest_filter=ZCASHMakeP2SHTransaction.ParseSignedRawTransaction)

--- a/core/test/integration/transactions/transaction_test_helper.h
+++ b/core/test/integration/transactions/transaction_test_helper.h
@@ -75,7 +75,7 @@ struct BitcoinMakeBaseTransaction : public BaseFixture {
         recreate();
     }
 
-    void recreate() {
+    virtual void recreate() {
         pool = newDefaultPool();
         wallet = wait(pool->createWallet(testData.walletName, testData.currencyName, testData.configuration));
         account = testData.inflate_btc(pool, wallet);


### PR DESCRIPTION
Prevent picker from using UTXO when the amount is less than dustAmount

Small issue with local tests, so using CI for now.