### PR TITLE
Inherit DerivationPath from its API interface

### DIFF
--- a/ledger-core/idl/configuration.djinni
+++ b/ledger-core/idl/configuration.djinni
@@ -56,6 +56,9 @@ ConfigurationDefaults = interface +c {
 
     # Default observable range for HD keychains
     const KEYCHAIN_DEFAULT_OBSERVABLE_RANGE : i32 = 20;
+    
+    # Default TTL for cache
+    const DEFAULT_TTL_CACHE : i32 = 30;
 }
 
 # Overall configuration.

--- a/ledger-core/idl/derivation.djinni
+++ b/ledger-core/idl/derivation.djinni
@@ -1,26 +1,26 @@
 DerivationPath = interface +c {
     # Get the number of element in this path.
-    getDepth(): i32;
+    const getDepth(): i32;
 
     # Get the child num at the given index in the path.
-    getChildNum(index: i32): i32;
+    const getChildNum(index: i32): i32;
 
     # Get the child num at the given index in the path. If the child num is hardened, returns it
     # without the hardened marker bit.
-    getUnhardenedChildNum(index: i32): i32;
+    const getUnhardenedChildNum(index: i32): i32;
 
     # Return true if the given index in the path is an hardened child num.
-    isHardened(index: i32): bool;
+    const isHardened(index: i32): bool;
 
     # Serialize the given path to a human readable string like "44'/0'/0'/0/0".
-    toString(): string;
+    const toString(addLeadingM: bool): string;
 
     # Return a derivation path without the last element, e.g. the parent of "44'/0'/0'/0/0" is
     # "44'/0'/0'/0".
-    getParent(): DerivationPath;
+    const getAbstractParent(): DerivationPath;
 
     # Return an array where which item is a child num of the path.
-    toArray(): list<i32>;
+    const toVector(): list<i32>;
 
     static parse(path: string): DerivationPath;
 }

