### PR TITLE
Tezos: fix recursive sync on originated accounts

### DIFF
--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -137,12 +137,17 @@ namespace ledger {
 
         FuturePtr<TezosLikeBlockchainExplorer::TransactionsBulk>
         ExternalTezosLikeBlockchainExplorer::getTransactions(const std::vector<std::string> &addresses,
-                                                             Option<std::string> fromBlockHash,
+                                                             Option<std::string> offset,
                                                              Option<void *> session) {
-            uint64_t offset = 0, limit = 100;
+            auto tryOffset = Try<uint64_t>::from([=]() -> uint64_t {
+                return std::stoul(offset.getValue(), nullptr, 16);
+            });
+
+            uint64_t localOffset = tryOffset.isSuccess() ? tryOffset.getValue() : 0;
+            uint64_t limit = 100;
             if (session.hasValue()) {
                 auto s = _sessions[*((std::string *)session.getValue())];
-                offset = limit * s;
+                localOffset += limit * s;
                 _sessions[*reinterpret_cast<std::string *>(session.getValue())]++;
             }
             if (addresses.size() != 1) {
@@ -151,8 +156,8 @@ namespace ledger {
                                      addresses.size());
             }
             std::string params = fmt::format("?limit={}",limit);
-            if (offset > 0) {
-                params += fmt::format("&offset={}",offset);
+            if (localOffset > 0) {
+                params += fmt::format("&offset={}",localOffset);
             }
             using EitherTransactionsBulk = Either<Exception, std::shared_ptr<TransactionsBulk>>;
             return _http->GET(fmt::format("account/{}/op{}", addresses[0], params))

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
@@ -74,7 +74,7 @@ namespace ledger {
 
             FuturePtr<TezosLikeBlockchainExplorer::TransactionsBulk>
             getTransactions(const std::vector<std::string> &addresses,
-                            Option<std::string> fromBlockHash = Option<std::string>(),
+                            Option<std::string> offset = Option<std::string>(),
                             Option<void *> session = Option<void *>()) override;
 
             FuturePtr<Block> getCurrentBlock() const override;


### PR DESCRIPTION
Basically we were not passing the session from a call to next recursion.
This is related to : https://ledgerhq.atlassian.net/browse/LLC-472