### PR TITLE
Add WalletStore::eraseDataSince & fix account’s wallet link

### DIFF
--- a/ledger-core/inc/core/wallet/WalletStore.hpp
+++ b/ledger-core/inc/core/wallet/WalletStore.hpp
@@ -66,6 +66,9 @@ namespace ledger {
                 std::shared_ptr<api::DynamicObject> const& configuration
             );
 
+            // Deletion
+            Future<api::ErrorCode> eraseDataSince(const std::chrono::system_clock::time_point & date);
+
             // Factories
 
             // Register a factory for a given currency. Return true if registered and false if

--- a/ledger-core/src/core/wallet/AbstractAccount.cpp
+++ b/ledger-core/src/core/wallet/AbstractAccount.cpp
@@ -56,7 +56,8 @@ namespace ledger {
                ->getSubPreferences(fmt::format("account_{}", index))
            ),
            _loggerApi(std::make_shared<LoggerApi>(_logger)),
-           _mainExecutionContext(services->getDispatcher()->getMainExecutionContext()) {
+           _mainExecutionContext(services->getDispatcher()->getMainExecutionContext()),
+           _wallet(wallet) {
            _publisher = std::make_shared<EventPublisher>(getContext());
         }
 


### PR DESCRIPTION
# Content

This PR:

- Brings in `WalletStore::eraseDataSince`, needed in tests to clean up wallets.
- Fixes the link between an `Account` and its associated `Wallet`.

# Mandatory picture of a dog handling the situation

![](https://phaazon.net/media/uploads/doing_everything_we_can.jpg)