### PR TITLE
Explicitely ask for bash in tools/lc

### DIFF
--- a/tools/lc
+++ b/tools/lc
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # project new <coin-id> [--force]
 usage() {


### PR DESCRIPTION
Using sh instead of bash produces
`./tools/lc: 17: ./tools/lc: Syntax error: redirection unexpected`

I suppose the syntax used l.17 is a bash-ism

The added `/usr/bin/env` is for possible non-standard OS users (nixOS notably only has /usr/bin/env to rely on)