### PR TITLE
Support BTC BEv3

### DIFF
--- a/core/src/wallet/bitcoin/explorers/api/InputParser.cpp
+++ b/core/src/wallet/bitcoin/explorers/api/InputParser.cpp
@@ -84,6 +84,8 @@ namespace ledger {
                 _input->signatureScript = Option<std::string>(value);
             } else if (_lastKey == "coinbase") {
                 _input->coinbase = Option<std::string>(value);
+            } else if (_lastKey == "value") {
+                _input->value = Option<BigInt>(BigInt::fromString(value));
             }
             return true;
         }

--- a/core/src/wallet/bitcoin/explorers/api/OutputParser.cpp
+++ b/core/src/wallet/bitcoin/explorers/api/OutputParser.cpp
@@ -78,6 +78,8 @@ namespace ledger {
                 _output->address = Option<std::string>(value);
             } else if (_lastKey == "script_hex") {
                 _output->script = value;
+            } else if (_lastKey == "value") {
+                _output->value = BigInt::fromString(value);
             }
             return true;
         }

--- a/core/src/wallet/bitcoin/explorers/api/TransactionsParser.hpp
+++ b/core/src/wallet/bitcoin/explorers/api/TransactionsParser.hpp
@@ -46,7 +46,8 @@ namespace ledger {
 
             bool StartObject() {
                 _objectDepth += 1;
-
+                // In v2 /transactions/${hash} endpoint returns an array of tx object => _arrayDepth == 0
+                // In v3 /transactions/${hash} endpoint returns a tx object => _arrayDepth == 1
                 if ((_arrayDepth == 1 || _arrayDepth == 0) && _objectDepth == 1) {
                     BitcoinLikeBlockchainExplorerTransaction transaction;
                     _transactions->push_back(transaction);

--- a/core/src/wallet/bitcoin/explorers/api/TransactionsParser.hpp
+++ b/core/src/wallet/bitcoin/explorers/api/TransactionsParser.hpp
@@ -44,6 +44,18 @@ namespace ledger {
                 _objectDepth = 0;
             }
 
+            bool StartObject() {
+                _objectDepth += 1;
+
+                if ((_arrayDepth == 1 || _arrayDepth == 0) && _objectDepth == 1) {
+                    BitcoinLikeBlockchainExplorerTransaction transaction;
+                    _transactions->push_back(transaction);
+                    getTransactionParser().init(&_transactions->back());
+                }
+
+                PROXY_PARSE_TX(StartObject)
+            };
+
         protected:
             TransactionParser &getTransactionParser() override {
                 return _transactionParser;

--- a/core/test/integration/synchronization/synchronization_tests.cpp
+++ b/core/test/integration/synchronization/synchronization_tests.cpp
@@ -43,6 +43,8 @@ TEST_F(BitcoinLikeWalletSynchronization, MediumXpubSynchronization) {
     {
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::KEYCHAIN_ENGINE,api::KeychainEngines::BIP173_P2WPKH);
+        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT,"https://bitcoin-mainnet.explorers.dev.aws.ledger.fr:443");
+        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_VERSION, "v3");
         auto wallet = wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "bitcoin",
                                               configuration));
         std::set<std::string> emittedOperations;


### PR DESCRIPTION
2 changes compared to BEv2:
1. value of outputs in a string,
2. transactions returned by `/transactions` endpoint is returning 1 object instead of 1 array of 1 object.