### PR TITLE
Tezos: fix update of tezos_transactions status

### DIFF
--- a/core/src/wallet/tezos/database/TezosLikeTransactionDatabaseHelper.cpp
+++ b/core/src/wallet/tezos/database/TezosLikeTransactionDatabaseHelper.cpp
@@ -126,8 +126,9 @@ namespace ledger {
             if (transactionExists(sql, tezosTxUid)) {
                 // UPDATE (we only update block information)
                 if (tx.block.nonEmpty()) {
-                    sql << "UPDATE tezos_transactions SET block_uid = :uid, status = :code WHERE hash = :tx_hash",
-                            use(blockUid), use(tx.status), use(tx.hash);
+                    auto type = api::to_string(tx.type);
+                    sql << "UPDATE tezos_transactions SET block_uid = :uid, status = :code WHERE hash = :tx_hash AND type = :type",
+                            use(blockUid), use(tx.status), use(tx.hash), use(type);
                 }
                 return tezosTxUid;
             } else {


### PR DESCRIPTION
We were updating status of all txs with same hash, knowing that we could have different status for different transactions with same hash (e.g. succeeding revelation + failing transfer ).
This is related to : https://ledgerhq.atlassian.net/browse/LLC-431