### PR TITLE
Fix DerivationScheme by backporting code from the legacy codebase.

### DIFF
--- a/ledger-core/src/core/utils/DerivationScheme.cpp
+++ b/ledger-core/src/core/utils/DerivationScheme.cpp
@@ -78,6 +78,25 @@ namespace ledger {
                 }
                 _scheme.push_back(node);
             }
+
+            // Account & node level both should be set to be used by keychain.
+            // Account level always comes before node level
+            auto itAccountLevel = std::find_if(_scheme.begin(), _scheme.end(), [](const DerivationSchemeNode &node) {return node.level == DerivationSchemeLevel::ACCOUNT_INDEX;});
+            auto itNodeLevel = std::find_if(itAccountLevel, _scheme.end(), [](const DerivationSchemeNode &node) {return node.level == DerivationSchemeLevel::NODE;});
+            if (itNodeLevel == _scheme.end() && _scheme.size() <= 5) {
+                static std::vector<DerivationSchemeLevel> schemeLevel {DerivationSchemeLevel::UNDEFINED,
+                                                                       DerivationSchemeLevel::COIN_TYPE,
+                                                                       DerivationSchemeLevel::ACCOUNT_INDEX,
+                                                                       DerivationSchemeLevel::NODE,
+                                                                       DerivationSchemeLevel::ADDRESS_INDEX};
+                for (size_t i = 0; i < _scheme.size(); i++ ) {
+                    // We don't set twice a level
+                    auto it = std::find_if(_scheme.begin() + i, _scheme.end(), [&](const DerivationSchemeNode &node){return node.level == schemeLevel[i];});
+                    if (it == _scheme.end() && _scheme[i].level == DerivationSchemeLevel::UNDEFINED) {
+                        _scheme[i].level = schemeLevel[i];
+                    }
+                }
+            }
         }
 
         DerivationScheme::DerivationScheme(const std::vector<DerivationSchemeNode> &nodes) {


### PR DESCRIPTION
# Content

This is needed by the Ripple project to pass test. It will also benefit other coins.

# Mandatory picture of dog trolling their hoomans

![bsXu8U](https://user-images.githubusercontent.com/506592/71674710-4381dc00-2d7c-11ea-8409-58cc6e1c46df.gif)