--- a/ledger-core/inc/core/key/ExtendedPublicKey.hpp
+++ b/ledger-core/inc/core/key/ExtendedPublicKey.hpp
@@ -48,7 +48,7 @@ namespace ledger {
         template <class NetworkParameters>
         class ExtendedPublicKey {
         public:
-            static inline DeterministicPublicKey _derive(int index, const std::vector<uint32_t>& childNums, const DeterministicPublicKey& key) {
+            static inline DeterministicPublicKey _derive(int index, const std::vector<int32_t>& childNums, const DeterministicPublicKey& key) {
                 if (index >= childNums.size()) {
                     return key;
                 }

--- a/ledger-core/inc/core/utils/DerivationPath.hpp
+++ b/ledger-core/inc/core/utils/DerivationPath.hpp
@@ -34,35 +34,42 @@
 #include <string>
 #include <vector>
 
+#include <core/api/DerivationPath.hpp>
 #include <core/utils/Exception.hpp>
 
 namespace ledger {
     namespace core {
-        class DerivationPath {
+        class DerivationPath : public api::DerivationPath {
         public:
             explicit DerivationPath(const std::string& path);
-            explicit DerivationPath(const std::vector<uint32_t>& path);
+            explicit DerivationPath(const std::vector<int32_t>& path);
             DerivationPath(const DerivationPath& path);
             DerivationPath(DerivationPath&& path);
             DerivationPath& operator=(DerivationPath&& path);
             DerivationPath& operator=(const DerivationPath& path);
-            uint32_t getDepth() const;
-            uint32_t getLastChildNum() const;
-            uint32_t getNonHardenedChildNum(int index) const;
-            uint32_t getNonHardenedLastChildNum() const;
-            uint32_t operator[](int index) const;
+
+            int32_t getDepth() const override;
+            int32_t getChildNum(int32_t index) const override;
+            int32_t getUnhardenedChildNum(int32_t index) const override;
+            bool isHardened(int32_t index) const override;
+            std::string toString(bool addLeadingM = false) const override;
+            std::shared_ptr<api::DerivationPath> getAbstractParent() const override;
+            std::vector<int32_t> toVector() const override;
+
+            DerivationPath getParent() const;
+            int32_t getLastChildNum() const;
+            int32_t getNonHardenedChildNum(int index) const;
+            int32_t getNonHardenedLastChildNum() const;
+            bool isRoot() const;
+            bool isLastChildHardened() const;
+ 
+            int32_t operator[](int32_t index) const;
             DerivationPath operator+(const DerivationPath& derivationPath) const;
             bool operator==(const DerivationPath& path) const;
             bool operator!=(const DerivationPath& path) const;
-            DerivationPath getParent() const;
-            bool isRoot() const;
-            std::string toString(bool addLeadingM = false) const;
-            std::vector<uint32_t> toVector() const;
-            bool isHardened(int index) const;
-            bool isLastChildHardened() const;
 
         public:
-            static std::vector<uint32_t> parse(const std::string& path);
+            static std::vector<int32_t> parse(const std::string& path);
             static DerivationPath fromScheme(
                 const std::string& scheme,
                 int coinType,
@@ -73,10 +80,10 @@ namespace ledger {
             );
 
         private:
-            inline void assertIndexIsValid(int index, const std::string& method) const;
+            inline void assertIndexIsValid(int32_t index, const std::string& method) const;
 
         private:
-            std::vector<uint32_t> _path;
+            std::vector<int32_t> _path;
         };
     }
 }

--- a/ledger-core/inc/core/utils/DerivationPath.hpp
+++ b/ledger-core/inc/core/utils/DerivationPath.hpp
@@ -82,7 +82,6 @@ namespace ledger {
         private:
             inline void assertIndexIsValid(int32_t index, const std::string& method) const;
 
-        private:
             std::vector<int32_t> _path;
         };
     }

--- a/ledger-core/src/core/utils/DerivationPath.cpp
+++ b/ledger-core/src/core/utils/DerivationPath.cpp
@@ -48,7 +48,11 @@ namespace ledger {
         }
 
         DerivationPath::DerivationPath(const std::vector<int32_t> &path) : _path(path) {
-
+            // we cannot use unsigned integer because of some unsupported type in binding 
+            // so we have to check the validity of all the indexes in the path.
+            for (auto index : path)  {
+                assertIndexIsValid(index, "ledger::core::DerivationPath::DerivationPath");
+            }
         }
 
         std::vector<int32_t> DerivationPath::parse(const std::string &path) {
@@ -113,7 +117,7 @@ namespace ledger {
 
 
         int32_t DerivationPath::getDepth() const {
-            return (int32_t) _path.size();
+            return static_cast<int32_t>(_path.size());
         }
 
         int32_t DerivationPath::getChildNum(int32_t index) const {
@@ -122,6 +126,7 @@ namespace ledger {
         }
 
         int32_t DerivationPath::getUnhardenedChildNum(int32_t index) const {
+            assertIndexIsValid(index, "ledger::core::DerivationPath::getUnhardenedChildNum");
             return getNonHardenedChildNum(index);
         }
 

--- a/ledger-core/src/core/utils/DerivationScheme.cpp
+++ b/ledger-core/src/core/utils/DerivationScheme.cpp
@@ -148,7 +148,7 @@ namespace ledger {
         }
 
         DerivationPath DerivationScheme::getPath() {
-            std::function<uint32_t (const DerivationSchemeNode&)> map = [] (const DerivationSchemeNode &item) -> uint32_t {
+            std::function<int32_t (const DerivationSchemeNode&)> map = [] (const DerivationSchemeNode &item) -> int32_t {
                 return item.value | (item.hardened ? 0x80000000 : 0x00);
             };
             auto segments = functional::map(_scheme, map);


### PR DESCRIPTION
In our legacy codebase we can found several definition and implementation of `DerivationPath`.

The purpose of this PR is to uniform that class and to expose a proper interface.  
We use signed integer type to represent index because of djinni limitation.

## Mandatory picture of a majestic cat
![majestic_cat](https://user-images.githubusercontent.com/6042495/72607793-97b2c180-3921-11ea-8b0f-152b61c6edf2.gif)
 