### PR TITLE
Add HOUR granularity for balance histories.

### DIFF
--- a/core/idl/wallet/common/wallet.djinni
+++ b/core/idl/wallet/common/wallet.djinni
@@ -274,6 +274,7 @@ Address = interface +c {
 }
 
 TimePeriod = enum {
+    hour;
     day;
     week;
     month;

--- a/core/src/api/TimePeriod.cpp
+++ b/core/src/api/TimePeriod.cpp
@@ -8,6 +8,7 @@ namespace ledger { namespace core { namespace api {
 
 std::string to_string(const TimePeriod& timePeriod) {
     switch (timePeriod) {
+        case TimePeriod::HOUR: return "HOUR";
         case TimePeriod::DAY: return "DAY";
         case TimePeriod::WEEK: return "WEEK";
         case TimePeriod::MONTH: return "MONTH";
@@ -15,7 +16,8 @@ std::string to_string(const TimePeriod& timePeriod) {
 };
 template <>
 TimePeriod from_string(const std::string& timePeriod) {
-    if (timePeriod == "DAY") return TimePeriod::DAY;
+    if (timePeriod == "HOUR") return TimePeriod::HOUR;
+    else if (timePeriod == "DAY") return TimePeriod::DAY;
     else if (timePeriod == "WEEK") return TimePeriod::WEEK;
     else return TimePeriod::MONTH;
 };
@@ -23,6 +25,7 @@ TimePeriod from_string(const std::string& timePeriod) {
 std::ostream &operator<<(std::ostream &os, const TimePeriod &o)
 {
     switch (o) {
+        case TimePeriod::HOUR:  return os << "HOUR";
         case TimePeriod::DAY:  return os << "DAY";
         case TimePeriod::WEEK:  return os << "WEEK";
         case TimePeriod::MONTH:  return os << "MONTH";

--- a/core/src/api/TimePeriod.hpp
+++ b/core/src/api/TimePeriod.hpp
@@ -18,6 +18,7 @@
 namespace ledger { namespace core { namespace api {
 
 enum class TimePeriod : int {
+    HOUR,
     DAY,
     WEEK,
     MONTH,

--- a/core/src/utils/DateUtils.cpp
+++ b/core/src/utils/DateUtils.cpp
@@ -150,7 +150,11 @@ namespace ledger {
         gmtime_r(&tt, &tm);
 #endif
 
-        switch (precision){
+        switch (precision) {
+            case api::TimePeriod::HOUR:
+                tm.tm_hour += 1;
+                break;
+
             case api::TimePeriod::DAY:
                 tm.tm_mday += 1;
                 break;

--- a/core/test/common/balance_history.cpp
+++ b/core/test/common/balance_history.cpp
@@ -106,6 +106,36 @@ TEST(BalanceHistory, ZeroesOutOfRange) {
     EXPECT_TRUE(all_zero);
 }
 
+TEST(BalanceHistory, CorrectBalancesPerHour) {
+    // a basic collections of “operations” with nothing
+    std::vector<DummyOperation> operations = {
+        DummyOperation(10, api::OperationType::RECEIVE, DateUtils::fromJSON("2019-01-01T00:00:00Z")),
+        DummyOperation(12, api::OperationType::RECEIVE, DateUtils::fromJSON("2019-01-01T02:00:00Z")),
+        DummyOperation(5, api::OperationType::SEND,     DateUtils::fromJSON("2019-01-01T04:00:00Z")),
+        DummyOperation(3, api::OperationType::SEND,     DateUtils::fromJSON("2019-01-01T07:30:00Z"))
+    };
+
+    auto start = DateUtils::fromJSON("2019-01-01T00:00:00Z");
+    auto end =   DateUtils::fromJSON("2019-02-01T00:00:00Z");
+
+    auto balances = agnostic::getBalanceHistoryFor<DummyOperationStrategy, int32_t, int32_t>(
+        start,
+        end,
+        api::TimePeriod::HOUR,
+        operations.cbegin(),
+        operations.cend(),
+        0
+    );
+
+    auto size = balances.size();
+    EXPECT_EQ(size, 744);
+
+    EXPECT_EQ(*balances[0], 10);
+    EXPECT_EQ(*balances[2], 22);
+    EXPECT_EQ(*balances[4], 17);
+    EXPECT_EQ(*balances[7], 14);
+}
+
 TEST(BalanceHistory, CorrectBalancesPerDay) {
     // a basic collections of “operations” with nothing
     std::vector<DummyOperation> operations = {


### PR DESCRIPTION
# Content

This brings _hour granularity_ to balance histories; feature asked by Live (LLC-474).

# Mandatory picture of a good boi

![ezgif-1-a1f345dc60bb](https://user-images.githubusercontent.com/506592/71179682-f298c080-2270-11ea-8762-98b01fd4b10b.gif)
