### PR TITLE
BTC segregation for the good

### DIFF
--- a/ledger-core-bitcoin/CMakeLists.txt
+++ b/ledger-core-bitcoin/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.12)
+project(ledger-core-bitcoin)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+option(TARGET_JNI "Indicates wheter or not the toolchain must build for JNI or not" OFF)
+option(BUILD_TESTS "Indicates wheter or not the toolchain must build the test or not" OFF)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(UseBackportedModules)
+
+# The project version number.
+set(VERSION_MAJOR   0   CACHE STRING "Project major version number.")
+set(VERSION_MINOR   1   CACHE STRING "Project minor version number.")
+set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
+mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
+
+# C++ version and standard
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)
+
+# Fix LLC-186: Add this flag to avoid crash for 10.10.x version
+# https://stackoverflow.com/questions/41865537/how-does-apples-codesign-utility-decide-which-sha-algorithms-to-sign-a-shared
+# Notes:
+# > This is a "blind" fix, no available 10.10.x macOS machine,
+# > Issue is specific to 10.10.x, 10.9.5 and > 10.10.x are fine
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X version to target for deployment: 10.9" FORCE)
+
+set(CMAKE_MACOSX_RPATH 1)
+
+add_definitions("-DSQLITE_HAS_CODEC")
+
+string(FIND "${CMAKE_OSX_SYSROOT}" "iphone" IS_IOS)
+if(IS_IOS GREATER_EQUAL 0 OR TARGET_JNI OR ANDROID)
+    set(BUILD_TESTING OFF CACHE BOOL "iOS build fail otherwise" FORCE)
+    set(BUILD_TESTS OFF CACHE BOOL "Cannot run tests for these options" FORCE)
+endif()
+
+add_subdirectory(src)
+
+string(FIND "${CMAKE_OSX_SYSROOT}" "iphone" IS_IOS)
+
+if(IS_IOS LESS 0 AND BUILD_TESTS AND NOT IS_ANDROID)
+    message(STATUS "Test are enabled")
+    enable_testing()
+    add_subdirectory(test)
+else()
+    message(STATUS "Test are disabled")
+endif()

--- a/ledger-core-bitcoin/cmake
+++ b/ledger-core-bitcoin/cmake
@@ -1,0 +1,1 @@
+../ledger-core/cmake

--- a/ledger-core-bitcoin/idl/addresses.djinni
+++ b/ledger-core-bitcoin/idl/addresses.djinni
@@ -1,0 +1,83 @@
+@extern "../../ledger-core/idl/core.yaml"
+
+# Strategy used to compute the amount of fees of transactions.
+#
+# This basically gives the unit in which the fee amount will be expressed.
+BitcoinLikeFeePolicy = enum {
+    PER_BYTE;
+    PER_KBYTE;
+}
+
+# Bitcoin network parameters.
+BitcoinLikeNetworkParameters = record {
+    # Name of the network.
+    Identifier: string;
+    # Version of the Pay To Public Hash standard.
+    P2PKHVersion: binary;
+    # Version of the Pay To Script Hash standard.
+    P2SHVersion: binary;
+    # Version of the Extended Public Key standard.
+    XPUBVersion: binary;
+    # Policy to use when expressing fee amount.
+    FeePolicy: BitcoinLikeFeePolicy;
+    # Minimal amount a UTXO should have before being considered BTC dust.
+    DustAmount: i64;
+    # Constant prefix to prepend all signature messages.
+    MessagePrefix: string;
+    # Are transactions encoded with timestamp?
+    UsesTimestampedTransaction: bool;
+    # Delay applied to all timestamps. Used to debounce transactions.
+    TimestampDelay: i64;
+    # Bitcoin signature flag indicating what part of a transaction a signature signs.
+    SigHash: binary;
+    # Addition BIPs enabled for this network.
+    AdditionalBIPs: list<string>;
+}
+
+# Helper class for manipulating Bitcoin like addresses
+BitcoinLikeAddress = interface +c {
+    # Gets the version of the address (P2SH or P2PKH)
+    # @return The version of the address
+    getVersion(): binary;
+    # Gets the raw hash160 of the public key
+    # @return The 20 bytes of the public key hash160
+    getHash160(): binary;
+    # Gets the network parameters used for serializing the address
+    # @return The network parameters of the address
+    getNetworkParameters(): BitcoinLikeNetworkParameters;
+    # Serializes the hash160 into a Base58 encoded address (with checksum)
+    # @return The Base58 serialization
+    toBase58(): string;
+    # Get the Bech32 encoded address (with respect to BIP173)
+    # @return The Bech32 encoded address
+    toBech32(): string;
+    # Serializes the hash160 to a payment uri (i.e bitcoin:16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM)
+    # @return A payment uri to this address
+    # toPaymentUri(): string;
+    # Checks if the given address is a P2SH address
+    # @return True if the keychain engine is P2SH
+    isP2SH(): bool;
+    # Checks if the given address is a P2PKH address
+    # @return if the keychain engine is P2PKH
+    isP2PKH(): bool;
+    # Checks if the given address is a P2WSH address
+    # @return True if the keychain engine is P2WSH
+    isP2WSH(): bool;
+    # Checks if the given address is a P2WPKH address
+    # @return True if the keychain engine is P2WPKH
+    isP2WPKH(): bool;
+}
+
+# The xPUB definition for Bitcoin.
+BitcoinLikeExtendedPublicKey = interface +c {
+    # Derive an address from an xPUB and a path.
+    derive(path: string): BitcoinLikeAddress;
+    # Derive a public key from an xPUB and a path.
+    derivePublicKey(path: string): binary;
+    # Derive a shorten version of a public key (SHA256 + RIPEMD160) from an xPUB and a path.
+    deriveHash160(path: string): binary;
+    # Get the xPUB in base 58.
+    toBase58(): string;
+    # Get the root path of the xPUB.
+    getRootPath(): string;
+}

--- a/ledger-core-bitcoin/idl/idl.djinni
+++ b/ledger-core-bitcoin/idl/idl.djinni
@@ -1,0 +1,317 @@
+@extern "../../ledger-core/idl/core.yaml"
+
+@import "addresses.djinni"
+@import "script.djinni"
+
+
+# Class of constants to set Bitcoin like wallet configurations.
+BitcoinLikeWalletConfiguration = interface +c {
+    # String keychain's name.
+    const KEYCHAIN: string = "keychain";
+    # String observer's name.
+    const OBSERVER: string = "observer";
+    # String explorer's name.
+    const EXPLORER: string = "explorer";
+    # String synchronizer's name.
+    const SYNCHRONIZER: string = "synchronizer";
+    # String with Payment Script type and BIP on which hierarchical wallet is based.
+    const KEYCHAIN_P2PKH_BIP44: string = "p2pkh_bip44";
+    # String websocket on which observer receives notifications from explorer.
+    const OBSERVER_LEDGER_WEBSOCKET: string = "ledger_websocket";
+    # String explorer api.
+    const EXPLORER_LEDGER_API: string = "ledger_api";
+    # String synchronizer by default.
+    const SYNCHRONIZER_DEFAULT: string = "default";
+}
+
+# Class representing Bitcoin inputs.
+BitcoinLikeInput = interface +c {
+    # Returns the address of the input (if an address can be computed).
+    getAddress(): optional<string>;
+    # Returns the public associated with the address. This value can be NULL if you are building a transaction with an
+    # address which does not belong to your wallet.
+    getPublicKeys(): list<binary>;
+    # Returns the derivation path of this input if the address is owned by the wallet.
+    getDerivationPath(): list<DerivationPath>;
+    # Returns the value of the amount. Depending on the backend this value may not exist if the input is not owned by
+    # the wallet.
+    getValue(): Amount;
+    # Get the transaction hash of the output spent by this input. The result can be NULL if the output is not owned by
+    # the wallet.
+    getPreviousTxHash(): optional<string>;
+    # Check whether input is for a coinbase.
+    # @return Boolean, true if input belongs to coinbase transaction (reward for mining a block)
+    isCoinbase(): bool;
+    # Stored data cointained in coinbase.
+    # @return Optional String
+    getCoinbase(): optional<string>;
+    # Get output index, it identifies which UTXO from tht transaction to spend.
+    # @return Optional 32 bits integer, index of previous transaction
+    getPreviousOutputIndex(): optional<i32>;
+    # Retrieve the output spent by this input. Depending on the implementation this method may
+    # use a lock to fetch data from a database. Therefore it may have poor performance, use with
+    # caution.
+    # @return The output spent by this input.
+    getPreviousOuput(): BitcoinLikeOutput;
+    # Get ScriptSig of this input. The scriptsig is the first half of a script necessary to spend a previous output.
+    getScriptSig(): binary;
+    # Parse the script sig to a [[BitcoinLikeScript]].
+    parseScriptSig(): BitcoinLikeScript;
+
+    # Set the ScriptS to the given value.
+    # @param scriptSig The ScriptSig to use for this input
+    setScriptSig(scriptSig: binary);
+    # Push data to the end of the current ScriptSig.
+    pushToScriptSig(data: binary);
+
+    # Set the sequence number of this input.
+    setSequence(sequence: i32);
+    # Get the sequence number of this input.
+    getSequence(): i64;
+
+    # Get the previous transaction associated with the input.
+    getPreviousTransaction(callback: callback2<void, optional<binary>, optional<Error>>);
+
+    # Easy way to set the P2PKH script signature. Shorthand for input.pushToScriptSig(input.getPublicKeys()[0], signature).
+    setP2PKHSigScript(signature: binary);
+}
+
+# Class representing Bitcoin outputs.
+BitcoinLikeOutput = interface +c {
+    # Get transaction hash in which output was 'created'.
+    # @return String, transaction hash containing output
+    getTransactionHash(): string;
+    # Get index of output in list of all outputs contained in same transaction.
+    # @return 32 bits integer, index of output
+    getOutputIndex(): i32;
+    # Get amount of output.
+    # @return Amount object, amount of output
+    getValue(): Amount;
+    # Get script (witness script) cryptographic puzzle that determines the conditions to spend the output.
+    # @return in Bytes (variable size depending on type of script P2PKH, P2SH), locking script to spend UTXO
+    getScript(): binary;
+    parseScript(): BitcoinLikeScript;
+    # Get address that spent the output.
+    # @return Optional String, address that spent
+    getAddress(): optional<string>;
+    getDerivationPath(): DerivationPath;
+    getBlockHeight(): optional<i64>;
+}
+
+# Class representing Bitcoin block
+BitcoinLikeBlock = interface +c {
+    # Hash of block.
+    # @return string representing hash of this block
+    getHash(): string;
+    # Height of block in blockchain.
+    # @return 64 bits integer, height of block
+    getHeight(): i64;
+    # Timestamp when block was mined.
+    # @return Date object, date when block was appended to blockchain
+    getTime(): date;
+}
+
+# Structure representing DER encoded signature
+# DER format :
+# - DER prefix
+# - Length of rest of signature
+# - Marker for r value
+# - Length of r value
+# - r value, Big Endian
+# - Marker for s value
+# - Length of s value
+# - s value, Big Endian
+# - SIGHASH byte (ALL, NONE, SINGLE)
+BitcoinLikeSignature = record {
+    # r data
+    r: binary;
+    # s data
+    s: binary;
+    # Ignored attribute
+    v: binary;
+}
+
+BitcoinLikeSignatureState = enum {
+    ALREADY_SIGNED;
+    MISSING_DATA;
+    SIGNING_SUCCEED;
+}
+
+# Class representing a Bitcoin transaction.
+BitcoinLikeTransaction = interface +c {
+    # Get the hash of the transaction.
+    getHash(): string;
+    # Get the input of the transaction.
+    getInputs(): list<BitcoinLikeInput>;
+    # Get the output of the transaction.
+    getOutputs(): list<BitcoinLikeOutput>;
+    # Get the block in which the transaction is inserted if the transaction is confirmed.
+    getBlock(): optional<BitcoinLikeBlock>;
+    # Get the lock time of the transaction.
+    getLockTime(): i64;
+    # Get the amount of fees of the transaction.
+    getFees(): Amount;
+    # Get the time when the transaction was issued or the time of the block including
+    # this transaction.
+    getTime(): date;
+    # Get the timestamps serialized in the raw transaction if the underlying currency handles it.
+    getTimestamp(): optional<i32>;
+    # Get Transaction version.
+    getVersion(): i32;
+    # Serialize the transaction to its raw format.
+    serialize(): binary;
+    # Serialize outputs of the raw transaction into a byte array using the bitcoin transaction format.
+    serializeOutputs(): binary;
+    # Get the witness if the underlying transaction is a segwit transaction.
+    getWitness(): optional<binary>;
+    # Estimate the size of the raw transaction in bytes. This method returns a minimum estimated size and a maximum estimated
+    # size.
+    getEstimatedSize(): EstimatedSize;
+    # Sign all inputs for given transaction. 
+    # Build DER encoded signature from RSV data.
+    # @return SIGNING_SUCCEED if succeed case else refers to BitcoinLikeSignatureState enumeration
+    setSignatures(signatures: list<BitcoinLikeSignature>, override: bool): BitcoinLikeSignatureState;
+    # Sign all inputs for given transaction. 
+    # @return SIGNING_SUCCEED if succeed case else refers to BitcoinLikeSignatureState enumeration
+    setDERSignatures(signatures: list<binary>, override: bool): BitcoinLikeSignatureState;
+}
+
+# Class representing a Bitcoin Operation.
+BitcoinLikeOperation = interface +c {
+    # Get operation's transaction.
+    # @return BitcoinLikeTransaction object
+    getTransaction(): BitcoinLikeTransaction;
+}
+
+# Structure representing a bitcoin transaction request.
+BitcoinLikeTransactionRequest = record {
+    # List of BitcoinLikeOutput objects, UTXO (Unspent Transaction Outputs) consumed by transaction's inputs.
+    UTXO: list<BitcoinLikeOutput>;
+    # List of BitcoinLikeOutput objects, transaction's output.
+    outputs: list<BitcoinLikeOutput>;
+    # Optional Amount object, amount of base fees.
+    baseFees: optional<Amount>;
+    # Optional Amount object, amount of total fees.
+    totalFees: optional<Amount>;
+    # Optional 32 bits integer, transaction's lock time (refer to BitcoinLikeTransaction class).
+    lockTime: optional<i32>;
+}
+
+# Structure representing a prepared bitcoin transaction (ready to be used with device).
+BitcoinLikePreparedTransaction = record {
+    # 32-bit integer representing version.
+    version: i32;
+    # List of BitcoinLikeInput objects, inputs aggregateed by transaction.
+    inputs: list<BitcoinLikeOutput>;
+    # List of stringsm paths to account creating transaction.
+    paths: list<string>;
+    # List of BitcoinLikeOutput objects, outputs aggregateed by transaction.
+    outputs: list<BitcoinLikeOutput>;
+    # 32-bit integer, block height after which transaction can be accepted.
+    lockTime: i32;
+}
+
+# Enum of picking strategies.
+BitcoinLikePickingStrategy = enum {
+    deep_outputs_first;
+    optimize_size;
+    merge_outputs;
+}
+
+BitcoinLikeTransactionBuilder = interface +c {
+    # Add the given input to the final transaction.
+    # @param transactionhash The hash of the transaction in where the UTXO can be located.
+    # @params index Index of the UTXO in the previous transaction
+    # @params sequence Sequence number to add at the end of the input serialization. This can be used for RBF transaction
+    # @return A reference on the same builder in order to chain calls.
+    addInput(transactionHash: string, index: i32, sequence: i32): BitcoinLikeTransactionBuilder;
+
+    # Add the given output to the final transaction.
+    # @return A reference on the same builder in order to chain calls.
+    addOutput(amount: Amount, script: BitcoinLikeScript): BitcoinLikeTransactionBuilder;
+
+    # If needed the transaction will send its change to the given path. It is possible to add multiple change path.
+    # @return A reference on the same builder in order to chain calls.
+    addChangePath(path: string): BitcoinLikeTransactionBuilder;
+
+    # Exclude UTXO from the coin selection (alias UTXO picking). You can call this method multiple times to exclude multiple
+    # UTXO.
+    # @param transactionHash The hash of the transaction in which this UTXO can be found.
+    # @param outputIndex The position of the output in the previous transaction,
+    # @return A reference on the same builder in order to chain calls.
+    excludeUTXO(transactionHash: string, outputIndex: i32): BitcoinLikeTransactionBuilder;
+
+    # Set the the number of change addresses in the transaction builder.
+    # @return A reference on the same builder in order to chain calls.
+    setNumberOfChangeAddresses(count: i32): BitcoinLikeTransactionBuilder;
+
+    # Set the maximum amount per change output. By default there is no max amount.
+    # @return A reference on the same builder in order to chain calls.
+    setMaxAmountOnChange(amount: Amount): BitcoinLikeTransactionBuilder;
+
+    # Set the minimum amount per change output. By default this value is the dust value of the currency.
+    # @return A reference on the same builder in order to chain calls.
+    setMinAmountOnChange(amount: Amount): BitcoinLikeTransactionBuilder;
+
+    # Set the UTXO picking strategy (see [[BitcoinLikePickingStrategy]]).
+    # @param strategy The strategy to adopt in order to select which input to use in the transaction.
+    # @param sequence The sequence value serialized at the end of the raw transaction. If you don't know what to put here
+    # just use 0xFFFFFF
+    # @return A reference on the same builder in order to chain calls.
+    pickInputs(strategy: BitcoinLikePickingStrategy, sequence: i32): BitcoinLikeTransactionBuilder;
+
+    # Send funds to the given address. This method can be called multiple times to send to multiple addresses.
+    # @param amount The value to send
+    # @param address Address of the recipient
+    # @return A reference on the same builder in order to chain calls.
+    sendToAddress(amount: Amount, address: string): BitcoinLikeTransactionBuilder;
+
+    # Send all available funds to the given address.
+    # @param address Address of the recipient
+    # @return A reference on the same builder in order to chain calls.
+    wipeToAddress(address: string): BitcoinLikeTransactionBuilder;
+
+    # Set the amount of fees per byte (of the raw transaction).
+    # @return A reference on the same builder in order to chain calls.
+    setFeesPerByte(fees: Amount): BitcoinLikeTransactionBuilder;
+
+    # Build a transaction from the given builder parameters.
+    build(callback: callback2<void, optional<BitcoinLikeTransaction>, optional<Error>>);
+
+    # Creates a clone of this builder.
+    # @return A copy of the current builder instance.
+    clone(): BitcoinLikeTransactionBuilder;
+
+    # Reset the current instance to its initial state.
+    reset();
+
+    # Parsing unsigned transaction.
+    # parsing a tx might change depending on block height we are on (if an update is effective starting from a given hight)
+    static parseRawUnsignedTransaction(currency: Currency, rawTransaction: binary, currentBlockHeight: optional<i32>): BitcoinLikeTransaction;
+}
+
+# Class representing a Bitcoin account.
+BitcoinLikeAccount = interface +c {
+    # Get UTXOs of account in a given range.
+    # @param from, integer, lower bound for account's UTXO's index
+    # @param to, integer, upper bound for account's UTXO's index
+    # @param callback, ListCallback object which returns a list of BitcoinLikeOutput if getUTXO succeed
+    getUTXO(from: i32, to: i32, callback: callback2<void, optional<list<BitcoinLikeOutput>>, optional<Error>>);
+    # Get UTXOs count of account.
+    # @param callback, Callback object which returns number of UTXO owned by this account
+    getUTXOCount(callback: callback2<void, optional<i32>, optional<Error>>);
+    broadcastRawTransaction(transaction: binary, callback: callback2<void, optional<string>, optional<Error>>);
+    broadcastTransaction(transaction: BitcoinLikeTransaction, callback: callback2<void, optional<string>, optional<Error>>);
+    buildTransaction(partial: optional<bool>): BitcoinLikeTransactionBuilder;
+    # Get fees from network, fees are ordered in descending order (i.e. fastest to slowest confirmation)
+    # Note: it would have been better to have this method on BitcoinLikeWallet
+    # but since BitcoinLikeWallet is not used anywhere, it's better to keep all
+    # specific methods under the same specific class so it will be easy to segratate
+    # when the right time comes !
+    getFees(callback: callback2<void, optional<list<BigInt>>, optional<Error>>);
+}
+
+# A bitcoin-like wallet.
+BitcoinLikeWallet = interface +c {
+
+}

--- a/ledger-core-bitcoin/idl/script.djinni
+++ b/ledger-core-bitcoin/idl/script.djinni
@@ -1,0 +1,26 @@
+@extern "../../ledger-core/idl/core.yaml"
+
+BitcoinLikeScriptOperator = record {
+    operatorName: string;
+    value: i8;
+}
+
+BitcoinLikeScriptChunk = interface +c {
+    isOperator(): bool;
+    isPushedData(): bool;
+    getOperator(): optional<BitcoinLikeScriptOperator>;
+    getPushedData(): optional<binary>;
+    next(): BitcoinLikeScriptChunk;
+    hasNext(): bool;
+}
+
+# A general purpose script.
+BitcoinLikeScript = interface +c {
+    # Get the head of the script. Scripts are organized by chunks, so you get an iterator-like
+    # interface.
+    head(): BitcoinLikeScriptChunk;
+    # Turn the script into a string representation.
+    toString(): string;
+    # Parse data into a script.
+    static parse(data: binary): BitcoinLikeScript;
+}

--- a/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeAccount.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeAccount.hpp
@@ -1,0 +1,160 @@
+/*
+ *
+ * BitcoinLikeAccount
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 28/04/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <soci.h>
+
+#include <core/api/Amount.hpp>
+#include <core/preferences/Preferences.hpp>
+#include <core/wallet/AbstractAccount.hpp>
+
+#include <bitcoin/BitcoinLikeWallet.hpp>
+#include <bitcoin/api/BitcoinLikeAccount.hpp>
+#include <bitcoin/api/BitcoinLikePickingStrategy.hpp>
+#include <bitcoin/api/BitcoinLikePreparedTransaction.hpp>
+#include <bitcoin/api/BitcoinLikeOutput.hpp>
+#include <bitcoin/api/BitcoinLikeTransactionRequest.hpp>
+#include <bitcoin/operations/BitcoinLikeOperation.hpp>
+#include <bitcoin/keychains/BitcoinLikeKeychain.hpp>
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+#include <bitcoin/synchronizers/BitcoinLikeAccountSynchronizer.hpp>
+#include <bitcoin/transactions/BitcoinLikeUTXOPicker.hpp>
+
+namespace ledger {
+    namespace core {
+        class Operation;
+        class BitcoinLikeUtxoPicker;
+        class BitcoinLikeAccount : public api::BitcoinLikeAccount, public AbstractAccount {
+        public:
+            static const int FLAG_NEW_TRANSACTION = 0x01;
+            static const int FLAG_TRANSACTION_UPDATED = 0x01 << 1;
+            static const int FLAG_TRANSACTION_IGNORED = 0x00;
+            static const int FLAG_TRANSACTION_ON_PREVIOUSLY_EMPTY_ADDRESS = 0x01 << 2;
+            static const int FLAG_TRANSACTION_ON_USED_ADDRESS = 0x01 << 3;
+            static const int FLAG_TRANSACTION_CREATED_SENDING_OPERATION = 0x01 << 4;
+            static const int FLAG_TRANSACTION_CREATED_RECEPTION_OPERATION = 0x01 << 5;
+
+            BitcoinLikeAccount(const std::shared_ptr<AbstractWallet>& wallet,
+                               int32_t index,
+                               const std::shared_ptr<BitcoinLikeBlockchainExplorer>& explorer,
+                               const std::shared_ptr<BitcoinLikeBlockchainObserver>& observer,
+                               const std::shared_ptr<BitcoinLikeAccountSynchronizer>& synchronizer,
+                               const std::shared_ptr<BitcoinLikeKeychain>& keychain
+            );
+
+            /**
+             *
+             * @param transaction
+             * @return A flag indicating if the transaction was ignored, inserted
+             */
+            int putTransaction(soci::session& sql, const BitcoinLikeBlockchainExplorerTransaction& transaction);
+            /**
+             *
+             * @param block
+             * @return true if the block wasn't already known.
+             */
+            bool putBlock(soci::session& sql, const BitcoinLikeBlockchainExplorer::Block& block);
+
+            std::shared_ptr<BitcoinLikeKeychain> getKeychain() const;
+
+            void startBlockchainObservation() override;
+            void stopBlockchainObservation() override;
+            bool isObservingBlockchain() override;
+
+            /***
+             * REVIEW
+             */
+
+            bool isSynchronizing() override;
+
+            FuturePtr<ledger::core::Amount> getBalance() override;
+
+            Future<std::vector<std::shared_ptr<api::Amount>>> getBalanceHistory(const std::string & start,
+                                                                           const std::string & end,
+                                                                           api::TimePeriod precision) override;
+
+            FuturePtr<BitcoinLikeBlockchainExplorerTransaction> getTransaction(const std::string& hash);
+
+            std::shared_ptr<api::EventBus> synchronize() override;
+
+            void broadcastRawTransaction(const std::vector<uint8_t> &transaction,
+                                         const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<api::Error>)> & callback) override;
+
+            void broadcastTransaction(const std::shared_ptr<api::BitcoinLikeTransaction> &transaction,
+                                      const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<api::Error>)> & callback) override;
+
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder> buildTransaction(std::experimental::optional<bool> partial) override;
+
+            std::shared_ptr<api::OperationQuery> queryOperations() override;
+
+            void getUTXO(int32_t from, int32_t to,
+                         const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>>, std::experimental::optional<api::Error>)> & callback) override;
+            Future<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>> getUTXO();
+            Future<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>> getUTXO(int32_t from, int32_t to);
+            void getUTXOCount(const std::function<void(std::experimental::optional<int32_t>, std::experimental::optional<api::Error>)> & callback) override;
+            Future<int32_t> getUTXOCount();
+
+            Future<AddressList> getFreshPublicAddresses() override;
+
+            Future<std::string> broadcastTransaction(const std::vector<uint8_t>& transaction);
+
+            std::string getRestoreKey() override;
+
+            const std::shared_ptr<BitcoinLikeBlockchainExplorer>& getExplorer() const;
+
+            Future<api::ErrorCode> eraseDataSince(const std::chrono::system_clock::time_point & date) override ;
+
+            void getFees(const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::BigInt>>>, std::experimental::optional<api::Error>)> & callback) override ;
+        protected:
+            bool checkIfWalletIsEmpty();
+
+        private:
+            std::shared_ptr<BitcoinLikeAccount> getSelf();
+            inline void inflateOperation(BitcoinLikeOperation& out,
+                                         const std::shared_ptr<const AbstractWallet>& wallet,
+                                         const BitcoinLikeBlockchainExplorerTransaction& tx);
+            inline void computeOperationTrust(BitcoinLikeOperation& operation,
+                                              const std::shared_ptr<const AbstractWallet>& wallet,
+                                              const BitcoinLikeBlockchainExplorerTransaction& tx);
+
+        private:
+            std::shared_ptr<BitcoinLikeKeychain> _keychain;
+            std::shared_ptr<BitcoinLikeBlockchainExplorer> _explorer;
+            std::shared_ptr<BitcoinLikeAccountSynchronizer> _synchronizer;
+            std::shared_ptr<BitcoinLikeBlockchainObserver> _observer;
+            std::shared_ptr<BitcoinLikeUTXOPicker> _picker;
+            std::shared_ptr<api::EventBus> _currentSyncEventBus;
+            std::mutex _synchronizationLock;
+            uint64_t _currentBlockHeight;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeAddress.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeAddress.hpp
@@ -1,0 +1,100 @@
+/*
+ *
+ * BitcoinLikeAddress
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 12/12/2016.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/address/Address.hpp>
+#include <core/collections/DynamicObject.hpp>
+#include <core/utils/Optional.hpp>
+
+#include <bitcoin/api/BitcoinLikeAddress.hpp>
+#include <bitcoin/api/BitcoinLikeNetworkParameters.hpp>
+#include <bitcoin/api/BitcoinLikeExtendedPublicKey.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeAddress : public api::BitcoinLikeAddress, public Address {
+        public:
+            BitcoinLikeAddress(const api::Currency& currency,
+                               const std::vector<uint8_t>& hash160,
+                               const std::string &keychainEngine,
+                               const Option<std::string>& derivationPath = Option<std::string>());
+            virtual std::vector<uint8_t> getVersion() override;
+            std::vector<uint8_t> getVersionFromKeychainEngine(const std::string &keychainEngine,
+                                                              const api::BitcoinLikeNetworkParameters &params) const;
+            virtual std::vector<uint8_t> getHash160() override;
+            virtual api::BitcoinLikeNetworkParameters getNetworkParameters() override;
+            virtual std::string toBase58() override;
+            virtual std::string toBech32() override;
+            std::string toBase58() const;
+            std::string toBech32() const;
+            virtual bool isP2SH() override;
+            virtual bool isP2PKH() override;
+            virtual bool isP2WSH() override;
+            virtual bool isP2WPKH() override;
+            virtual optional<std::string> getDerivationPath() override;
+
+            std::string toString() override;
+            std::string getStringAddress() const;
+
+            static std::shared_ptr<Address> parse(const std::string& address, const api::Currency& currency,
+                                                          const Option<std::string>& derivationPath = Option<std::string>());
+            static std::shared_ptr<BitcoinLikeAddress> fromBase58(const std::string& address,
+                                                                  const api::Currency& currency,
+                                                                  const Option<std::string>& derivationPath = Option<std::string>());
+
+            static std::shared_ptr<BitcoinLikeAddress> fromBech32(const std::string& address,
+                                                                  const api::Currency& currency,
+                                                                  const Option<std::string>& derivationPath = Option<std::string>());
+
+            static std::string fromPublicKey(const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &pubKey,
+                                             const api::Currency &currency,
+                                             const std::string &derivationPath,
+                                             const std::string &keychainEngine);
+
+            static std::vector<uint8_t> fromPublicKeyToHash160(const std::vector<uint8_t> &pubKey,
+                                                               const std::vector<uint8_t> &pubKeyHash160,
+                                                               const api::Currency &currency,
+                                                               const std::string &keychainEngine);
+
+            static std::vector<uint8_t> fromPublicKeyToHash160(const std::vector<uint8_t> &pubKey,
+                                                               const api::Currency &currency,
+                                                               const std::string &keychainEngine);
+
+
+        private:
+            const std::vector<uint8_t> _hash160;
+            const api::BitcoinLikeNetworkParameters _params;
+            const Option<std::string> _derivationPath;
+            const std::string _keychainEngine;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeCoinID.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeCoinID.hpp
@@ -1,0 +1,61 @@
+/*
+ *
+ * RippleLikeCoinID
+ *
+ * Created by Alexis Le Provost on 2019/12/12.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+namespace ledger {
+    namespace core {
+        static uint64_t constexpr BITCOIN_COIN_ID = 0;
+        static uint64_t constexpr BITCOIN_TESTNET_COIN_ID = 1;
+        static uint64_t constexpr BITCOIN_CASH_COIN_ID = 145;
+        static uint64_t constexpr BITCOIN_GOLD_COIN_ID = 156;
+        static uint64_t constexpr ZCASH_COIN_ID = 121;
+        static uint64_t constexpr LITE_COIN_ID = 2;
+        static uint64_t constexpr PEERCOIN_COIN_ID = 6;
+        static uint64_t constexpr DIGIBYTE_COIN_ID = 20;
+        static uint64_t constexpr HCASH_COIN_ID = 171;
+        static uint64_t constexpr QTUM_COIN_ID = 88;
+        static uint64_t constexpr STEALTHCOIN_COIN_ID = 125;
+        static uint64_t constexpr VERTCOIN_COIN_ID = 128;
+        static uint64_t constexpr VIACOIN_COIN_ID = 14;
+        static uint64_t constexpr DASH_COIN_ID = 5;
+        static uint64_t constexpr DOGECOIN_COIN_ID = 3;
+        static uint64_t constexpr STRATIS_COIN_ID = 105;
+        static uint64_t constexpr KOMODO_COIN_ID = 141;
+        static uint64_t constexpr POSWALLET_COIN_ID = 47;
+        static uint64_t constexpr PIVX_COIN_ID = 77;
+        static uint64_t constexpr CLUBCOIN_COIN_ID = 79;
+        static uint64_t constexpr DECRED_COIN_ID = 42;
+        static uint64_t constexpr STAKENET_COIN_ID = 384;
+        
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeCurrencies.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeCurrencies.hpp
@@ -1,0 +1,71 @@
+/*
+ *
+ * BitcoinLikeCurrencies
+ *
+ * Created Alexis Le Provost on 2019/12/12
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#ifndef LIBCORE_EXPORT
+    #if defined(_MSC_VER)
+        #include <core/LibCoreExport.hpp>
+    #else
+        #define LIBCORE_EXPORT
+    #endif
+#endif
+
+#include <core/api/Currency.hpp>
+
+namespace ledger {
+    namespace core {
+        namespace currencies {
+            extern LIBCORE_EXPORT const api::Currency BITCOIN;
+            extern LIBCORE_EXPORT const api::Currency BITCOIN_TESTNET;
+            extern LIBCORE_EXPORT const api::Currency BITCOIN_CASH;
+            extern LIBCORE_EXPORT const api::Currency BITCOIN_GOLD;
+            extern LIBCORE_EXPORT const api::Currency ZCASH;
+            extern LIBCORE_EXPORT const api::Currency ZENCASH;
+            extern LIBCORE_EXPORT const api::Currency LITECOIN;
+            extern LIBCORE_EXPORT const api::Currency PEERCOIN;
+            extern LIBCORE_EXPORT const api::Currency DIGIBYTE;
+            extern LIBCORE_EXPORT const api::Currency HCASH;
+            extern LIBCORE_EXPORT const api::Currency QTUM;
+            extern LIBCORE_EXPORT const api::Currency STEALTHCOIN;
+            extern LIBCORE_EXPORT const api::Currency VERTCOIN;
+            extern LIBCORE_EXPORT const api::Currency VIACOIN;
+            extern LIBCORE_EXPORT const api::Currency DASH;
+            extern LIBCORE_EXPORT const api::Currency DOGECOIN;
+            extern LIBCORE_EXPORT const api::Currency STRATIS;
+            extern LIBCORE_EXPORT const api::Currency KOMODO;
+            extern LIBCORE_EXPORT const api::Currency POSWALLET;
+            extern LIBCORE_EXPORT const api::Currency PIVX;
+            extern LIBCORE_EXPORT const api::Currency CLUBCOIN;
+            extern LIBCORE_EXPORT const api::Currency DECRED;
+            extern LIBCORE_EXPORT const api::Currency STAKENET;
+        }
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeExtendedPublicKey.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeExtendedPublicKey.hpp
@@ -1,0 +1,104 @@
+/*
+ *
+ * BitcoinLikeExtendedPublicKey
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 14/12/2016.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <core/api/Currency.hpp>
+#include <core/crypto/DeterministicPublicKey.hpp>
+#include <core/key/ExtendedPublicKey.hpp>
+#include <core/utils/DerivationPath.hpp>
+#include <core/utils/Option.hpp>
+
+#include <bitcoin/BitcoinNetworks.hpp>
+#include <bitcoin/api/BitcoinLikeExtendedPublicKey.hpp>
+#include <bitcoin/api/BitcoinLikeNetworkParameters.hpp>
+
+namespace ledger {
+    namespace core {
+        using BitcoinExtendedPublicKey = ExtendedPublicKey<api::BitcoinLikeNetworkParameters>;
+        class BitcoinLikeExtendedPublicKey : public BitcoinExtendedPublicKey, public api::BitcoinLikeExtendedPublicKey {
+        public:
+            BitcoinLikeExtendedPublicKey(const api::Currency& params,
+                                         const DeterministicPublicKey& key,
+                                         const std::shared_ptr<DynamicObject> &configuration,
+                                         const DerivationPath& path = DerivationPath("m/"));
+            std::shared_ptr<api::BitcoinLikeAddress> derive(const std::string &path) override;
+            std::shared_ptr<BitcoinLikeExtendedPublicKey> derive(const DerivationPath& path);
+
+            std::vector<uint8_t> derivePublicKey(const std::string &path) override;
+
+            std::vector<uint8_t> deriveHash160(const std::string &path) override;
+
+            std::string toBase58() override;
+
+            std::string getRootPath() override;
+
+        public:
+            static std::shared_ptr<BitcoinLikeExtendedPublicKey> fromRaw(
+                    const api::Currency& params,
+                    const optional<std::vector<uint8_t>>& parentPublicKey,
+                    const std::vector<uint8_t>& publicKey,
+                    const std::vector<uint8_t> &chainCode,
+                    const std::string& path,
+                    const std::shared_ptr<DynamicObject> &configuration
+            );
+
+            static std::shared_ptr<BitcoinLikeExtendedPublicKey> fromBase58(
+                const api::Currency& currency,
+                const std::string& xpubBase58,
+                const Option<std::string>& path,
+                const std::shared_ptr<DynamicObject> &configuration
+            );
+
+        protected:
+            const api::BitcoinLikeNetworkParameters params() const override {
+                return networks::getBitcoinLikeNetworkParameters(_currency.name);
+            };
+            const DeterministicPublicKey &getKey() const override {
+                return _key;
+            };
+            const DerivationPath &getPath() const override {
+                return _path;
+            };
+            const api::Currency &getCurrency() const override {
+                return _currency;
+            };
+        private:
+
+            const api::Currency _currency;
+            const DerivationPath _path;
+            const DeterministicPublicKey _key;
+            const std::shared_ptr<DynamicObject> _configuration;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeWallet.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeWallet.hpp
@@ -1,0 +1,98 @@
+/*
+ *
+ * BitcoinLikeWallet
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 19/12/2016.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <core/Services.hpp>
+#include <core/wallet/AbstractWallet.hpp>
+
+#include <bitcoin/api/BitcoinLikeWallet.hpp>
+#include <bitcoin/api/BitcoinLikeNetworkParameters.hpp>
+#include <bitcoin/database/BitcoinLikeWalletDatabase.hpp>
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+#include <bitcoin/factories/BitcoinLikeWalletFactory.hpp>
+#include <bitcoin/keychains/BitcoinLikeKeychain.hpp>
+#include <bitcoin/observers/BitcoinLikeBlockchainObserver.hpp>
+#include <bitcoin/synchronizers/BitcoinLikeAccountSynchronizer.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeWallet : public virtual api::BitcoinLikeWallet, public virtual AbstractWallet {
+        public:
+            using BitcoinLikeAccountSynchronizerFactory = std::function<std::shared_ptr<BitcoinLikeAccountSynchronizer> ()>;
+
+            BitcoinLikeWallet(
+                const std::string& name,
+                const std::shared_ptr<BitcoinLikeBlockchainExplorer>& explorer,
+                const std::shared_ptr<BitcoinLikeBlockchainObserver>& observer,
+                const std::shared_ptr<BitcoinLikeKeychainFactory>& keychainFactory,
+                const BitcoinLikeAccountSynchronizerFactory& synchronizerFactory,
+                const std::shared_ptr<Services>& services,
+                const api::Currency& network,
+                const std::shared_ptr<DynamicObject>& configuration,
+                const DerivationScheme& scheme
+            );
+
+            // API methods
+            bool isSynchronizing() override;
+            std::shared_ptr<api::EventBus> synchronize() override;
+
+            FuturePtr<ledger::core::api::Account> newAccountWithInfo(const api::AccountCreationInfo &info) override;
+
+            FuturePtr<ledger::core::api::Account>
+            newAccountWithExtendedKeyInfo(const api::ExtendedKeyAccountCreationInfo &info) override;
+
+            Future<api::ExtendedKeyAccountCreationInfo>
+            getExtendedKeyAccountCreationInfo(int32_t accountIndex) override;
+
+            Future<api::AccountCreationInfo> getAccountCreationInfo(int32_t accountIndex) override;
+
+            std::shared_ptr<BitcoinLikeBlockchainExplorer> getBlockchainExplorer();
+
+            bool hasMultipleAddresses() const override;
+
+        protected:
+            std::shared_ptr<AbstractAccount>
+            createAccountInstance(soci::session &sql, const std::string &accountUid) override;
+
+        private:
+            std::shared_ptr<BitcoinLikeWallet> getSelf();
+
+        private:
+            std::shared_ptr<BitcoinLikeBlockchainExplorer> _explorer;
+            std::shared_ptr<BitcoinLikeBlockchainObserver> _observer;
+            std::shared_ptr<BitcoinLikeKeychainFactory> _keychainFactory;
+            BitcoinLikeAccountSynchronizerFactory _synchronizerFactory;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/BitcoinNetworks.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/BitcoinNetworks.hpp
@@ -1,0 +1,124 @@
+/*
+ *
+ * networks
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 27/01/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#ifndef LIBCORE_EXPORT
+    #if defined(_MSC_VER)
+        #include <libcore_export.h>
+    #else
+        #define LIBCORE_EXPORT
+    #endif
+#endif
+
+#include <bitcoin/api/BitcoinLikeNetworkParameters.hpp>
+
+namespace ledger {
+    namespace core {
+
+        namespace networks {
+
+            enum sigHashType : uint8_t {
+                SIGHASH_ALL = 0x01,
+                SIGHASH_NONE = 0x02,
+                SIGHASH_SINGLE = 0x03,
+                SIGHASH_FORKID = 0x40,
+                SIGHASH_ANYONECANPAY = 0x80
+            };
+            
+            // Since version for networks are starting at 1
+            static const int HIGHTEST_PARAMETERS_VERSION = 2;
+
+            extern LIBCORE_EXPORT const api::BitcoinLikeNetworkParameters getBitcoinLikeNetworkParameters(const std::string &networkName, int version = HIGHTEST_PARAMETERS_VERSION);
+            extern LIBCORE_EXPORT const std::vector<api::BitcoinLikeNetworkParameters> ALL_BITCOIN;
+
+            // Since we are not (supposed) to have too many versions, we migrate from the beginning ...
+            // TODO: could be optimized by saving last HIGHTEST_PARAMETERS_VERSION and start from it
+            // or better add a field version to BitcoinLikeNetworkParameters
+            template <int Migration>
+            void migrateParameters(api::BitcoinLikeNetworkParameters &params) {
+                // Migration not implemented
+                return;
+            }
+            void migrateParameters(api::BitcoinLikeNetworkParameters &params, int migration);
+
+            static bool migrateParameters(api::BitcoinLikeNetworkParameters &params,
+                                          int currentVersion,
+                                          int targetVersion) {
+                if (targetVersion < 2 || currentVersion < 1) {
+                    return false;
+                }
+                auto previous = migrateParameters(params, currentVersion,  targetVersion - 1);
+                if (currentVersion < targetVersion) {
+                    migrateParameters(params, targetVersion);
+                    return true;
+                }
+                return previous;
+            };
+
+            //BIP115 (ex: Zencash)
+            struct BIP115Parameters {
+                std::string blockHash;
+                std::vector<uint8_t> blockHeight;
+            };
+            extern LIBCORE_EXPORT const BIP115Parameters BIP115_PARAMETERS;
+
+            //ZIP: Zcash improvements/updates (ex: Zcash overwinter, Sapling ...)
+            struct ZIPParameters {
+                uint32_t version;
+                std::vector<uint8_t> overwinterFlag;
+                std::vector<uint8_t> versionGroupId;
+                uint64_t blockHeight; //block height at which ZIP will be effective
+            };
+            extern LIBCORE_EXPORT const ZIPParameters ZIP143_PARAMETERS;
+            extern LIBCORE_EXPORT const ZIPParameters ZIP_SAPLING_PARAMETERS;
+            template<class Archive>
+            void serialize(Archive & archive,
+                           api::BitcoinLikeNetworkParameters & p)
+            {
+                archive(
+                    p.Identifier,
+                    p.P2PKHVersion,
+                    p.P2SHVersion,
+                    p.XPUBVersion,
+                    p.FeePolicy,
+                    p.DustAmount,
+                    p.MessagePrefix,
+                    p.UsesTimestampedTransaction,
+                    p.TimestampDelay,
+                    p.SigHash,
+                    p.AdditionalBIPs
+                );
+            }
+
+        }
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/bech32/BCHBech32.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/bech32/BCHBech32.hpp
@@ -1,0 +1,56 @@
+/*
+ *
+ * BCHBech32
+ *
+ * Created by El Khalil Bellakrid on 18/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <bitcoin/bech32/Bech32.hpp>
+#include <bitcoin/bech32/Bech32Parameters.hpp>
+
+// Refecrence: https://github.com/bitcoincashjs/cashaddrjs
+namespace ledger {
+    namespace core {
+        class BCHBech32 : public Bech32 {
+        public:
+            BCHBech32() {
+                _bech32Params = Bech32Parameters::getBech32Params("abc");
+            };
+
+            uint64_t polymod(const std::vector<uint8_t>& values) override;
+
+            std::vector<uint8_t> expandHrp(const std::string& hrp) override;
+
+            std::string encode(const std::vector<uint8_t>& hash,
+                               const std::vector<uint8_t>& version) override;
+
+            std::pair<std::vector<uint8_t>, std::vector<uint8_t>>
+            decode(const std::string& str) override;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/bech32/BTCBech32.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/bech32/BTCBech32.hpp
@@ -1,0 +1,56 @@
+/*
+ *
+ * BTCBech32
+ *
+ * Created by El Khalil Bellakrid on 18/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <bitcoin/bech32/Bech32.hpp>
+#include <bitcoin/bech32/Bech32Parameters.hpp>
+
+// Reference: https://github.com/sipa/bech32
+namespace ledger {
+    namespace core {
+        class BTCBech32 : public Bech32 {
+        public:
+            BTCBech32(const std::string &networkIdentifier) {
+                _bech32Params = Bech32Parameters::getBech32Params(networkIdentifier);
+            };
+
+            uint64_t polymod(const std::vector<uint8_t>& values) override;
+
+            std::vector<uint8_t> expandHrp(const std::string& hrp) override;
+
+            std::string encode(const std::vector<uint8_t>& hash,
+                               const std::vector<uint8_t>& version) override;
+
+            std::pair<std::vector<uint8_t>, std::vector<uint8_t>>
+            decode(const std::string& str) override;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/bech32/Bech32.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/bech32/Bech32.hpp
@@ -1,0 +1,85 @@
+/*
+ *
+ * Bech32
+ *
+ * Created by El Khalil Bellakrid on 13/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+// References:
+// BIP173: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+// Implementation: https://github.com/sipa/bech32/tree/master/ref/c%2B%2B
+
+#include <vector>
+#include <string>
+
+#include <bitcoin/bech32/Bech32Parameters.hpp>
+
+// HRP refers to Human Readable Part
+namespace ledger {
+    namespace core {
+        class Bech32 {
+        public:
+            // Find the polynomial with value coefficients mod the generator as 64-bit.
+            virtual uint64_t polymod(const std::vector<uint8_t>& values) = 0;
+
+            // Expand a HRP for use in checksum computation.
+            virtual std::vector<uint8_t> expandHrp(const std::string& hrp) = 0;
+
+            bool verifyChecksum(const std::vector<uint8_t>& values);
+
+            std::vector<uint8_t> createChecksum(const std::vector<uint8_t>& values);
+
+            virtual std::string encode(const std::vector<uint8_t>& hash,
+                                       const std::vector<uint8_t>& version) = 0;
+
+            // Decode from bech32 address
+            // @return pair<hrp, hash>
+            std::pair<std::string, std::vector<uint8_t>>
+            decodeBech32(const std::string& str);
+            // @return tuple<witnessVersion, hash>
+            virtual std::pair<std::vector<uint8_t>, std::vector<uint8_t>>
+            decode(const std::string& str) = 0;
+
+            static unsigned char toLowerCase(unsigned char c);
+
+            static bool convertBits(const std::vector<uint8_t>& in,
+                                    int fromBits,
+                                    int toBits,
+                                    bool pad,
+                                    std::vector<uint8_t>& out);
+
+            Bech32Parameters::Bech32Struct getBech32Params() {
+                return _bech32Params;
+            }
+
+        protected:
+            std::string encodeBech32(const std::vector<uint8_t>& values);
+            Bech32Parameters::Bech32Struct _bech32Params;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/bech32/Bech32Factory.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/bech32/Bech32Factory.hpp
@@ -1,0 +1,48 @@
+/*
+ *
+ * Bech32Factory
+ *
+ * Created by El Khalil Bellakrid on 18/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <string>
+#include <memory>
+
+#include <core/utils/Option.hpp>
+
+#include <bitcoin/bech32/Bech32.hpp>
+
+namespace ledger {
+    namespace core {
+        class Bech32Factory {
+        public:
+            static Option<std::shared_ptr<Bech32>> newBech32Instance(const std::string &networkIdentifier);
+        };
+    }
+}
+

--- a/ledger-core-bitcoin/inc/bitcoin/bech32/Bech32Parameters.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/bech32/Bech32Parameters.hpp
@@ -1,0 +1,82 @@
+/*
+ *
+ * Bech32Parameters
+ *
+ * Created by El Khalil Bellakrid on 14/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#ifndef LIBCORE_EXPORT
+    #if defined(_MSC_VER)
+        #include <libcore_export.h>
+    #else
+        #define LIBCORE_EXPORT
+    #endif
+#endif
+
+#include <string>
+#include <vector>
+
+#include <soci.h>
+
+namespace ledger {
+    namespace core {
+        namespace Bech32Parameters {
+
+            struct Bech32Struct {
+                std::string name;
+                std::string hrp;
+                std::string separator;
+                size_t checksumSize;
+                std::vector<unsigned long long> generator;
+                std::vector<uint8_t> P2WPKHVersion;
+                std::vector<uint8_t> P2WSHVersion;
+
+                Bech32Struct() = default;
+                Bech32Struct(const std::string &_name,
+                             const std::string &_hrp,
+                             const std::string &_separator,
+                             size_t _checksumSize,
+                             const std::vector<unsigned long long> &_generator,
+                             const std::vector<uint8_t> &_P2WPKHVersion,
+                             const std::vector<uint8_t> &_P2WSHVersion) : name(_name),
+                                                                          hrp(_hrp),
+                                                                          separator(_separator),
+                                                                          checksumSize(_checksumSize),
+                                                                          generator(_generator),
+                                                                          P2WPKHVersion(_P2WPKHVersion),
+                                                                          P2WSHVersion(_P2WSHVersion)
+
+                {};
+
+            };
+            extern LIBCORE_EXPORT const Bech32Struct getBech32Params(const std::string &networkIdentifier);
+            extern LIBCORE_EXPORT const std::vector<Bech32Struct> ALL;
+            bool insertParameters(soci::session& sql, const Bech32Struct &params);
+        }
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/block/BitcoinLikeBlock.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/block/BitcoinLikeBlock.hpp
@@ -1,0 +1,52 @@
+/*
+ *
+ * BitcoinLikeBlockApi
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 12/07/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/operation/Operation.hpp>
+#include <core/api/Block.hpp>
+
+#include <bitcoin/api/BitcoinLikeBlock.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeBlock : public api::BitcoinLikeBlock {
+        public:
+            BitcoinLikeBlock(const api::Block& block);
+            std::string getHash() override;
+            int64_t getHeight() override;
+            std::chrono::system_clock::time_point getTime() override;
+
+        private:
+            api::Block _block;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/block/BitcoinLikeBlockParser.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/block/BitcoinLikeBlockParser.hpp
@@ -1,0 +1,53 @@
+/*
+ *
+ * BlockParser
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 27/03/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/explorers/AbstractBlockParser.hpp>
+
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeBlockParser : public AbstractBlockParser<BitcoinLikeBlockchainExplorer::Block> {
+        public:
+            BitcoinLikeBlockParser(std::string &lastKey) : _lastKey(lastKey) {};
+
+        protected:
+            std::string &getLastKey() override {
+                return _lastKey;
+            };
+
+        private:
+            std::string& _lastKey;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeAccountDatabase.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeAccountDatabase.hpp
@@ -1,0 +1,51 @@
+/*
+ *
+ * BitcoinLikeAccountDatabase
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 29/05/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/database/DatabaseSessionPool.hpp>
+
+#include <bitcoin/database/BitcoinLikeAccountDatabaseEntry.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeAccountDatabase {
+        public:
+            BitcoinLikeAccountDatabase(const std::string& walletUid, int32_t index);
+            std::string getAccountUid() {
+                return _accountUid;
+            };
+
+        private:
+            std::string _accountUid;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeAccountDatabaseEntry.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeAccountDatabaseEntry.hpp
@@ -1,0 +1,43 @@
+/*
+ *
+ * BitcoinLikeAccountDatabaseEntry
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 29/05/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <string>
+
+namespace ledger {
+    namespace core {
+        struct BitcoinLikeAccountDatabaseEntry {
+            int32_t index;
+            std::string xpub;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeAccountDatabaseHelper.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeAccountDatabaseHelper.hpp
@@ -1,0 +1,46 @@
+/*
+ *
+ * BitcoinLikeAccountDatabaseHelper
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 15/06/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <soci.h>
+
+#include <bitcoin/database/BitcoinLikeAccountDatabaseEntry.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeAccountDatabaseHelper {
+        public:
+            static void createAccount(soci::session& sql, const std::string walletUid, int32_t index, const std::string& xpub);
+            static bool queryAccount(soci::session& sql, const std::string& accountUid, BitcoinLikeAccountDatabaseEntry& entry);
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeBlockDatabaseHelper.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeBlockDatabaseHelper.hpp
@@ -1,0 +1,46 @@
+/*
+ *
+ * BitcoinLikeBlockDatabaseHelper.h
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 04/10/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <soci.h>
+
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeBlockDatabaseHelper {
+        public:
+            static bool blockExists(soci::session& sql, const BitcoinLikeBlockchainExplorer::Block& block);
+            static bool putBlock(soci::session& sql, const BitcoinLikeBlockchainExplorer::Block& block);
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.hpp
@@ -1,0 +1,67 @@
+/*
+ *
+ * BitcoinLikeTransactionDatabaseHelper
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 02/06/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma onoce
+
+#include <soci.h>
+
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeTransactionDatabaseHelper {
+        public:
+            static bool transactionExists(soci::session& sql, const std::string& btcTxUid);
+            static std::string putTransaction(soci::session& sql, const std::string& accountUid, const BitcoinLikeBlockchainExplorerTransaction& tx);
+            static inline void insertOutput(soci::session& sql,
+                                            const std::string& btcTxUid,
+                                            const std::string& transactionHash,
+                                            const BitcoinLikeBlockchainExplorerOutput& output);
+            static inline void insertInput(soci::session& sql,
+                                           const std::string& btcTxUid,
+                                           const std::string& accountUid,
+                                           const std::string& transactionHash,
+                                           const BitcoinLikeBlockchainExplorerInput& input);
+
+            static std::string createInputUid(const std::string& accountUid, int32_t previousOutputIndex, const std::string& previousTxHash, const std::string& coinbase);
+            static std::string createBitcoinTransactionUid(const std::string& accountUid, const std::string& txHash);
+            static bool getTransactionByHash(soci::session &sql,
+                                             const std::string &hash,
+                                             const std::string &accountUid,
+                                             BitcoinLikeBlockchainExplorerTransaction &out);
+
+            static inline bool inflateTransaction(soci::session& sql,
+                                                  const soci::row& row,
+                                                  const std::string &accountUid,
+                                                  BitcoinLikeBlockchainExplorerTransaction& out);
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.hpp
@@ -29,7 +29,7 @@
  *
  */
 
-#pragma onoce
+#pragma once
 
 #include <soci.h>
 

--- a/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeUTXODatabaseHelper.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeUTXODatabaseHelper.hpp
@@ -1,0 +1,56 @@
+/*
+ *
+ * BitcoinLikeUTXODatabaseHelper.h
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 25/09/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <soci.h>
+
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeUTXODatabaseHelper {
+            BitcoinLikeUTXODatabaseHelper() = delete;
+
+            ~BitcoinLikeUTXODatabaseHelper() = delete;
+
+        public:
+            static std::size_t queryUTXO(soci::session &sql, const std::string &accountUid,
+                           int32_t offset,
+                           int32_t count,
+                           std::vector<BitcoinLikeBlockchainExplorerOutput>& out,
+                           std::function<bool (const std::string& address)> filter);
+
+            static std::size_t UTXOcount(soci::session& sql, const std::string& accountUid,
+                                         std::function<bool (const std::string& address)> filter);
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeWalletDatabase.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/database/BitcoinLikeWalletDatabase.hpp
@@ -1,0 +1,61 @@
+/*
+ *
+ * BitcoinLikeSociWallet
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 29/05/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <soci.h>
+
+#include <core/Services.hpp>
+#include <core/database/DatabaseSessionPool.hpp>
+
+#include <bitcoin/database/BitcoinLikeAccountDatabase.hpp>
+
+namespace ledger {
+    namespace core {
+
+        class BitcoinLikeWalletDatabase {
+        public:
+            BitcoinLikeWalletDatabase(const std::shared_ptr<Services>& services,
+                                  const std::string& walletName,
+                                  const std::string& currencyName
+            );
+            int64_t getAccountsCount() const;
+            bool accountExists(int32_t index) const;
+            void createAccount(int32_t index, const std::string& xpub) const;
+            const std::string& getWalletUid() const;
+            int32_t getNextAccountIndex() const;
+
+        private:
+            const std::string _walletUid;
+            mutable std::shared_ptr<DatabaseSessionPool> _database;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/database/Migrations.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/database/Migrations.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <core/database/Migrations.hpp>
+
+#include <bitcoin/BitcoinLikeCoinID.hpp>
+
+namespace ledger {
+    namespace core {
+        /// Tag type.
+        struct BitcoinMigration {
+          static int constexpr COIN_ID = BITCOIN_COIN_ID;
+          static uint32_t constexpr CURRENT_VERSION = 6;
+        };
+
+        // migrations
+        template <> void migrate<1, BitcoinMigration>(soci::session& sql);
+        template <> void rollback<1, BitcoinMigration>(soci::session& sql);
+
+        template <> void migrate<2, BitcoinMigration>(soci::session& sql);
+        template <> void rollback<2, BitcoinMigration>(soci::session& sql);
+
+        template <> void migrate<3, BitcoinMigration>(soci::session& sql);
+        template <> void rollback<3, BitcoinMigration>(soci::session& sql);
+
+        template <> void migrate<4, BitcoinMigration>(soci::session& sql);
+        template <> void rollback<4, BitcoinMigration>(soci::session& sql);
+
+        template <> void migrate<5, BitcoinMigration>(soci::session& sql);
+        template <> void rollback<5, BitcoinMigration>(soci::session& sql);
+
+        template <> void migrate<6, BitcoinMigration>(soci::session& sql);
+        template <> void rollback<6, BitcoinMigration>(soci::session& sql);
+  }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp
@@ -1,0 +1,118 @@
+/*
+ *
+ * BitcoinLikeBlockchainExplorer
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 17/01/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include <core/api/BigInt.hpp>
+#include <core/api/Error.hpp>
+#include <core/async/Future.hpp>
+#include <core/collections/Collections.hpp>
+#include <core/explorers/AbstractBlockchainExplorer.hpp>
+#include <core/math/BigInt.hpp>
+#include <core/utils/ConfigurationMatchable.hpp>
+#include <core/utils/optional.hpp>
+#include <core/utils/Option.hpp>
+
+namespace ledger {
+    namespace core {
+        struct BitcoinLikeBlockchainExplorerInput {
+            uint64_t index;
+            Option<BigInt> value;
+            Option<std::string> previousTxHash;
+            Option<uint32_t> previousTxOutputIndex;
+            Option<std::string> address;
+            Option<std::string> signatureScript;
+            Option<std::string> coinbase;
+            uint32_t sequence;
+
+            BitcoinLikeBlockchainExplorerInput() {
+                sequence = 0xFFFFFFFF;
+            }
+        };
+
+        struct BitcoinLikeBlockchainExplorerOutput {
+            uint64_t index;
+            std::string transactionHash;
+            BigInt value;
+            Option<std::string> address;
+            std::string script;
+            std::string time;
+            Option<uint64_t> blockHeight;
+
+            BitcoinLikeBlockchainExplorerOutput() = default;
+        };
+
+        struct BitcoinLikeBlockchainExplorerTransaction {
+            uint32_t  version;
+            std::string hash;
+            std::chrono::system_clock::time_point receivedAt;
+            uint64_t lockTime;
+            Option<api::Block> block;
+            std::vector<BitcoinLikeBlockchainExplorerInput> inputs;
+            std::vector<BitcoinLikeBlockchainExplorerOutput> outputs;
+            Option<BigInt> fees;
+            uint64_t confirmations;
+
+            BitcoinLikeBlockchainExplorerTransaction() {
+                version = 1;
+                confirmations = -1;
+            }
+
+            BitcoinLikeBlockchainExplorerTransaction(const BitcoinLikeBlockchainExplorerTransaction &cpy) {
+                this->confirmations = cpy.confirmations;
+                this->version = cpy.version;
+                this->outputs = cpy.outputs;
+                this->inputs = cpy.inputs;
+                this->receivedAt = cpy.receivedAt;
+                this->lockTime = cpy.lockTime;
+                this->fees = cpy.fees;
+                this->hash = cpy.hash;
+                this->block = cpy.block;
+            }
+        };
+
+        class BitcoinLikeBlockchainExplorer : public ConfigurationMatchable,
+                                              public AbstractBlockchainExplorer<BitcoinLikeBlockchainExplorerTransaction> {
+        public:
+            using Block = api::Block;
+            
+            BitcoinLikeBlockchainExplorer(const std::shared_ptr<api::DynamicObject>& configuration,
+                                          const std::vector<std::string> &matchableKeys);
+
+            virtual Future<std::vector<std::shared_ptr<api::BigInt>>> getFees() = 0;
+
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/explorers/LedgerApiBitcoinLikeBlockchainExplorer.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/explorers/LedgerApiBitcoinLikeBlockchainExplorer.hpp
@@ -1,0 +1,95 @@
+/*
+ *
+ * LedgerApiBitcoinLikeBlockchainExplorer
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 10/03/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/async/DedicatedContext.hpp>
+#include <core/async/Future.hpp>
+#include <core/collections/Collections.hpp>
+#include <core/explorers/AbstractLedgerApiBlockchainExplorer.hpp>
+#include <core/net/HttpClient.hpp>
+
+#include <bitcoin/api/BitcoinLikeNetworkParameters.hpp>
+#include <bitcoin/block/BitcoinLikeBlockParser.hpp>
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+#include <bitcoin/transactions/BitcoinLikeTransactionParser.hpp>
+#include <bitcoin/transactions/BitcoinLikeTransactionsBulkParser.hpp>
+
+namespace ledger {
+    namespace core {
+
+        using LedgerApiBlockchainExplorer = AbstractLedgerApiBlockchainExplorer<
+            BitcoinLikeBlockchainExplorerTransaction,
+            BitcoinLikeBlockchainExplorer::TransactionsBulk,
+            BitcoinLikeAbstractTransactionParser,
+            BitcoinLikeAbstractTransactionBulkParser,
+            BitcoinLikeBlockParser,
+            api::BitcoinLikeNetworkParameters>;
+
+        class LedgerApiBitcoinLikeBlockchainExplorer : public BitcoinLikeBlockchainExplorer,
+                                                       public LedgerApiBlockchainExplorer,
+                                                       public DedicatedContext,
+                                                       public std::enable_shared_from_this<LedgerApiBitcoinLikeBlockchainExplorer> {
+        public:
+            LedgerApiBitcoinLikeBlockchainExplorer(
+                const std::shared_ptr<api::ExecutionContext>& context,
+                const std::shared_ptr<HttpClient>& http,
+                const api::BitcoinLikeNetworkParameters& parameters,
+                const std::shared_ptr<api::DynamicObject>& configuration
+            );
+
+            Future<String> pushLedgerApiTransaction(const std::vector<uint8_t> &transaction) override;
+            Future<void *> startSession() override;
+            Future<Unit> killSession(void *session) override;
+            Future<Bytes> getRawTransaction(const String& transactionHash) override;
+            Future<String> pushTransaction(const std::vector<uint8_t>& transaction) override;
+
+            FuturePtr<TransactionsBulk>
+            getTransactions(const std::vector<std::string> &addresses,
+                            Option<std::string> fromBlockHash = Option<std::string>(),
+                            Option<void *> session = Option<void *>()) override;
+
+            FuturePtr<Block> getCurrentBlock() const override;
+
+            FuturePtr<BitcoinLikeBlockchainExplorerTransaction> getTransactionByHash(const String &transactionHash) const override;
+
+            Future<int64_t > getTimestamp() const override;
+
+            std::shared_ptr<api::ExecutionContext> getExplorerContext() const override;
+            api::BitcoinLikeNetworkParameters getNetworkParameters() const override;
+            std::string getExplorerVersion() const override;
+            Future<std::vector<std::shared_ptr<api::BigInt>>> getFees() override;
+        private:
+            api::BitcoinLikeNetworkParameters _parameters;
+            std::string _explorerVersion;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/explorers/WebSocketNotificationParser.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/explorers/WebSocketNotificationParser.hpp
@@ -1,0 +1,90 @@
+/*
+ *
+ * WebSocketNotificationParser.h
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 10/10/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <cstdio>
+#include <cstdint>
+#include <stack>
+
+#include <rapidjson/reader.h>
+
+#include <core/collections/Collections.hpp>
+#include <core/explorers/AbstractWebSocketNotificationParser.hpp>
+#include <core/net/HttpClient.hpp>
+
+#include <bitcoin/block/BitcoinLikeBlockParser.hpp>
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+#include <bitcoin/transactions/BitcoinLikeTransactionParser.hpp>
+
+namespace ledger {
+    namespace core {
+        class WebSocketNotificationParser : public AbstractWebSocketNotificationParser<
+            BitcoinLikeBlockchainExplorerTransaction,
+            BitcoinLikeBlockchainExplorer::Block, 
+            BitcoinLikeTransactionParser, 
+            BitcoinLikeBlockParser> {
+        public:
+
+
+            explicit WebSocketNotificationParser(std::string& lastKey) : _lastKey(lastKey),
+                                                                        _blockParser(lastKey),
+                                                                        _transactionParser(lastKey) {
+
+            }
+
+            bool Key(const rapidjson::Reader::Ch* str, rapidjson::SizeType length, bool copy) override {
+                _lastKey = std::string(str, length);
+                return AbstractWebSocketNotificationParser<BitcoinLikeBlockchainExplorerTransaction,
+                        BitcoinLikeBlockchainExplorer::Block,
+                        BitcoinLikeTransactionParser,
+                        BitcoinLikeBlockParser>::Key(str, length, copy);
+            }
+
+        protected:
+
+            BitcoinLikeTransactionParser &getTransactionParser() override {
+              return _transactionParser;
+            };
+            BitcoinLikeBlockParser &getBlockParser() override {
+                return _blockParser;
+            };
+            std::string &getLastKey() override {
+                return _lastKey;
+            };
+
+        private:
+            std::string& _lastKey;
+            BitcoinLikeBlockParser _blockParser;
+            BitcoinLikeTransactionParser _transactionParser;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/factories/BitcoinLikeCommonKeychainFactory.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/factories/BitcoinLikeCommonKeychainFactory.hpp
@@ -1,0 +1,83 @@
+/*
+ *
+ * BitcoinLikeCommonKeychainFactory
+ *
+ * Created by El Khalil Bellakrid on 24/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+namespace ledger {
+    namespace core {
+        template <class Keychain>
+        class BitcoinLikeCommonKeychainFactory : public BitcoinLikeKeychainFactory {
+        public:
+            std::shared_ptr<ledger::core::BitcoinLikeKeychain>
+            build(int32_t index,
+                  const DerivationPath &path,
+                  const std::shared_ptr<DynamicObject> &configuration,
+                  const api::ExtendedKeyAccountCreationInfo& info,
+                  const std::shared_ptr<Preferences> &accountPreferences, const api::Currency &currency) override {
+                if (!info.extendedKeys.empty()) {
+                    auto xpub = make_try<std::shared_ptr<BitcoinLikeExtendedPublicKey>>([&] () -> std::shared_ptr<BitcoinLikeExtendedPublicKey> {
+                        return BitcoinLikeExtendedPublicKey::fromBase58(
+                                currency,
+                                info.extendedKeys[0],
+                                Option<std::string>(path.toString()),
+                                configuration
+                        );
+                    });
+                    if (xpub.isFailure()) {
+                        throw xpub.getFailure();
+                    } else {
+                        auto keychain = std::make_shared<Keychain>(
+                                configuration, currency, index, xpub.getValue(), accountPreferences
+                        );
+                        return keychain;
+                    }
+                } else {
+                    throw make_exception(api::ErrorCode::MISSING_DERIVATION, "Cannot find derivation {}", path.toString());
+                }
+            };
+
+            std::shared_ptr<ledger::core::BitcoinLikeKeychain>
+            restore(int32_t index,
+                    const DerivationPath &path,
+                    const std::shared_ptr<DynamicObject> &configuration, const std::string &databaseXpubEntry,
+                    const std::shared_ptr<Preferences> &accountPreferences, const api::Currency &currency) override {
+                auto keychain = std::make_shared<Keychain>(configuration,
+                                                           currency,
+                                                           index,
+                                                           BitcoinLikeExtendedPublicKey::fromBase58(currency,
+                                                                                                    databaseXpubEntry,
+                                                                                                    Option<std::string>(path.toString()),
+                                                                                                    configuration),
+                                                           accountPreferences);
+                return keychain;
+            };
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/factories/BitcoinLikeKeychainFactory.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/factories/BitcoinLikeKeychainFactory.hpp
@@ -1,0 +1,61 @@
+/*
+ *
+ * BitcoinLikeKeychainFactory
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 14/06/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/api/Currency.hpp>
+#include <core/api/ExtendedKeyAccountCreationInfo.hpp>
+#include <core/async/Future.hpp>
+#include <core/collections/DynamicObject.hpp>
+
+#include <bitcoin/keychains/BitcoinLikeKeychain.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeKeychainFactory {
+        public:
+            virtual std::shared_ptr<BitcoinLikeKeychain> build(int32_t index,
+                                                         const DerivationPath &path,
+                                                         const std::shared_ptr<DynamicObject>& configuration,
+                                                         const api::ExtendedKeyAccountCreationInfo& info,
+                                                         const std::shared_ptr<Preferences>& accountPreferences,
+                                                         const api::Currency& currency
+            ) = 0;
+            virtual std::shared_ptr<BitcoinLikeKeychain> restore(int32_t index,
+                                                           const DerivationPath &path,
+                                                           const std::shared_ptr<DynamicObject>& configuration,
+                                                           const std::string& databaseXpubEntry,
+                                                           const std::shared_ptr<Preferences>& accountPreferences,
+                                                           const api::Currency& currency
+            ) = 0;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/factories/BitcoinLikeWalletFactory.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/factories/BitcoinLikeWalletFactory.hpp
@@ -1,0 +1,66 @@
+/*
+ *
+ * BitcoinLikeWalletFactory
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 31/01/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/Services.hpp>
+#include <core/wallet/AbstractWalletFactory.hpp>
+
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+#include <bitcoin/keychains/P2PKHBitcoinLikeKeychain.hpp>
+#include <bitcoin/factories/BitcoinLikeKeychainFactory.hpp>
+#include <bitcoin/observers/BitcoinLikeBlockchainObserver.hpp>
+
+namespace ledger {
+    namespace core {
+        class WalletPool;
+
+        class BitcoinLikeWalletFactory : public AbstractWalletFactory {
+        public:
+            BitcoinLikeWalletFactory(const api::Currency &currency, const std::shared_ptr<Services> &services);
+            std::shared_ptr<AbstractWallet> build(const WalletDatabaseEntry &entry) override;
+
+        private:
+            std::shared_ptr<BitcoinLikeBlockchainExplorer> getExplorer(const std::string& currencyName, const std::shared_ptr<api::DynamicObject>& configuration);
+            std::shared_ptr<BitcoinLikeBlockchainObserver> getObserver(const std::string& currencyName, const std::shared_ptr<api::DynamicObject>& configuration);
+        private:
+            // Explorers
+            std::list<std::weak_ptr<BitcoinLikeBlockchainExplorer>> _runningExplorers;
+
+            // Observers
+            std::list<std::weak_ptr<BitcoinLikeBlockchainObserver>> _runningObservers;
+
+            // Keychain factories
+            std::unordered_map<std::string, std::shared_ptr<BitcoinLikeKeychainFactory>> _keychainFactories;
+
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/io/BitcoinLikeInput.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/io/BitcoinLikeInput.hpp
@@ -1,0 +1,88 @@
+/*
+ *
+ * BitcoinLikeInput
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 12/07/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <bitcoin/api/BitcoinLikeInput.hpp>
+#include <bitcoin/api/BitcoinLikeOperation.hpp>
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+
+namespace ledger {
+namespace core {
+
+class BitcoinLikeInput : public api::BitcoinLikeInput {
+public:
+  BitcoinLikeInput(const std::shared_ptr<api::BitcoinLikeOperation> &operation,
+                   int32_t inputIndex);
+  optional<std::string> getAddress() override;
+  std::shared_ptr<api::Amount> getValue() override;
+  bool isCoinbase() override;
+  optional<std::string> getCoinbase() override;
+  optional<std::string> getPreviousTxHash() override;
+  optional<int32_t> getPreviousOutputIndex() override;
+
+  std::vector<std::vector<uint8_t>> getPublicKeys() override;
+
+  std::vector<std::shared_ptr<api::DerivationPath>>
+  getDerivationPath() override;
+
+  std::shared_ptr<api::BitcoinLikeOutput> getPreviousOuput() override;
+
+  std::vector<uint8_t> getScriptSig() override;
+
+  std::shared_ptr<api::BitcoinLikeScript> parseScriptSig() override;
+
+  void setScriptSig(const std::vector<uint8_t> &scriptSig) override;
+
+  void pushToScriptSig(const std::vector<uint8_t> &data) override;
+
+  void setSequence(int32_t sequence) override;
+
+  int64_t getSequence() override;
+
+  void getPreviousTransaction(
+      const std::function<void(
+          std::experimental::optional<std::vector<uint8_t>>,
+          std::experimental::optional<::ledger::core::api::Error>)> &callback)
+      override;
+
+  void setP2PKHSigScript(const std::vector<uint8_t> &signature) override;
+
+private:
+  inline api::BitcoinLikeInput &getInput();
+
+private:
+  std::shared_ptr<api::BitcoinLikeOperation> _operation;
+  int32_t _inputIndex;
+};
+
+} // namespace core
+} // namespace ledger

--- a/ledger-core-bitcoin/inc/bitcoin/io/BitcoinLikeInputParser.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/io/BitcoinLikeInputParser.hpp
@@ -1,0 +1,69 @@
+/*
+ *
+ * InputParser
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 12/04/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <rapidjson/reader.h>
+
+#include <core/net/HttpClient.hpp>
+
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeInputParser {
+        public:
+            typedef BitcoinLikeBlockchainExplorerInput Result;
+
+            BitcoinLikeInputParser(std::string& lastKey) : _lastKey(lastKey) {};
+            void init(BitcoinLikeBlockchainExplorerInput* input);
+            bool Null();
+            bool Bool(bool b);
+            bool Int(int i);
+            bool Uint(unsigned i);
+            bool Int64(int64_t i);
+            bool Uint64(uint64_t i);
+            bool Double(double d);
+            bool RawNumber(const rapidjson::Reader::Ch* str, rapidjson::SizeType length, bool copy);
+            bool String(const rapidjson::Reader::Ch* str, rapidjson::SizeType length, bool copy);
+            bool StartObject();
+            bool Key(const rapidjson::Reader::Ch* str, rapidjson::SizeType length, bool copy);
+            bool EndObject(rapidjson::SizeType memberCount);
+            bool StartArray();
+            bool EndArray(rapidjson::SizeType elementCount);
+
+        private:
+            std::string& _lastKey;
+            BitcoinLikeBlockchainExplorerInput* _input;
+
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/io/BitcoinLikeOutput.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/io/BitcoinLikeOutput.hpp
@@ -1,0 +1,77 @@
+/*
+ *
+ * BitcoinLikeOutput
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 12/07/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/operation/Operation.hpp>
+#include <core/utils/Either.hpp>
+#include <core/wallet/Amount.hpp>
+
+#include <bitcoin/api/BitcoinLikeOutput.hpp>
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+#include <bitcoin/operations/BitcoinLikeOperation.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeOutput : public api::BitcoinLikeOutput {
+        public:
+            BitcoinLikeOutput(const std::shared_ptr<::ledger::core::BitcoinLikeOperation>& operation, int32_t outputIndex);
+            BitcoinLikeOutput(const BitcoinLikeBlockchainExplorerOutput& output, const api::Currency& currency);
+            BitcoinLikeOutput(
+                    const BitcoinLikeBlockchainExplorerOutput& output,
+                    const api::Currency& currency,
+                    const std::shared_ptr<api::DerivationPath>& path
+            );
+            std::string getTransactionHash() override;
+            int32_t getOutputIndex() override;
+            std::shared_ptr<api::Amount> getValue() override;
+            std::vector<uint8_t> getScript() override;
+            optional<std::string> getAddress() override;
+
+            std::shared_ptr<api::BitcoinLikeScript> parseScript() override;
+
+            std::shared_ptr<api::DerivationPath> getDerivationPath() override;
+
+            std::experimental::optional<int64_t> getBlockHeight() override;
+
+            const BigInt& value();
+
+        private:
+            BitcoinLikeBlockchainExplorerOutput &getOutput();
+
+        private:
+            Either<std::shared_ptr<::ledger::core::BitcoinLikeOperation>, BitcoinLikeBlockchainExplorerOutput>  _backend;
+            std::shared_ptr<api::DerivationPath> _path;
+            int32_t _outputIndex;
+            api::Currency _currency;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/io/BitcoinLikeOutputParser.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/io/BitcoinLikeOutputParser.hpp
@@ -1,0 +1,69 @@
+/*
+ *
+ * OutputParser
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 13/04/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <rapidjson/reader.h>
+
+#include <core/net/HttpClient.hpp>
+
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeOutputParser {
+        public:
+            typedef BitcoinLikeBlockchainExplorerOutput Result;
+
+            BitcoinLikeOutputParser(std::string& lastKey) : _lastKey(lastKey) {};
+            void init(BitcoinLikeBlockchainExplorerOutput* output);
+            bool Null();
+            bool Bool(bool b);
+            bool Int(int i);
+            bool Uint(unsigned i);
+            bool Int64(int64_t i);
+            bool Uint64(uint64_t i);
+            bool Double(double d);
+            bool RawNumber(const rapidjson::Reader::Ch* str, rapidjson::SizeType length, bool copy);
+            bool String(const rapidjson::Reader::Ch* str, rapidjson::SizeType length, bool copy);
+            bool StartObject();
+            bool Key(const rapidjson::Reader::Ch* str, rapidjson::SizeType length, bool copy);
+            bool EndObject(rapidjson::SizeType memberCount);
+            bool StartArray();
+            bool EndArray(rapidjson::SizeType elementCount);
+
+        private:
+            std::string& _lastKey;
+            BitcoinLikeBlockchainExplorerOutput* _output;
+
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/io/BitcoinLikeWritableInput.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/io/BitcoinLikeWritableInput.hpp
@@ -1,0 +1,95 @@
+/*
+ *
+ * BitcoinLikeWritableInput
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 10/04/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/utils/DerivationPath.hpp>
+
+#include <bitcoin/BitcoinLikeAccount.hpp>
+#include <bitcoin/api/BitcoinLikeInput.hpp>
+#include <bitcoin/scripts/BitcoinLikeScript.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeWritableInput : public api::BitcoinLikeInput {
+        public:
+            BitcoinLikeWritableInput(
+                    const std::shared_ptr<ledger::core::BitcoinLikeBlockchainExplorer>& explorer,
+                    const std::shared_ptr<api::ExecutionContext>& context,
+                    uint32_t sequence,
+                    const std::vector<std::vector<uint8_t> >& pubKeys,
+                    const std::vector<std::shared_ptr<api::DerivationPath>>& paths,
+                    const std::string& address,
+                    const std::shared_ptr<api::Amount>& amount,
+                    const std::string& previousTxHash,
+                    int32_t index,
+                    const std::vector<uint8_t>& scriptSig,
+                    const std::shared_ptr<api::BitcoinLikeOutput>& previousOutput,
+                    const std::string &keychainEngine = ""
+            );
+            optional<std::string> getAddress() override;
+            std::vector<std::vector<uint8_t>> getPublicKeys() override;
+            std::shared_ptr<api::Amount> getValue() override;
+
+            std::vector<std::shared_ptr<api::DerivationPath> > getDerivationPath() override;
+
+            bool isCoinbase() override;
+            optional<std::string> getCoinbase() override;
+            optional<std::string> getPreviousTxHash() override;
+            optional<int32_t> getPreviousOutputIndex() override;
+            std::shared_ptr<api::BitcoinLikeOutput> getPreviousOuput() override;
+            std::vector<uint8_t> getScriptSig() override;
+            std::shared_ptr<api::BitcoinLikeScript> parseScriptSig() override;
+            void setScriptSig(const std::vector<uint8_t> &scriptSig) override;
+            void pushToScriptSig(const std::vector<uint8_t> &data) override;
+            void setSequence(int32_t sequence) override;
+            int64_t getSequence() override;
+            void getPreviousTransaction(const std::function<void(std::experimental::optional<std::vector<uint8_t>>, std::experimental::optional<api::Error>)> & callback) override;
+            Future<std::vector<uint8_t>> getPreviousTransaction();
+            void setP2PKHSigScript(const std::vector<uint8_t> &signature) override;
+
+
+
+        private:
+            std::shared_ptr<ledger::core::BitcoinLikeBlockchainExplorer> _explorer;
+            std::shared_ptr<ledger::core::api::ExecutionContext> _context;
+            uint32_t _sequence;
+            std::vector<std::vector<uint8_t> > _pubKeys;
+            std::vector<std::shared_ptr<api::DerivationPath>> _paths;
+            std::string _address;
+            std::shared_ptr<api::Amount> _amount;
+            std::string _previousHash;
+            int32_t  _index;
+            BitcoinLikeScript _scriptSig;
+            std::shared_ptr<api::BitcoinLikeOutput> _previousScript;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/keychains/BitcoinLikeKeychain.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/keychains/BitcoinLikeKeychain.hpp
@@ -1,0 +1,115 @@
+/*
+ *
+ * BitcoinLikeKeychain
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 17/01/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once 
+
+#include <string>
+#include <vector>
+
+#include <core/api/Configuration.hpp>
+#include <core/api/Currency.hpp>
+#include <core/api/AccountCreationInfo.hpp>
+#include <core/api/ExtendedKeyAccountCreationInfo.hpp>
+#include <core/api/DynamicObject.hpp>
+#include <core/preferences/Preferences.hpp>
+#include <core/utils/DerivationScheme.hpp>
+#include <core/utils/Option.hpp>
+
+#include <bitcoin/BitcoinLikeAddress.hpp>
+#include <bitcoin/BitcoinLikeExtendedPublicKey.hpp>
+
+namespace ledger {
+    namespace core {
+
+        class BitcoinLikeKeychain {
+        public:
+            enum KeyPurpose {
+                RECEIVE, CHANGE
+            };
+
+        public:
+            using Address = std::shared_ptr<BitcoinLikeAddress>;
+
+            BitcoinLikeKeychain(
+                    const std::shared_ptr<api::DynamicObject>& configuration,
+                    const api::Currency& params,
+                    int account,
+                    const std::shared_ptr<Preferences>& preferences);
+
+            virtual bool markAsUsed(const std::vector<std::string>& addresses);
+            virtual bool markAsUsed(const std::string& address);
+            virtual bool markPathAsUsed(const DerivationPath& path) = 0;
+
+            virtual std::vector<Address> getAllObservableAddresses(uint32_t from, uint32_t to)  = 0;
+            virtual std::vector<Address> getAllObservableAddresses(KeyPurpose purpose, uint32_t from, uint32_t to) = 0;
+
+            virtual Address getFreshAddress(KeyPurpose purpose) = 0;
+            virtual std::vector<Address> getFreshAddresses(KeyPurpose purpose, size_t n) = 0;
+
+            virtual Option<KeyPurpose> getAddressPurpose(const std::string& address) const = 0;
+            virtual Option<std::string> getAddressDerivationPath(const std::string& address) const = 0;
+            virtual bool isEmpty() const = 0;
+
+            int getAccountIndex() const;
+            const api::BitcoinLikeNetworkParameters getNetworkParameters() const;
+            const api::Currency& getCurrency() const;
+
+            virtual Option<std::vector<uint8_t>> getPublicKey(const std::string& address) const = 0;
+
+
+            std::shared_ptr<api::DynamicObject> getConfiguration() const;
+            const DerivationScheme& getDerivationScheme() const;
+            const DerivationScheme& getFullDerivationScheme() const;
+            std::string getKeychainEngine() const;
+            bool isSegwit() const;
+            bool isNativeSegwit() const;
+
+            virtual std::string getRestoreKey() const = 0;
+            virtual int32_t getObservableRangeSize() const = 0;
+            virtual bool contains(const std::string& address) const = 0;
+            virtual int32_t getOutputSizeAsSignedTxInput() const = 0;
+
+            static bool isSegwit(const std::string &keychainEngine);
+            static bool isNativeSegwit(const std::string &keychainEngine);
+        protected:
+            std::shared_ptr<Preferences> getPreferences() const;
+            DerivationScheme& getDerivationScheme();
+
+        private:
+            const api::Currency _currency;
+            DerivationScheme _scheme;
+            DerivationScheme _fullScheme;
+            int _account;
+            std::shared_ptr<Preferences> _preferences;
+            std::shared_ptr<api::DynamicObject> _configuration;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/keychains/CommonBitcoinLikeKeychains.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/keychains/CommonBitcoinLikeKeychains.hpp
@@ -1,0 +1,103 @@
+/*
+ *
+ * CommonBitcoinLikeKeychain
+ * ledger-core
+ *
+ * Created by El Khalil Bellakrid on 30/04/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <set>
+
+#include <core/collections/DynamicObject.hpp>
+
+#include <bitcoin/keychains/BitcoinLikeKeychain.hpp>
+#include <bitcoin/BitcoinLikeAddress.hpp>
+
+namespace ledger {
+    namespace core {
+
+        struct KeychainPersistentState {
+            uint32_t maxConsecutiveChangeIndex;
+            uint32_t maxConsecutiveReceiveIndex;
+            std::set<uint32_t> nonConsecutiveChangeIndexes;
+            std::set<uint32_t> nonConsecutiveReceiveIndexes;
+            bool empty;
+
+            template <class Archive>
+            void serialize(Archive& archive, std::uint32_t const version) {
+                if (version == 0) {
+                    archive(
+                            maxConsecutiveChangeIndex,
+                            maxConsecutiveReceiveIndex,
+                            nonConsecutiveChangeIndexes,
+                            nonConsecutiveReceiveIndexes,
+                            empty
+                    );
+                }
+            }
+        };
+
+        class CommonBitcoinLikeKeychains : public BitcoinLikeKeychain {
+        public:
+            CommonBitcoinLikeKeychains(const std::shared_ptr<api::DynamicObject> &configuration,
+                                     const api::Currency &params, int account,
+                                     const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &xpub,
+                                     const std::shared_ptr<Preferences> &preferences);
+
+            bool markPathAsUsed(const DerivationPath &path) override;
+
+            BitcoinLikeKeychain::Address getFreshAddress(KeyPurpose purpose) override;
+            std::vector<BitcoinLikeKeychain::Address> getAllObservableAddresses(uint32_t from, uint32_t to) override;
+            std::vector<BitcoinLikeKeychain::Address> getFreshAddresses(KeyPurpose purpose, size_t n) override;
+            Option<KeyPurpose> getAddressPurpose(const std::string &address) const override;
+            Option<std::string> getAddressDerivationPath(const std::string &address) const override;
+            std::vector<BitcoinLikeKeychain::Address> getAllObservableAddresses(KeyPurpose purpose, uint32_t from, uint32_t to) override;
+            bool isEmpty() const override;
+            std::shared_ptr<api::BitcoinLikeExtendedPublicKey> getExtendedPublicKey() const;
+            std::string getRestoreKey() const override;
+
+            bool contains(const std::string &address) const override;
+
+            int32_t getObservableRangeSize() const override;
+
+            Option<std::vector<uint8_t>> getPublicKey(const std::string &address) const override;
+
+        protected:
+            std::shared_ptr<api::BitcoinLikeExtendedPublicKey> _internalNodeXpub;
+            std::shared_ptr<api::BitcoinLikeExtendedPublicKey> _publicNodeXpub;
+            uint32_t _observableRange;
+            std::string _keychainEngine;
+
+        private:
+            BitcoinLikeKeychain::Address derive(KeyPurpose purpose, off_t index);
+            void saveState();
+            KeychainPersistentState _state;
+            std::shared_ptr<api::BitcoinLikeExtendedPublicKey> _xpub;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/keychains/P2PKHBitcoinLikeKeychain.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/keychains/P2PKHBitcoinLikeKeychain.hpp
@@ -1,0 +1,50 @@
+/*
+ *
+ * P2PKHBitcoinLikeKeychain
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 25/01/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once 
+
+#include <core/api/Currency.hpp>
+#include <core/collections/DynamicObject.hpp>
+
+#include <bitcoin/keychains/CommonBitcoinLikeKeychains.hpp>
+
+namespace ledger {
+    namespace core {
+        class P2PKHBitcoinLikeKeychain : public CommonBitcoinLikeKeychains {
+        public:
+            P2PKHBitcoinLikeKeychain(const std::shared_ptr<api::DynamicObject> &configuration,
+                                     const api::Currency &params, int account,
+                                     const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &xpub,
+                                     const std::shared_ptr<Preferences> &preferences);
+            int32_t getOutputSizeAsSignedTxInput() const override ;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/keychains/P2SHBitcoinLikeKeychain.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/keychains/P2SHBitcoinLikeKeychain.hpp
@@ -1,0 +1,48 @@
+/*
+ *
+ * P2SHBitcoinLikeKeychain
+ * ledger-core
+ *
+ * Created by El Khalil Bellakrid on 30/04/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once 
+
+#include <bitcoin/keychains/CommonBitcoinLikeKeychains.hpp>
+
+namespace ledger {
+    namespace core {
+
+        class P2SHBitcoinLikeKeychain : public CommonBitcoinLikeKeychains {
+        public:
+            P2SHBitcoinLikeKeychain(const std::shared_ptr<api::DynamicObject> &configuration,
+                                     const api::Currency &params, int account,
+                                     const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &xpub,
+                                     const std::shared_ptr<Preferences> &preferences);
+            int32_t getOutputSizeAsSignedTxInput() const override ;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/keychains/P2WPKHBitcoinLikeKeychain.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/keychains/P2WPKHBitcoinLikeKeychain.hpp
@@ -1,0 +1,47 @@
+/*
+ *
+ * P2WPKHBitcoinLikeKeychain
+ *
+ * Created by El Khalil Bellakrid on 19/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+
+#pragma once
+
+#include <bitcoin/keychains/CommonBitcoinLikeKeychains.hpp>
+
+namespace ledger {
+    namespace core {
+        class P2WPKHBitcoinLikeKeychain : public CommonBitcoinLikeKeychains {
+        public:
+            P2WPKHBitcoinLikeKeychain(const std::shared_ptr<api::DynamicObject> &configuration,
+                                      const api::Currency &params, int account,
+                                      const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &xpub,
+                                      const std::shared_ptr<Preferences> &preferences);
+            int32_t getOutputSizeAsSignedTxInput() const override ;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/keychains/P2WSHBitcoinLikeKeychain.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/keychains/P2WSHBitcoinLikeKeychain.hpp
@@ -1,0 +1,46 @@
+/*
+ *
+ * P2WSHBitcoinLikeKeychain
+ *
+ * Created by El Khalil Bellakrid on 25/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <bitcoin/keychains/CommonBitcoinLikeKeychains.hpp>
+
+namespace ledger {
+    namespace core {
+        class P2WSHBitcoinLikeKeychain : public CommonBitcoinLikeKeychains {
+        public:
+            P2WSHBitcoinLikeKeychain(const std::shared_ptr<api::DynamicObject> &configuration,
+                                     const api::Currency &params, int account,
+                                     const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &xpub,
+                                     const std::shared_ptr<Preferences> &preferences);
+            int32_t getOutputSizeAsSignedTxInput() const override ;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/observers/BitcoinLikeBlockchainObserver.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/observers/BitcoinLikeBlockchainObserver.hpp
@@ -1,0 +1,78 @@
+/*
+ *
+ * BitcoinLikeBlockchainObserver
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 28/04/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/api/Currency.hpp>
+#include <core/api/ExecutionContext.hpp>
+#include <core/api/DynamicObject.hpp>
+#include <core/async/DedicatedContext.hpp>
+#include <core/debug/logger.hpp>
+#include <core/observers/AbstractBlockchainObserver.hpp>
+
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeAccount;
+
+        using BitcoinBlockchainObserver = AbstractBlockchainObserver<
+            BitcoinLikeAccount,
+            BitcoinLikeBlockchainExplorerTransaction,
+            BitcoinLikeBlockchainExplorer::Block>;
+
+        class BitcoinLikeBlockchainObserver : public BitcoinBlockchainObserver,
+                                              public DedicatedContext,
+                                              public ConfigurationMatchable {
+        public:
+            BitcoinLikeBlockchainObserver(const std::shared_ptr<api::ExecutionContext>& context,
+                                          const std::shared_ptr<api::DynamicObject>& configuration,
+                                          const std::shared_ptr<spdlog::logger>& logger,
+                                          const api::Currency& currency,
+                                          const std::vector<std::string>& matchableKeys);
+
+        protected:
+            void putTransaction(const BitcoinLikeBlockchainExplorerTransaction& tx) override ;
+            void putBlock(const BitcoinLikeBlockchainExplorer::Block& block) override ;
+
+            const api::Currency& getCurrency() const {
+                return _currency;
+            };
+            std::shared_ptr<api::DynamicObject> getConfiguration() const {
+                return _configuration;
+            };
+
+        private:
+            api::Currency _currency;
+            std::shared_ptr<api::DynamicObject> _configuration;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/observers/LedgerApiBitcoinLikeBlockchainObserver.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/observers/LedgerApiBitcoinLikeBlockchainObserver.hpp
@@ -1,0 +1,74 @@
+/*
+ *
+ * LedgerApiBitcoinLikeBlockchainObserver.h
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 05/10/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once 
+
+#include <core/net/WebSocketClient.hpp>
+#include <core/net/WebSocketConnection.hpp>
+#include <core/observers/AbstractLedgerApiBlockchainObserver.hpp>
+
+#include <bitcoin/observers/BitcoinLikeBlockchainObserver.hpp>
+
+namespace ledger {
+    namespace core {
+        class LedgerApiBitcoinLikeBlockchainObserver : public AbstractLedgerApiBlockchainObserver,
+                                                       public BitcoinLikeBlockchainObserver,
+                                                       public std::enable_shared_from_this<LedgerApiBitcoinLikeBlockchainObserver> {
+        public:
+            LedgerApiBitcoinLikeBlockchainObserver(const std::shared_ptr<api::ExecutionContext> &context,
+                                                   const std::shared_ptr<WebSocketClient>& client,
+                                                   const std::shared_ptr<api::DynamicObject>& configuration,
+                                                   const std::shared_ptr<spdlog::logger>& logger,
+                                                   const api::Currency &currency);
+
+        protected:
+            void onStop() override;
+
+            void onStart() override;
+
+
+        private:
+            std::shared_ptr<spdlog::logger> logger() const override {
+                return BitcoinLikeBlockchainObserver::logger();
+            };
+            void connect() override ;
+            void reconnect() override ;
+            void onMessage(const std::string& message) override ;
+
+        private:
+            std::shared_ptr<WebSocketClient> _client;
+            //std::shared_ptr<WebSocketConnection> _socket;
+            WebSocketEventHandler _handler;
+            //int32_t _attempt;
+            //std::string _url;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/operations/BitcoinLikeOperation.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/operations/BitcoinLikeOperation.hpp
@@ -1,0 +1,70 @@
+/*
+ *
+ * BitcoinLikeOperation
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 12/07/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <core/operation/Operation.hpp>
+#include <core/wallet/AbstractWallet.hpp>
+
+#include <bitcoin/api/BitcoinLikeOperation.hpp>
+#include <bitcoin/api/BitcoinLikeTransaction.hpp>
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeOperation : public api::BitcoinLikeOperation, public Operation {
+        public:
+            BitcoinLikeOperation() = default;
+
+            BitcoinLikeOperation(
+                const std::shared_ptr<const AbstractWallet>& wallet,
+                BitcoinLikeBlockchainExplorerTransaction const& tx);
+
+            BitcoinLikeOperation(
+                const std::shared_ptr<BitcoinLikeOperation>& operation,
+                BitcoinLikeBlockchainExplorerTransaction const& tx);
+
+            std::shared_ptr<api::BitcoinLikeTransaction> getTransaction() override;
+
+            void refreshUid(std::string const& additional = "") override;
+            bool isComplete() override;
+
+            void setExplorerTransaction(BitcoinLikeBlockchainExplorerTransaction const& tx);
+            BitcoinLikeBlockchainExplorerTransaction& getExplorerTransaction();
+
+        private:
+            std::shared_ptr<api::BitcoinLikeTransaction> _tx;
+            BitcoinLikeBlockchainExplorerTransaction _explorerTx;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/operations/BitcoinLikeOperationQuery.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/operations/BitcoinLikeOperationQuery.hpp
@@ -1,0 +1,58 @@
+/*
+ *
+ * BitcoinLikeOperationQuery
+ *
+ * Created by Alexis Le Provost on 16/01/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <soci.h>
+
+#include <core/api/QueryFilter.hpp>
+#include <core/operation/OperationQuery.hpp>
+
+#include <bitcoin/operations/BitcoinLikeOperation.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeOperationQuery : public OperationQuery<BitcoinLikeOperation> {
+        public:
+         BitcoinLikeOperationQuery(
+                const std::shared_ptr<api::QueryFilter>& headFilter,
+                const std::shared_ptr<DatabaseSessionPool>& pool,
+                const std::shared_ptr<api::ExecutionContext>& context,
+                const std::shared_ptr<api::ExecutionContext>& mainContext);
+
+        protected:
+            virtual void inflateCompleteTransaction(
+                soci::session &sql, const std::string &accountUid, BitcoinLikeOperation& operation) override;
+
+            virtual std::shared_ptr<BitcoinLikeOperation> createOperation(
+                std::shared_ptr<AbstractAccount> &account) override;
+        };
+
+
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/scripts/BitcoinLikeInternalScript.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/scripts/BitcoinLikeInternalScript.hpp
@@ -1,0 +1,78 @@
+/*
+ *
+ * BitcoinLikeScriptApi.h
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 09/04/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <bitcoin/api/BitcoinLikeScript.hpp>
+#include <bitcoin/api/BitcoinLikeScriptChunk.hpp>
+#include <bitcoin/api/BitcoinLikeScriptOperator.hpp>
+#include <bitcoin/scripts/BitcoinLikeScript.hpp>
+
+namespace ledger {
+    namespace core {
+
+        class BitcoinLikeInternalScript;
+
+        class BitcoinLikeInternalScriptChunk : public api::BitcoinLikeScriptChunk {
+        public:
+            BitcoinLikeInternalScriptChunk(const std::shared_ptr<BitcoinLikeInternalScript>& script, int index);
+            bool isOperator() override;
+
+            bool isPushedData() override;
+
+            optional<api::BitcoinLikeScriptOperator> getOperator() override;
+
+            optional<std::vector<uint8_t>> getPushedData() override;
+
+            std::shared_ptr<api::BitcoinLikeScriptChunk> next() override;
+
+            bool hasNext() override;
+
+            inline const ::ledger::core::BitcoinLikeScriptChunk& getChunk() const;
+
+        private:
+            int _index;
+            std::shared_ptr<BitcoinLikeInternalScript> _script;
+            const ::ledger::core::BitcoinLikeScriptChunk& _chunk;
+        };
+
+        class BitcoinLikeInternalScript : public api::BitcoinLikeScript, public std::enable_shared_from_this<BitcoinLikeInternalScript> {
+        public:
+            explicit BitcoinLikeInternalScript(const ::ledger::core::BitcoinLikeScript& script);
+            std::shared_ptr<api::BitcoinLikeScriptChunk> head() override;
+            std::string toString() override;
+            const ::ledger::core::BitcoinLikeScript& getScript() const;
+
+        private:
+            ::ledger::core::BitcoinLikeScript _script;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/scripts/BitcoinLikeScript.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/scripts/BitcoinLikeScript.hpp
@@ -1,0 +1,136 @@
+/*
+ *
+ * BitcoinLikeScript.h
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 03/04/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <list>
+
+#include <core/utils/Either.hpp>
+#include <core/utils/Try.hpp>
+
+#include <bitcoin/BitcoinLikeAddress.hpp>
+#include <bitcoin/api/BitcoinLikeNetworkParameters.hpp>
+#include <bitcoin/scripts/BitcoinLikeScriptOperators.hpp>
+
+namespace ledger {
+    namespace core {
+
+        using BitcoinLikeScriptOpCode = btccore::opcodetype;
+
+        class BitcoinLikeScriptChunk {
+        public:
+            explicit BitcoinLikeScriptChunk(BitcoinLikeScriptOpCode op);
+
+            explicit BitcoinLikeScriptChunk(const std::vector<uint8_t> &bytes);
+
+            const std::vector<uint8_t> &getBytes() const;
+
+            bool isBytes() const;
+
+            BitcoinLikeScriptOpCode getOpCode() const;
+
+            bool isEqualTo(btccore::opcodetype code) const;
+
+            bool sizeEqualsTo(std::size_t size) const;
+
+            bool isOpCode() const;
+
+        private:
+            Either<std::vector<uint8_t>, BitcoinLikeScriptOpCode> _value;
+        };
+
+        struct BitcoinLikeScriptConfiguration {
+            bool isSigned;
+            std::string keychainEngine;
+
+            BitcoinLikeScriptConfiguration(bool isSigned_,
+                                           const std::string &keychainEngine_) : isSigned(isSigned_),
+                                                                                 keychainEngine(keychainEngine_) {
+                if (isSigned_ && keychainEngine_.empty()) {
+                    throw make_exception(api::ErrorCode::INVALID_ARGUMENT,
+                                         "Keychain engine required when constructing signed scripts");
+                }
+            }
+
+            BitcoinLikeScriptConfiguration(const BitcoinLikeScriptConfiguration &copy) {
+                this->isSigned = copy.isSigned;
+                this->keychainEngine = copy.keychainEngine;
+            }
+
+            BitcoinLikeScriptConfiguration &operator=(const BitcoinLikeScriptConfiguration &copy) {
+                this->isSigned = copy.isSigned;
+                this->keychainEngine = copy.keychainEngine;
+                return *this;
+            }
+        };
+
+        class BitcoinLikeScript {
+        public:
+            BitcoinLikeScript() : _configuration(BitcoinLikeScriptConfiguration(false, "")) {};
+
+            BitcoinLikeScript(const BitcoinLikeScriptConfiguration &configuration) : _configuration(configuration) {};
+
+            BitcoinLikeScript &operator<<(btccore::opcodetype op_code);
+
+            BitcoinLikeScript &operator<<(const std::vector<uint8_t> &bytes);
+
+            const BitcoinLikeScriptChunk &operator[](int index) const;
+
+            std::size_t size() const;
+
+            std::string toString() const;
+
+            std::vector<uint8_t> serialize() const;
+
+            const std::list<BitcoinLikeScriptChunk> &toList() const;
+
+            bool isP2PKH() const;
+
+            bool isP2SH() const;
+
+            bool isP2WPKH() const;
+
+            bool isP2WSH() const;
+
+            Option<BitcoinLikeAddress> parseAddress(const api::Currency &currency) const;
+
+            static Try<BitcoinLikeScript> parse(const std::vector<uint8_t> &script,
+                                                const BitcoinLikeScriptConfiguration &configuration = BitcoinLikeScriptConfiguration(
+                                                        false, ""));
+
+            static BitcoinLikeScript fromAddress(const std::string &address, const api::Currency &currency);
+
+        private:
+            std::list<BitcoinLikeScriptChunk> _chunks;
+            BitcoinLikeScriptConfiguration _configuration;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/scripts/BitcoinLikeScriptOperators.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/scripts/BitcoinLikeScriptOperators.hpp
@@ -1,0 +1,191 @@
+/*
+ *
+ * operators.h
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 03/04/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <bitcoin/api/BitcoinLikeScriptOperator.hpp>
+
+// Code from https://github.com/bitcoin/bitcoin/blob/master/src/script/script.h
+
+namespace ledger {
+    namespace core {
+        namespace btccore {
+            /** Script opcodes */
+            enum opcodetype {
+                // push value
+                OP_0 = 0x00,
+                OP_FALSE = OP_0,
+                OP_PUSHDATA1 = 0x4c,
+                OP_PUSHDATA2 = 0x4d,
+                OP_PUSHDATA4 = 0x4e,
+                OP_1NEGATE = 0x4f,
+                OP_RESERVED = 0x50,
+                OP_1 = 0x51,
+                OP_TRUE = OP_1,
+                OP_2 = 0x52,
+                OP_3 = 0x53,
+                OP_4 = 0x54,
+                OP_5 = 0x55,
+                OP_6 = 0x56,
+                OP_7 = 0x57,
+                OP_8 = 0x58,
+                OP_9 = 0x59,
+                OP_10 = 0x5a,
+                OP_11 = 0x5b,
+                OP_12 = 0x5c,
+                OP_13 = 0x5d,
+                OP_14 = 0x5e,
+                OP_15 = 0x5f,
+                OP_16 = 0x60,
+
+                // control
+                OP_NOP = 0x61,
+                OP_VER = 0x62,
+                OP_IF = 0x63,
+                OP_NOTIF = 0x64,
+                OP_VERIF = 0x65,
+                OP_VERNOTIF = 0x66,
+                OP_ELSE = 0x67,
+                OP_ENDIF = 0x68,
+                OP_VERIFY = 0x69,
+                OP_RETURN = 0x6a,
+
+                // stack ops
+                OP_TOALTSTACK = 0x6b,
+                OP_FROMALTSTACK = 0x6c,
+                OP_2DROP = 0x6d,
+                OP_2DUP = 0x6e,
+                OP_3DUP = 0x6f,
+                OP_2OVER = 0x70,
+                OP_2ROT = 0x71,
+                OP_2SWAP = 0x72,
+                OP_IFDUP = 0x73,
+                OP_DEPTH = 0x74,
+                OP_DROP = 0x75,
+                OP_DUP = 0x76,
+                OP_NIP = 0x77,
+                OP_OVER = 0x78,
+                OP_PICK = 0x79,
+                OP_ROLL = 0x7a,
+                OP_ROT = 0x7b,
+                OP_SWAP = 0x7c,
+                OP_TUCK = 0x7d,
+
+                // splice ops
+                OP_CAT = 0x7e,
+                OP_SUBSTR = 0x7f,
+                OP_LEFT = 0x80,
+                OP_RIGHT = 0x81,
+                OP_SIZE = 0x82,
+
+                // bit logic
+                OP_INVERT = 0x83,
+                OP_AND = 0x84,
+                OP_OR = 0x85,
+                OP_XOR = 0x86,
+                OP_EQUAL = 0x87,
+                OP_EQUALVERIFY = 0x88,
+                OP_RESERVED1 = 0x89,
+                OP_RESERVED2 = 0x8a,
+
+                // numeric
+                OP_1ADD = 0x8b,
+                OP_1SUB = 0x8c,
+                OP_2MUL = 0x8d,
+                OP_2DIV = 0x8e,
+                OP_NEGATE = 0x8f,
+                OP_ABS = 0x90,
+                OP_NOT = 0x91,
+                OP_0NOTEQUAL = 0x92,
+
+                OP_ADD = 0x93,
+                OP_SUB = 0x94,
+                OP_MUL = 0x95,
+                OP_DIV = 0x96,
+                OP_MOD = 0x97,
+                OP_LSHIFT = 0x98,
+                OP_RSHIFT = 0x99,
+
+                OP_BOOLAND = 0x9a,
+                OP_BOOLOR = 0x9b,
+                OP_NUMEQUAL = 0x9c,
+                OP_NUMEQUALVERIFY = 0x9d,
+                OP_NUMNOTEQUAL = 0x9e,
+                OP_LESSTHAN = 0x9f,
+                OP_GREATERTHAN = 0xa0,
+                OP_LESSTHANOREQUAL = 0xa1,
+                OP_GREATERTHANOREQUAL = 0xa2,
+                OP_MIN = 0xa3,
+                OP_MAX = 0xa4,
+
+                OP_WITHIN = 0xa5,
+
+                // crypto
+                OP_RIPEMD160 = 0xa6,
+                OP_SHA1 = 0xa7,
+                OP_SHA256 = 0xa8,
+                OP_HASH160 = 0xa9,
+                OP_HASH256 = 0xaa,
+                OP_CODESEPARATOR = 0xab,
+                OP_CHECKSIG = 0xac,
+                OP_CHECKSIGVERIFY = 0xad,
+                OP_CHECKMULTISIG = 0xae,
+                OP_CHECKMULTISIGVERIFY = 0xaf,
+
+                // expansion
+                OP_NOP1 = 0xb0,
+                OP_CHECKLOCKTIMEVERIFY = 0xb1,
+                OP_NOP2 = OP_CHECKLOCKTIMEVERIFY,
+                OP_CHECKSEQUENCEVERIFY = 0xb2,
+                OP_NOP3 = OP_CHECKSEQUENCEVERIFY,
+                OP_NOP4 = 0xb3,
+                OP_CHECKBLOCKATHEIGHT = 0xb4,
+                OP_NOP6 = 0xb5,
+                OP_NOP7 = 0xb6,
+                OP_NOP8 = 0xb7,
+                OP_NOP9 = 0xb8,
+                OP_NOP10 = 0xb9,
+
+
+                // template matching params
+                OP_SMALLINTEGER = 0xfa,
+                OP_PUBKEYS = 0xfb,
+                OP_PUBKEYHASH = 0xfd,
+                OP_PUBKEY = 0xfe,
+
+                OP_INVALIDOPCODE = 0xff,
+            };
+
+            const char* GetOpName(opcodetype opcode);
+
+        }
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/synchronizers/BitcoinLikeAccountSynchronizer.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/synchronizers/BitcoinLikeAccountSynchronizer.hpp
@@ -1,0 +1,43 @@
+/*
+ *
+ * BitcoinLikeAccountSynchronizer
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 28/04/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/synchronizers/AbstractAccountSynchronizer.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeAccount;
+        class BitcoinLikeAccountSynchronizer : public AbstractAccountSynchronizer<BitcoinLikeAccount> {
+
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/synchronizers/BitcoinLikeBlockchainExplorerAccountSynchronizer.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/synchronizers/BitcoinLikeBlockchainExplorerAccountSynchronizer.hpp
@@ -1,0 +1,72 @@
+/*
+ *
+ * BlockchainExplorerAccountSynchronizer
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 26/05/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/Services.hpp>
+#include <core/async/DedicatedContext.hpp>
+#include <core/preferences/Preferences.hpp>
+#include <core/synchronizers/AbstractBlockchainExplorerAccountSynchronizer.hpp>
+
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+#include <bitcoin/keychains/BitcoinLikeKeychain.hpp>
+#include <bitcoin/synchronizers/BitcoinLikeAccountSynchronizer.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeAccount;
+
+        using BlockchainAccountSynchronizer = AbstractBlockchainExplorerAccountSynchronizer<BitcoinLikeAccount, BitcoinLikeAddress, BitcoinLikeKeychain, BitcoinLikeBlockchainExplorer>;
+        
+        class BlockchainExplorerAccountSynchronizer : public BitcoinLikeAccountSynchronizer,
+                                                      public BlockchainAccountSynchronizer,
+                                                      public DedicatedContext,
+                                                      public std::enable_shared_from_this<BlockchainExplorerAccountSynchronizer> {
+        public:
+            BlockchainExplorerAccountSynchronizer(const std::shared_ptr<Services>& services,
+                                                  const std::shared_ptr<BitcoinLikeBlockchainExplorer>& explorer);
+
+            void updateCurrentBlock(std::shared_ptr<AbstractBlockchainExplorerAccountSynchronizer::SynchronizationBuddy> &buddy,
+                                    const std::shared_ptr<api::ExecutionContext> &context) override;
+            void updateTransactionsToDrop(soci::session &sql,
+                                          std::shared_ptr<SynchronizationBuddy> &buddy,
+                                          const std::string &accountUid) override;
+
+            void reset(const std::shared_ptr<BitcoinLikeAccount>& account, const std::chrono::system_clock::time_point& toDate) override;
+            std::shared_ptr<ProgressNotifier<Unit>> synchronize(const std::shared_ptr<BitcoinLikeAccount>& account) override;
+            bool isSynchronizing() const override;
+
+        private:
+            std::shared_ptr<BlockchainAccountSynchronizer> getSharedFromThis() override ;
+            std::shared_ptr<api::ExecutionContext> getSynchronizerContext() override ;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeAbstractTransactionParser.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeAbstractTransactionParser.hpp
@@ -1,0 +1,57 @@
+/*
+ *
+ * BitcoinLikeAbstractTransactionParser
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 13/04/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/explorers/AbstractTransactionsParser.hpp>
+
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+#include <bitcoin/transactions/BitcoinLikeTransactionParser.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeAbstractTransactionParser : public AbstractTransactionsParser<BitcoinLikeBlockchainExplorerTransaction, BitcoinLikeTransactionParser>{
+        public:
+            BitcoinLikeAbstractTransactionParser(std::string& lastKey) : _transactionParser(lastKey) {
+                _arrayDepth = 0;
+                _objectDepth = 0;
+            }
+
+        protected:
+            BitcoinLikeTransactionParser &getTransactionParser() override {
+                return _transactionParser;
+            }
+
+        private:
+            BitcoinLikeTransactionParser _transactionParser;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeStrategyUTXOPicker.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeStrategyUTXOPicker.hpp
@@ -1,0 +1,80 @@
+/*
+ *
+ * BitcoinLikeStrategyUTXOPicker.h
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 29/03/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <bitcoin/transactions/BitcoinLikeUTXOPicker.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeStrategyUTXOPicker : public BitcoinLikeUTXOPicker {
+        public:
+            BitcoinLikeStrategyUTXOPicker(const std::shared_ptr<api::ExecutionContext> &context,
+                                          const api::Currency &currency);
+        protected:
+            Future<UTXODescriptorList> filterInputs(const std::shared_ptr<Buddy> &buddy) override;
+            UTXODescriptorList filterWithDeepFirst(const std::shared_ptr<Buddy> &buddy,
+                                     const std::vector<std::shared_ptr<api::BitcoinLikeOutput>>& UTXO,
+                                     const BigInt& aggregatedAmount);
+            bool hasEnough(const std::shared_ptr<Buddy>& buddy, const BigInt& aggregatedAmount, int inputCount, bool computeOutputAmount = false);
+            inline Future<BigInt> computeAggregatedAmount(const std::shared_ptr<Buddy>& buddy);
+
+            //Only usefull for filterWithLowestFees
+            struct EffectiveUTXO {
+                std::shared_ptr<api::BitcoinLikeOutput> output;
+                int64_t effectiveValue;
+                int64_t effectiveFees;
+                int64_t longTermFees;
+            };
+            BitcoinLikeUTXOPicker::UTXODescriptorList filterWithOptimizeSize(const std::shared_ptr<BitcoinLikeUTXOPicker::Buddy> &buddy,
+                                                                                     const std::vector<std::shared_ptr<api::BitcoinLikeOutput>> &UTXOs,
+                                                                                     const BigInt &aggregatedAmount);
+
+            BitcoinLikeUTXOPicker::UTXODescriptorList filterWithMergeOutputs(const std::shared_ptr<BitcoinLikeUTXOPicker::Buddy> &buddy,
+                                                                                     const std::vector<std::shared_ptr<api::BitcoinLikeOutput>> &UTXOs,
+                                                                                     const BigInt &aggregatedAmount);
+
+            //Usefull for filterWithLowFeesFirst
+            static const int64_t DEFAULT_FALLBACK_FEE = 20;
+            static const int64_t DEFAULT_DISCARD_FEE = 10;
+            static const int64_t COIN = 100000000;
+            static const int64_t MAX_MONEY = 21000000 * COIN;
+            static const uint32_t TOTAL_TRIES = 100000;
+            static const int64_t CENT = 1000000;
+            static const int64_t MIN_CHANGE = 100000;
+        private:
+            BitcoinLikeUTXOPicker::UTXODescriptorList filterWithKnapsackSolver(const std::shared_ptr<BitcoinLikeUTXOPicker::Buddy> &buddy,
+                                                                                       const std::vector<std::shared_ptr<api::BitcoinLikeOutput>> &UTXOs,
+                                                                                       const BigInt &aggregatedAmount);
+
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeTransaction.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeTransaction.hpp
@@ -1,0 +1,182 @@
+/*
+ *
+ * BitcoinLikeTransaction
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 12/07/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+// #include <core/operation/Operation.hpp>
+#include <core/api/EstimatedSize.hpp>
+#include <core/api/KeychainEngines.hpp>
+
+#include <bitcoin/api/BitcoinLikeBlock.hpp>
+#include <bitcoin/api/BitcoinLikeSignature.hpp>
+#include <bitcoin/api/BitcoinLikeSignatureState.hpp>
+#include <bitcoin/api/BitcoinLikeTransaction.hpp>
+#include <bitcoin/block/BitcoinLikeBlock.hpp>
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+#include <bitcoin/io/BitcoinLikeInput.hpp>
+#include <bitcoin/io/BitcoinLikeOutput.hpp>
+#include <bitcoin/io/BitcoinLikeWritableInput.hpp>
+
+namespace ledger {
+    namespace core {
+
+        struct BitcoinLikePreparedInput {
+            uint32_t sequence;
+            std::string address;
+            std::string previousTxHash;
+            int32_t outputIndex;
+            std::vector<std::vector<uint8_t>> pubKeys;
+            BitcoinLikeBlockchainExplorerOutput output;
+
+            BitcoinLikePreparedInput() = default;
+
+            BitcoinLikePreparedInput(uint32_t sequence_,
+                                     const std::string &address_,
+                                     const std::string &previousTxHash_,
+                                     int32_t outputIndex_,
+                                     std::vector<std::vector<uint8_t>> pubKeys_,
+                                     BitcoinLikeBlockchainExplorerOutput output_) : sequence(sequence_),
+                                                                                      address(address_),
+                                                                                      previousTxHash(previousTxHash_),
+                                                                                      outputIndex(outputIndex_),
+                                                                                      pubKeys(pubKeys_) {
+                output.value = output_.value;
+                output.index = output_.index;
+                output.address = output_.address;
+                output.script = output_.script;
+                output.transactionHash = output_.transactionHash;
+                output.time = output_.time;
+
+            }
+        };
+
+        class BytesWriter;
+
+        class BitcoinLikeTransaction : public api::BitcoinLikeTransaction {
+        public:
+            explicit BitcoinLikeTransaction(const api::Currency &currency,
+                                            const std::string &keychainEngine = api::KeychainEngines::BIP32_P2PKH,
+                                            uint64_t currentBlockHeight = 0);
+
+            BitcoinLikeTransaction(
+                const std::shared_ptr<BitcoinLikeOperation>& operation,
+                const api::Currency &currency,
+                const std::string &keychainEngine = api::KeychainEngines::BIP32_P2PKH,
+                uint64_t currentBlockHeight = 0);
+
+            std::vector<std::shared_ptr<api::BitcoinLikeInput>> getInputs() override;
+
+            std::vector<std::shared_ptr<api::BitcoinLikeOutput>> getOutputs() override;
+
+            std::shared_ptr<api::BitcoinLikeBlock> getBlock() override;
+
+            int64_t getLockTime() override;
+
+            std::shared_ptr<api::Amount> getFees() override;
+
+            std::string getHash() override;
+
+            std::chrono::system_clock::time_point getTime() override;
+
+            optional<int32_t> getTimestamp() override;
+
+            std::vector<uint8_t> serialize() override;
+
+            optional<std::vector<uint8_t>> getWitness() override;
+
+            api::EstimatedSize getEstimatedSize() override;
+
+            std::vector<uint8_t> serializeOutputs() override;
+
+            int32_t getVersion() override;
+            
+            api::BitcoinLikeSignatureState setSignatures(const std::vector<api::BitcoinLikeSignature> & signatures, bool override = false) override;
+
+            api::BitcoinLikeSignatureState setDERSignatures(const std::vector<std::vector<uint8_t>> & signatures, bool override = false) override;
+
+            BitcoinLikeTransaction &addInput(const std::shared_ptr<BitcoinLikeWritableInput> &input);
+
+            BitcoinLikeTransaction &addOutput(const std::shared_ptr<api::BitcoinLikeOutput> &output);
+
+            BitcoinLikeTransaction &setLockTime(uint32_t lockTime);
+
+            BitcoinLikeTransaction &setVersion(uint32_t version);
+
+            BitcoinLikeTransaction &setTimestamp(uint32_t timestamp);
+
+            BitcoinLikeTransaction &setHash(const std::string &hash);
+
+
+            static std::shared_ptr<api::BitcoinLikeTransaction> parseRawTransaction(const api::Currency &currency,
+                                                                                    const std::vector<uint8_t> &rawTransaction,
+                                                                                    std::experimental::optional<int32_t> currentBlockHeight,
+                                                                                    bool isSigned);
+
+            static std::shared_ptr<api::BitcoinLikeTransaction> parseRawSignedTransaction(const api::Currency &currency,
+                                                                                          const std::vector<uint8_t> &rawTransaction,
+                                                                                          std::experimental::optional<int32_t> currentBlockHeight);
+
+            static api::EstimatedSize estimateSize(std::size_t inputCount,
+                                                   std::size_t outputCount,
+                                                   const api::Currency &currency,
+                                                   const std::string &keychainEngine);
+
+        private:
+            inline bool isWriteable() const;
+
+            inline bool isReadOnly() const;
+
+            inline void serializeProlog(BytesWriter &out);
+
+            inline void serializeInputs(BytesWriter &out);
+
+            inline void serializeOutputs(BytesWriter &out);
+
+            inline void serializeEpilogue(BytesWriter &out);
+
+        private:
+            int32_t _version;
+            std::vector<std::shared_ptr<api::BitcoinLikeInput>> _inputs;
+            std::vector<std::shared_ptr<api::BitcoinLikeOutput>> _outputs;
+            int32_t _lockTime;
+            std::shared_ptr<api::Amount> _fees;
+            std::chrono::system_clock::time_point _time;
+            std::shared_ptr<BitcoinLikeBlock> _block;
+            std::string _hash;
+            api::Currency _currency;
+            api::BitcoinLikeNetworkParameters _params;
+            Option<uint32_t> _timestamp;
+            bool _writable;
+            std::string _keychainEngine;
+            uint64_t _currentBlockHeight;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeTransactionBuilder.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeTransactionBuilder.hpp
@@ -1,0 +1,123 @@
+/*
+ *
+ * BitcoinLikeTransactionBuilder.h
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 27/03/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <functional>
+#include <list>
+
+#include <spdlog/logger.h>
+
+#include <core/api/Amount.hpp>
+#include <core/api/Currency.hpp>
+#include <core/async/Future.hpp>
+#include <core/math/BigInt.hpp>
+
+#include <bitcoin/api/BitcoinLikeNetworkParameters.hpp>
+#include <bitcoin/api/BitcoinLikePickingStrategy.hpp>
+#include <bitcoin/api/BitcoinLikeTransaction.hpp>
+#include <bitcoin/api/BitcoinLikeTransactionBuilder.hpp>
+
+namespace ledger {
+    namespace core {
+
+        struct BitcoinLikeTransactionBuildRequest {
+            BitcoinLikeTransactionBuildRequest(const std::shared_ptr<BigInt>& minChange);
+            std::list<std::tuple<std::string, int32_t, uint32_t>> inputs;
+            std::list<std::tuple<std::shared_ptr<BigInt>, std::shared_ptr<api::BitcoinLikeScript>>> outputs;
+            std::list<std::string> changePaths;
+            std::list<std::tuple<std::string, int32_t>> excludedUTXO;
+            int32_t changeCount;
+            std::shared_ptr<BigInt> feePerByte;
+            Option<std::tuple<api::BitcoinLikePickingStrategy, uint32_t>> UTXOPicker;
+            std::shared_ptr<BigInt> maxChange;
+            std::shared_ptr<BigInt> minChange;
+            bool wipe;
+        };
+
+        using BitcoinLikeTransactionBuildFunction = std::function<Future<std::shared_ptr<api::BitcoinLikeTransaction>> (const BitcoinLikeTransactionBuildRequest&)>;
+
+        class BitcoinLikeTransactionBuilder : public api::BitcoinLikeTransactionBuilder, public std::enable_shared_from_this<BitcoinLikeTransactionBuilder> {
+        public:
+            explicit BitcoinLikeTransactionBuilder(
+                    const std::shared_ptr<api::ExecutionContext>& context,
+                    const api::Currency& params,
+                    const std::shared_ptr<spdlog::logger>& logger,
+                    const BitcoinLikeTransactionBuildFunction& buildFunction);
+            BitcoinLikeTransactionBuilder(const BitcoinLikeTransactionBuilder& cpy);
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+            addInput(const std::string &transactionHash, int32_t index, int32_t sequence) override;
+
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder> addOutput(const std::shared_ptr<api::Amount> &amount,
+                                                                          const std::shared_ptr<api::BitcoinLikeScript> &script) override;
+
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder> addChangePath(const std::string &path) override;
+
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+            excludeUTXO(const std::string &transactionHash, int32_t outputIndex) override;
+
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder> setNumberOfChangeAddresses(int32_t count) override;
+
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+            pickInputs(api::BitcoinLikePickingStrategy strategy, int32_t sequence) override;
+
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+            sendToAddress(const std::shared_ptr<api::Amount> &amount, const std::string &address) override;
+
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+            wipeToAddress(const std::string &address) override;
+
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+            setFeesPerByte(const std::shared_ptr<api::Amount> &fees) override;
+
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+            setMaxAmountOnChange(const std::shared_ptr<api::Amount> &amount) override;
+
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+            setMinAmountOnChange(const std::shared_ptr<api::Amount> &amount) override;
+
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder> clone() override;
+
+            void reset() override;
+
+            void build(const std::function<void(std::shared_ptr<api::BitcoinLikeTransaction>, std::experimental::optional<api::Error>)> & callback) override;
+            Future<std::shared_ptr<api::BitcoinLikeTransaction>> build();
+        private:
+            api::Currency _currency;
+            std::shared_ptr<api::BitcoinLikeScript> createSendScript(const std::string &address);
+            BitcoinLikeTransactionBuildFunction _build;
+            BitcoinLikeTransactionBuildRequest _request;
+            std::shared_ptr<api::ExecutionContext> _context;
+            std::shared_ptr<spdlog::logger> _logger;
+
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeTransactionParser.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeTransactionParser.hpp
@@ -1,0 +1,81 @@
+/*
+ *
+ * BitcoinLikeTransactionParser
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 27/03/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <cstdio>
+#include <cstdint>
+#include <stack>
+
+#include <rapidjson/reader.h>
+
+#include <core/collections/Collections.hpp>
+#include <core/net/HttpClient.hpp>
+
+#include <bitcoin/block/BitcoinLikeBlockParser.hpp>
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+#include <bitcoin/io/BitcoinLikeInputParser.hpp>
+#include <bitcoin/io/BitcoinLikeOutputParser.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeTransactionParser {
+        public:
+            typedef BitcoinLikeBlockchainExplorerTransaction Result;
+
+            BitcoinLikeTransactionParser(std::string& lastKey);
+            void init(BitcoinLikeBlockchainExplorerTransaction* transaction);
+            bool Null();
+            bool Bool(bool b);
+            bool Int(int i);
+            bool Uint(unsigned i);
+            bool Int64(int64_t i);
+            bool Uint64(uint64_t i);
+            bool Double(double d);
+            bool RawNumber(const rapidjson::Reader::Ch* str, rapidjson::SizeType length, bool copy);
+            bool String(const rapidjson::Reader::Ch* str, rapidjson::SizeType length, bool copy);
+            bool StartObject();
+            bool Key(const rapidjson::Reader::Ch* str, rapidjson::SizeType length, bool copy);
+            bool EndObject(rapidjson::SizeType memberCount);
+            bool StartArray();
+            bool EndArray(rapidjson::SizeType elementCount);
+
+        private:
+            std::string& _lastKey;
+            BitcoinLikeBlockchainExplorerTransaction* _transaction;
+            std::stack<std::string> _hierarchy;
+            uint32_t _arrayDepth;
+            BitcoinLikeBlockParser _blockParser;
+            BitcoinLikeInputParser _inputParser;
+            BitcoinLikeOutputParser _outputParser;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeTransactionsBulkParser.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeTransactionsBulkParser.hpp
@@ -1,0 +1,60 @@
+/*
+ *
+ * TransactionsBulk
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 14/04/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/explorers/AbstractTransactionsBulkParser.hpp>
+
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+#include <bitcoin/transactions/BitcoinLikeAbstractTransactionParser.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeAbstractTransactionBulkParser : public AbstractTransactionsBulkParser<BitcoinLikeBlockchainExplorer::TransactionsBulk, BitcoinLikeAbstractTransactionParser> {
+        public:
+            BitcoinLikeAbstractTransactionBulkParser(std::string& lastKey) : _lastKey(lastKey), _transactionsParser(lastKey) {
+                _depth = 0;
+            };
+        protected:
+            BitcoinLikeAbstractTransactionParser &getTransactionsParser() override {
+                return _transactionsParser;
+            }
+
+            std::string &getLastKey() override {
+                return _lastKey;
+            }
+
+        private:
+            BitcoinLikeAbstractTransactionParser _transactionsParser;
+            std::string& _lastKey;
+        };
+    }
+}

--- a/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeUTXOPicker.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeUTXOPicker.hpp
@@ -35,7 +35,6 @@
 #include <core/async/DedicatedContext.hpp>
 #include <core/async/Future.hpp>
 
-#include <bitcoin/BitcoinTypes.hpp>
 #include <bitcoin/api/BitcoinLikeOutput.hpp>
 #include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
 #include <bitcoin/keychains/BitcoinLikeKeychain.hpp>

--- a/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeUTXOPicker.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeUTXOPicker.hpp
@@ -1,0 +1,114 @@
+/*
+ *
+ * BitcoinLikeUTXOPicker.h
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 28/03/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/api/Currency.hpp>
+#include <core/async/DedicatedContext.hpp>
+#include <core/async/Future.hpp>
+
+#include <bitcoin/BitcoinTypes.hpp>
+#include <bitcoin/api/BitcoinLikeOutput.hpp>
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+#include <bitcoin/keychains/BitcoinLikeKeychain.hpp>
+#include <bitcoin/transactions/BitcoinLikeTransactionBuilder.hpp>
+
+namespace ledger {
+    namespace core {
+        class BitcoinLikeTransaction;
+        class BitcoinLikeWritableInput;
+        using BitcoinLikeGetUTXOFunction = std::function<Future<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>> ()>;
+        using BitcoinLikeGetTxFunction = std::function<FuturePtr<BitcoinLikeBlockchainExplorerTransaction> (const std::string&)>;
+
+        class BitcoinLikeUTXOPicker : public DedicatedContext, public std::enable_shared_from_this<BitcoinLikeUTXOPicker> {
+        public:
+            BitcoinLikeUTXOPicker(
+                    const std::shared_ptr<api::ExecutionContext> &context,
+                    const api::Currency& currency
+            );
+            virtual BitcoinLikeTransactionBuildFunction getBuildFunction(
+                    const BitcoinLikeGetUTXOFunction& getUTXO,
+                    const BitcoinLikeGetTxFunction& getTransaction,
+                    const std::shared_ptr<BitcoinLikeBlockchainExplorer>& explorer,
+                    const std::shared_ptr<BitcoinLikeKeychain>& keychain,
+                    const uint64_t currentBlockHeight,
+                    const std::shared_ptr<spdlog::logger>& logger,
+                    bool partial);
+            const api::Currency& getCurrency() const;
+
+        protected:
+            using UTXODescriptor = std::tuple<std::string, int32_t, uint32_t >;
+            using UTXODescriptorList = std::vector<UTXODescriptor>;
+            struct Buddy {
+                Buddy(
+                        const BitcoinLikeTransactionBuildRequest& r,
+                        const BitcoinLikeGetUTXOFunction& g,
+                        const BitcoinLikeGetTxFunction& tx,
+                        const std::shared_ptr<BitcoinLikeBlockchainExplorer>& e,
+                        const std::shared_ptr<BitcoinLikeKeychain>& k,
+                        const std::shared_ptr<spdlog::logger>& l,
+                        std::shared_ptr<BitcoinLikeTransaction> t,
+                        bool partial) : request(r), explorer(e), keychain(k), transaction(t), getUTXO(g),
+                          getTransaction(tx), logger(l), isPartial(partial)
+                {
+                    if(request.wipe) {
+                        outputAmount = ledger::core::BigInt::ZERO;
+                    } else {
+                        for (auto& output : r.outputs)
+                            outputAmount = outputAmount + *std::get<0>(output);
+                    }
+                }
+                const BitcoinLikeTransactionBuildRequest request;
+                BitcoinLikeGetUTXOFunction getUTXO;
+                BitcoinLikeGetTxFunction getTransaction;
+                std::shared_ptr<BitcoinLikeBlockchainExplorer> explorer;
+                std::shared_ptr<BitcoinLikeKeychain> keychain;
+                std::shared_ptr<BitcoinLikeTransaction> transaction;
+                BigInt outputAmount;
+                std::shared_ptr<spdlog::logger> logger;
+                BigInt changeAmount;
+                bool isPartial;
+            };
+
+            virtual Future<Unit> fillInputs(const std::shared_ptr<Buddy>& buddy);
+            virtual Future<UTXODescriptorList> filterInputs(const std::shared_ptr<Buddy>& buddy) = 0;
+            virtual Future<Unit> fillOutputs(const std::shared_ptr<Buddy>& buddy);
+            virtual Future<Unit> fillTransactionInfo(const std::shared_ptr<Buddy>& buddy);
+
+        private:
+            Future<Unit> fillInput(const std::shared_ptr<Buddy>& buddy, const UTXODescriptor& desc);
+            BitcoinLikeGetUTXOFunction createFilteredUTXOFunction(const BitcoinLikeTransactionBuildRequest& buddy,
+                                                                  const BitcoinLikeGetUTXOFunction& getUTXO);
+        private:
+            api::Currency _currency;
+        };
+    }
+}

--- a/ledger-core-bitcoin/lib
+++ b/ledger-core-bitcoin/lib
@@ -1,0 +1,1 @@
+../ledger-core/lib

--- a/ledger-core-bitcoin/src/CMakeLists.txt
+++ b/ledger-core-bitcoin/src/CMakeLists.txt
@@ -1,0 +1,182 @@
+cmake_minimum_required(VERSION 3.12)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(ANDROID_CPP_FEATURES exceptions)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+find_package(ledger-core 0.1.0 REQUIRED)
+
+# Automatically add API files to the library
+file(
+    GLOB ledger-core-bitcoin-api-sources
+    "${CMAKE_SOURCE_DIR}/inc/bitcoin/api/*"
+)
+list(APPEND ledger-core-bitcoin-sources ${ledger-core-bitcoin-api-sources})
+
+# Configure JNI target
+if (TARGET_JNI)
+    message(STATUS "Configure project for JNI")
+
+    file(
+        GLOB ledger-core-bitcoin-jni-sources
+        "jni/*.cpp"
+        "jni/*.hpp"
+        "jni/jni/*"
+    )
+
+    if(NOT ANDROID)
+        find_package(JNI REQUIRED)
+    endif()
+
+    list(APPEND ledger-core-bitcoin-sources ${ledger-core-bitcoin-jni-sources})
+    add_definitions(-DTARGET_JNI=1)
+endif ()
+
+# Add files to compile to the project
+set(SRC_FILES
+    # bech32
+    bitcoin/bech32/BCHBech32.cpp
+    bitcoin/bech32/Bech32.cpp
+    bitcoin/bech32/Bech32Factory.cpp
+    bitcoin/bech32/Bech32Parameters.cpp
+    bitcoin/bech32/BTCBech32.cpp
+    # block
+    bitcoin/block/BitcoinLikeBlock.cpp
+    # database
+    bitcoin/database/BitcoinLikeAccountDatabase.cpp
+    bitcoin/database/BitcoinLikeAccountDatabaseHelper.cpp
+    bitcoin/database/BitcoinLikeBlockDatabaseHelper.cpp
+    bitcoin/database/BitcoinLikeTransactionDatabaseHelper.cpp
+    bitcoin/database/BitcoinLikeUTXODatabaseHelper.cpp
+    bitcoin/database/BitcoinLikeWalletDatabase.cpp
+    bitcoin/database/Migrations.cpp
+    # explorers
+    bitcoin/explorers/BitcoinLikeBlockchainExplorer.cpp
+    bitcoin/explorers/LedgerApiBitcoinLikeBlockchainExplorer.cpp
+    # factories
+    bitcoin/factories/BitcoinLikeWalletFactory.cpp
+    # io
+    bitcoin/io/BitcoinLikeInput.cpp
+    bitcoin/io/BitcoinLikeInputParser.cpp
+    bitcoin/io/BitcoinLikeOutput.cpp
+    bitcoin/io/BitcoinLikeOutputParser.cpp
+    bitcoin/io/BitcoinLikeWritableInput.cpp
+    # keychains
+    bitcoin/keychains/BitcoinLikeKeychain.cpp
+    bitcoin/keychains/CommonBitcoinLikeKeychains.cpp
+    bitcoin/keychains/P2PKHBitcoinLikeKeychain.cpp
+    bitcoin/keychains/P2SHBitcoinLikeKeychain.cpp
+    bitcoin/keychains/P2WPKHBitcoinLikeKeychain.cpp
+    bitcoin/keychains/P2WSHBitcoinLikeKeychain.cpp
+    # observers
+    bitcoin/observers/BitcoinLikeBlockchainObserver.cpp
+    bitcoin/observers/LedgerApiBitcoinLikeBlockchainObserver.cpp
+    # operations
+    bitcoin/operations/BitcoinLikeOperation.cpp
+    bitcoin/operations/BitcoinLikeOperationQuery.cpp
+    # scripts
+    bitcoin/scripts/BitcoinLikeScriptOperators.cpp
+    bitcoin/scripts/BitcoinLikeScript.cpp
+    bitcoin/scripts/BitcoinLikeInternalScript.cpp
+    # synchronizers
+    bitcoin/synchronizers/BitcoinLikeBlockchainExplorerAccountSynchronizer.cpp
+    # transactions
+    bitcoin/transactions/BitcoinLikeStrategyUTXOPicker.cpp
+    bitcoin/transactions/BitcoinLikeTransaction.cpp
+    bitcoin/transactions/BitcoinLikeTransactionBuilder.cpp
+    bitcoin/transactions/BitcoinLikeTransactionParser.cpp
+    bitcoin/transactions/BitcoinLikeUTXOPicker.cpp
+    # others
+    bitcoin/BitcoinLikeAccount.cpp
+    bitcoin/BitcoinLikeAddress.cpp
+    bitcoin/BitcoinLikeCurrencies.cpp
+    bitcoin/BitcoinLikeExtendedPublicKey.cpp
+    bitcoin/BitcoinLikeWallet.cpp
+    bitcoin/BitcoinNetworks.cpp
+)
+
+# Interface library used to hold shared properties
+add_library(ledger-core-bitcoin-interface INTERFACE)
+
+target_compile_definitions(ledger-core-bitcoin-interface INTERFACE ledger_core_EXPORTS)
+target_compile_definitions(ledger-core-bitcoin-interface INTERFACE
+    LIB_VERSION_MAJOR=${VERSION_MAJOR}
+    LIB_VERSION_MINOR=${VERSION_MINOR}
+    LIB_VERSION_PATCH=${VERSION_PATCH}
+)
+
+string(FIND "${CMAKE_OSX_SYSROOT}" "iphone" IS_IOS)
+if(IS_IOS GREATER_EQUAL 0)
+    add_library(ledger-core-bitcoin SHARED
+        ${ledger-core-bitcoin-sources}
+        ${SRC_FILES}
+        ${CORE_SRC_FILES}
+        ${HEADERS_FILES})
+    target_link_libraries(ledger-core-bitcoin PUBLIC ledger-core-bitcoin-interface)
+    set(CMAKE_SHARED_LINKER_FLAGS "-Wall")
+    set(FRAMEWORK_BUNDLE_IDENTIFIER "com.ledger.core")
+    set(DEPLOYMENT_TARGET 9.0)
+    set(DEVICE_FAMILY "1")
+    set(PRODUCT_NAME ledger_core)
+    set_target_properties(ledger-core-bitcoin PROPERTIES
+        FRAMEWORK TRUE
+        FRAMEWORK_VERSION A
+        MACOSX_FRAMEWORK_IDENTIFIER ${FRAMEWORK_BUNDLE_IDENTIFIER}
+        MACOSX_FRAMEWORK_BUNDLE_VERSION ${VERSION_MAJOR}
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
+        MACOSX_FRAMEWORK_INFO_PLIST ${CMAKE_BINARY_DIR}/framework.plist.in
+        # "current version" in semantic format in Mach-O binary file
+        VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
+        # "compatibility version" in semantic format in Mach-O binary file
+        SOVERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
+        PUBLIC_HEADER "${CMAKE_BINARY_DIR}/include/ledger/core"
+        XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET ${DEPLOYMENT_TARGET}
+        XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY ${DEVICE_FAMILY}
+        XCODE_ATTRIBUTE_SKIP_INSTALL "YES"
+    )
+    add_custom_command(
+        TARGET ledger-core-bitcoin
+        POST_BUILD
+        COMMAND /bin/bash -c "${CMAKE_BINARY_DIR}/install_name.sh \${BUILT_PRODUCTS_DIR}/\${PRODUCT_NAME}.framework/\${PRODUCT_NAME} ${CMAKE_OSX_ARCHITECTURES}"
+    )
+    add_custom_command(
+        TARGET ledger-core-bitcoin
+        POST_BUILD
+        COMMAND install_name_tool -id \"@rpath/\${PRODUCT_NAME}.framework/\${PRODUCT_NAME}\"
+        \${BUILT_PRODUCTS_DIR}/\${PRODUCT_NAME}.framework/\${PRODUCT_NAME}
+    )
+else()
+    add_library(ledger-core-bitcoin-obj OBJECT
+        ${ledger-core-bitcoin-sources}
+        ${SRC_FILES}
+        ${CORE_SRC_FILES}
+        ${HEADERS_FILES}
+        ${CORE_HEADER_FILES})
+    target_link_libraries(ledger-core-bitcoin-obj PUBLIC ledger-core-bitcoin-interface)
+
+    # shared and static libraries built from the same object files
+    add_library(ledger-core-bitcoin SHARED)
+    target_link_libraries(ledger-core-bitcoin PUBLIC ledger-core-bitcoin-obj)
+
+    add_library(ledger-core-bitcoin-static STATIC)
+    target_link_libraries(ledger-core-bitcoin-static PUBLIC ledger-core-bitcoin-obj)
+    install(TARGETS ledger-core-bitcoin-static DESTINATION "lib")
+endif()
+
+if(UNIX AND NOT APPLE AND NOT ANDROID)
+    target_link_libraries(ledger-core-bitcoin-interface INTERFACE -static-libstdc++)
+endif()
+
+# link the ledger-core library
+target_link_libraries(ledger-core-bitcoin-interface INTERFACE Core::ledger-core)
+
+if (TARGET_JNI)
+    target_include_directories(ledger-core-bitcoin-interface INTERFACE ${JNI_INCLUDE_DIRS})
+    target_link_libraries(ledger-core-bitcoin-interface INTERFACE ${JNI_LIBRARIES})
+endif ()
+
+target_include_directories(ledger-core-bitcoin-interface INTERFACE ${CMAKE_SOURCE_DIR}/inc)
+target_include_directories(ledger-core-bitcoin-interface INTERFACE ${CMAKE_SOURCE_DIR}/inc/bitcoin/api)
+
+install(TARGETS ledger-core-bitcoin DESTINATION lib)

--- a/ledger-core-bitcoin/src/bitcoin/BitcoinLikeAccount.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/BitcoinLikeAccount.cpp
@@ -1,0 +1,697 @@
+    /*
+    *
+    * BitcoinLikeAccount
+    * ledger-core
+    *
+    * Created by Pierre Pollastri on 28/04/2017.
+    *
+    * The MIT License (MIT)
+    *
+    * Copyright (c) 2016 Ledger
+    *
+    * Permission is hereby granted, free of charge, to any person obtaining a copy
+    * of this software and associated documentation files (the "Software"), to deal
+    * in the Software without restriction, including without limitation the rights
+    * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    * copies of the Software, and to permit persons to whom the Software is
+    * furnished to do so, subject to the following conditions:
+    *
+    * The above copyright notice and this permission notice shall be included in all
+    * copies or substantial portions of the Software.
+    *
+    * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    * SOFTWARE.
+    *
+    */
+
+    #include <spdlog/logger.h>
+
+    #include <core/database/query/QueryBuilder.hpp>
+    #include <core/collections/Functional.hpp>
+    #include <core/utils/DateUtils.hpp>
+    #include <core/operation/Operation.hpp>
+    #include <core/operation/OperationDatabaseHelper.hpp>
+    #include <core/synchronizers/AbstractBlockchainExplorerAccountSynchronizer.hpp>
+    #include <core/api/EventCode.hpp>
+    #include <core/events/EventPublisher.hpp>
+    #include <core/events/Event.hpp>
+    #include <core/database/SociNumber.hpp>
+    #include <core/database/SociDate.hpp>
+    #include <core/database/SociOption.hpp>
+
+    #include <bitcoin/database/BitcoinLikeUTXODatabaseHelper.hpp>
+    #include <bitcoin/BitcoinLikeAccount.hpp>
+    #include <bitcoin/database/BitcoinLikeBlockDatabaseHelper.hpp>
+    #include <bitcoin/io/BitcoinLikeOutput.hpp>
+    #include <bitcoin/api/BitcoinLikeInput.hpp>
+    #include <bitcoin/database/BitcoinLikeBlockDatabaseHelper.hpp>
+    #include <bitcoin/transactions/BitcoinLikeTransactionBuilder.hpp>
+    #include <bitcoin/transactions/BitcoinLikeStrategyUTXOPicker.hpp>
+    #include <bitcoin/database/BitcoinLikeTransactionDatabaseHelper.hpp>
+    #include <bitcoin/transactions/BitcoinLikeTransaction.hpp>
+    #include <bitcoin/operations/BitcoinLikeOperationQuery.hpp>
+
+    namespace ledger {
+        namespace core {
+
+            BitcoinLikeAccount::BitcoinLikeAccount(const std::shared_ptr<AbstractWallet> &wallet,
+                                                int32_t index,
+                                                const std::shared_ptr<BitcoinLikeBlockchainExplorer> &explorer,
+                                                const std::shared_ptr<BitcoinLikeBlockchainObserver> &observer,
+                                                const std::shared_ptr<BitcoinLikeAccountSynchronizer> &synchronizer,
+                                                const std::shared_ptr<BitcoinLikeKeychain> &keychain)
+                    : AbstractAccount(wallet->getServices(), wallet, index) {
+                _explorer = explorer;
+                _observer = observer;
+                _synchronizer = synchronizer;
+                _keychain = keychain;
+                _keychain->getAllObservableAddresses(0, 40);
+                _picker = std::make_shared<BitcoinLikeStrategyUTXOPicker>(getContext(), getWallet()->getCurrency());
+                _currentBlockHeight = 0;
+            }
+
+            void
+            BitcoinLikeAccount::inflateOperation(BitcoinLikeOperation &out,
+                                                const std::shared_ptr<const AbstractWallet>& wallet,
+                                                const BitcoinLikeBlockchainExplorerTransaction &tx) {
+                out.accountUid = getAccountUid();
+                out.block = tx.block;
+                out.currencyName = getWallet()->getCurrency().name;
+                out.walletUid = wallet->getWalletUid();
+                out.date = tx.receivedAt;
+                
+                if (out.block.nonEmpty())
+                    out.block.getValue().currencyName = wallet->getCurrency().name;
+            }
+
+            int BitcoinLikeAccount::putTransaction(soci::session &sql,
+                                                const BitcoinLikeBlockchainExplorerTransaction &transaction) {
+                auto wallet = getWallet();
+                if (wallet == nullptr) {
+                    throw Exception(api::ErrorCode::RUNTIME_ERROR, "Wallet reference is dead.");
+                }
+                if (transaction.block.nonEmpty())
+                    putBlock(sql, transaction.block.getValue());
+                auto nodeIndex = std::const_pointer_cast<const BitcoinLikeKeychain>(_keychain)->getFullDerivationScheme().getPositionForLevel(DerivationSchemeLevel::NODE);
+                std::list<std::pair<BitcoinLikeBlockchainExplorerInput *, DerivationPath>> accountInputs;
+                std::list<std::pair<BitcoinLikeBlockchainExplorerOutput *, DerivationPath>> accountOutputs;
+                uint64_t fees = 0L;
+                uint64_t sentAmount = 0L;
+                uint64_t receivedAmount = 0L;
+                std::vector<std::string> senders;
+                senders.reserve(transaction.inputs.size());
+                std::vector<std::string> recipients;
+                recipients.reserve(transaction.outputs.size());
+                int result = 0x00;
+
+                // Find inputs
+                for (auto& input : transaction.inputs) {
+
+                    if (input.address.nonEmpty()) {
+                        senders.push_back(input.address.getValue());
+                    }
+                    // Extend input with derivation paths
+
+                    if (input.address.nonEmpty() && input.value.nonEmpty()) {
+                        auto path = _keychain->getAddressDerivationPath(input.address.getValue());
+                        if (path.nonEmpty()) {
+                            // This address is part of the account.
+                            sentAmount += input.value.getValue().toUint64();
+                            accountInputs.push_back(std::make_pair(const_cast<BitcoinLikeBlockchainExplorerInput *>(&input), DerivationPath(path.getValue())));
+                            if (_keychain->markPathAsUsed(DerivationPath(path.getValue()))) {
+                                result = result | FLAG_TRANSACTION_ON_PREVIOUSLY_EMPTY_ADDRESS;
+                            } else {
+                                result = result | FLAG_TRANSACTION_ON_USED_ADDRESS;
+                            }
+                        }
+                    }
+                    if (input.value.nonEmpty()) {
+                        fees += input.value.getValue().toUint64();
+                    }
+                }
+
+                // Find outputs
+                auto hasSpentNothing = sentAmount == 0L;
+                auto outputCount = transaction.outputs.size();
+                for (auto index = 0; index < outputCount; index++) {
+                    auto& output = transaction.outputs[index];
+                    if (output.address.nonEmpty()) {
+                        auto path = _keychain->getAddressDerivationPath(output.address.getValue());
+                        if (path.nonEmpty()) {
+                            DerivationPath p(path.getValue());
+                            accountOutputs.push_back(std::make_pair(const_cast<BitcoinLikeBlockchainExplorerOutput *>(&output), p));
+                            if (p.getNonHardenedChildNum(nodeIndex) == 1) {
+                                if (hasSpentNothing) {
+                                    receivedAmount +=  output.value.toUint64();
+                                }
+                                if ((recipients.size() == 0 && index + 1 >= outputCount) || hasSpentNothing) {
+                                    recipients.push_back(output.address.getValue());
+                                }
+                            } else {
+                                receivedAmount += output.value.toUint64();
+                                recipients.push_back(output.address.getValue());
+                            }
+                            if (_keychain->markPathAsUsed(DerivationPath(path.getValue()))) {
+                                result = result | FLAG_TRANSACTION_ON_PREVIOUSLY_EMPTY_ADDRESS;
+                            } else {
+                                result = result | FLAG_TRANSACTION_ON_USED_ADDRESS;
+                            }
+                        } else {
+                            recipients.push_back(output.address.getValue());
+                        }
+                    }
+                    fees = fees - output.value.toUint64();
+                }
+                std::stringstream snds;
+                strings::join(senders, snds, ",");
+
+                BitcoinLikeOperation operation(getWallet(), transaction);
+                
+                inflateOperation(operation, wallet, transaction);
+                
+                operation.senders = std::move(senders);
+                operation.recipients = std::move(recipients);
+                operation.fees = std::move(BigInt().assignI64(fees));
+                operation.trust = std::make_shared<TrustIndicator>();
+                operation.date = transaction.receivedAt;
+
+                // Compute trust
+                computeOperationTrust(operation, wallet, transaction);
+
+                if (accountInputs.size() > 0) {
+                    // Create a send operation
+                    result = result | FLAG_TRANSACTION_CREATED_SENDING_OPERATION;
+
+                    for (auto& accountOutput : accountOutputs) {
+                        if (accountOutput.second.getNonHardenedChildNum(nodeIndex) == 1)
+                            sentAmount -= accountOutput.first->value.toInt64();
+                    }
+                    sentAmount -= fees;
+
+                    operation.amount.assignI64(sentAmount);
+                    operation.type = api::OperationType::SEND;
+                    operation.refreshUid();
+                    if (OperationDatabaseHelper::putOperation(sql, operation))
+                        emitNewOperationEvent(operation);
+                }
+
+                if (accountOutputs.size() > 0) {
+                    // Receive
+                    BigInt amount;
+                    auto flag = 0;
+                    bool filterChangeAddresses = true;
+
+                    if (accountInputs.size() == 0) {
+                        filterChangeAddresses = false;
+                    }
+
+                    BigInt finalAmount;
+                    auto accountOutputCount = 0;
+                    for (auto& o : accountOutputs) {
+                        if (filterChangeAddresses && o.second.getNonHardenedChildNum(nodeIndex) == 1)
+                            continue;
+                        finalAmount = finalAmount + o.first->value;
+                        accountOutputCount += 1;
+                    }
+                    if (accountOutputCount > 0) {
+                        operation.amount = finalAmount;
+                        operation.type = api::OperationType::RECEIVE;
+                        operation.refreshUid();
+                        if (OperationDatabaseHelper::putOperation(sql, operation))
+                            emitNewOperationEvent(operation);
+                    }
+
+                    auto accountUid = getAccountUid();
+                    //Update account_uid column of bitcoin_outputs table
+                    for (auto& o : accountOutputs) {
+                        if (o.first->address.nonEmpty()) {
+                            auto address = o.first->address.getValue();
+                            soci::rowset<soci::row> rows = (sql.prepare << "SELECT transaction_uid, transaction_hash FROM bitcoin_outputs WHERE address = :address AND account_uid IS NULL ",
+                                    soci::use(address));
+
+                            for (auto &row : rows) {
+                                auto txUid = row.get<std::string>(0);
+                                auto txHash = row.get<std::string>(1);
+                                //This check is made to avoid setting account_uid of bitcoin_outputs which was set during another's account scan/sync
+                                //since now bitcoin_outputs has transaction_uid (accountUid-hash) as primary key
+                                if (txUid == BitcoinLikeTransactionDatabaseHelper::createBitcoinTransactionUid(accountUid, txHash)) {
+                                    sql << "UPDATE bitcoin_outputs SET account_uid = :accountUid WHERE address = :address AND transaction_uid = :txUid",
+                                            soci::use(accountUid), soci::use(address), soci::use(txUid);
+                                }
+                            }
+                        }
+                    }
+
+                }
+
+                return result;
+            }
+
+            void
+            BitcoinLikeAccount::computeOperationTrust(BitcoinLikeOperation &operation, const std::shared_ptr<const AbstractWallet> &wallet,
+                                                    const BitcoinLikeBlockchainExplorerTransaction &tx) {
+                if (tx.block.nonEmpty()) {
+                    auto txBlockHeight = tx.block.getValue().height;
+                    if (_currentBlockHeight > txBlockHeight + 5 ) {
+                        operation.trust->setTrustLevel(api::TrustLevel::TRUSTED);
+                    } else if (_currentBlockHeight > txBlockHeight) {
+                        operation.trust->setTrustLevel(api::TrustLevel::UNTRUSTED);
+                    } else if (_currentBlockHeight == txBlockHeight) {
+                        operation.trust->setTrustLevel(api::TrustLevel::PENDING);
+                    }
+
+                } else {
+                    operation.trust->setTrustLevel(api::TrustLevel::DROPPED);
+                }
+            }
+
+            std::shared_ptr<BitcoinLikeKeychain> BitcoinLikeAccount::getKeychain() const {
+                return _keychain;
+            }
+
+
+            bool BitcoinLikeAccount::isSynchronizing() {
+                std::lock_guard<std::mutex> lock(_synchronizationLock);
+                return _currentSyncEventBus != nullptr;
+            }
+
+            std::shared_ptr<api::EventBus> BitcoinLikeAccount::synchronize() {
+                std::lock_guard<std::mutex> lock(_synchronizationLock);
+                if (_currentSyncEventBus)
+                    return _currentSyncEventBus;
+                auto eventPublisher = std::make_shared<EventPublisher>(getContext());
+                auto wasEmpty = checkIfWalletIsEmpty();
+                _currentSyncEventBus = eventPublisher->getEventBus();
+                auto future = _synchronizer->synchronize(std::static_pointer_cast<BitcoinLikeAccount>(shared_from_this()))->getFuture();
+                auto self = std::static_pointer_cast<BitcoinLikeAccount>(shared_from_this());
+
+                //Update current block height (needed to compute trust level)
+                _explorer->getCurrentBlock().onComplete(getContext(), [self] (const TryPtr<BitcoinLikeBlockchainExplorer::Block>& block) mutable {
+                    if (block.isSuccess()) {
+                        self->_currentBlockHeight = block.getValue()->height;
+                    }
+                });
+
+                auto startTime = DateUtils::now();
+                eventPublisher->postSticky(std::make_shared<Event>(api::EventCode::SYNCHRONIZATION_STARTED, api::DynamicObject::newInstance()), 0);
+                future.onComplete(getContext(), [eventPublisher, self, wasEmpty, startTime] (const Try<Unit>& result) {
+                    auto isEmpty = self->checkIfWalletIsEmpty();
+                    api::EventCode code;
+                    auto payload = std::make_shared<DynamicObject>();
+                    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(DateUtils::now() - startTime).count();
+                    payload->putLong(api::Account::EV_SYNC_DURATION_MS, duration);
+                    if (result.isSuccess()) {
+                        code = !isEmpty && wasEmpty ? api::EventCode::SYNCHRONIZATION_SUCCEED_ON_PREVIOUSLY_EMPTY_ACCOUNT
+                                                    : api::EventCode::SYNCHRONIZATION_SUCCEED;
+                    } else {
+                        code = api::EventCode::SYNCHRONIZATION_FAILED;
+                        payload->putString(api::Account::EV_SYNC_ERROR_CODE, api::to_string(result.getFailure().getErrorCode()));
+                        payload->putInt(api::Account::EV_SYNC_ERROR_CODE_INT, (int32_t)result.getFailure().getErrorCode());
+                        payload->putString(api::Account::EV_SYNC_ERROR_MESSAGE, result.getFailure().getMessage());
+                    }
+                    eventPublisher->postSticky(std::make_shared<Event>(code, payload), 0);
+                    std::lock_guard<std::mutex> lock(self->_synchronizationLock);
+                    self->_currentSyncEventBus = nullptr;
+
+                });
+                return eventPublisher->getEventBus();
+            }
+
+            void BitcoinLikeAccount::getUTXO(int32_t from, int32_t to,
+                                            const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>>, std::experimental::optional<api::Error>)> & callback) {
+                getUTXO(from, to).callback(getMainExecutionContext(), callback);
+            }
+
+            Future<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>>
+            BitcoinLikeAccount::getUTXO(int32_t from, int32_t to) {
+                auto self = getSelf();
+                return async<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>>([=] () -> std::vector<std::shared_ptr<api::BitcoinLikeOutput>> {
+                    auto keychain = self->getKeychain();
+                    soci::session sql(self->getWallet()->getDatabase()->getPool());
+                    std::vector<BitcoinLikeBlockchainExplorerOutput> utxo;
+                    BitcoinLikeUTXODatabaseHelper::queryUTXO(sql, self->getAccountUid(), from, to - from, utxo, [&keychain] (const std::string& addr) {
+                        return keychain->contains(addr);
+                    });
+                    auto currency = self->getWallet()->getCurrency();
+                    return functional::map<BitcoinLikeBlockchainExplorerOutput, std::shared_ptr<api::BitcoinLikeOutput>>(utxo, [&currency] (const BitcoinLikeBlockchainExplorerOutput& output) -> std::shared_ptr<api::BitcoinLikeOutput> {
+                        return std::make_shared<BitcoinLikeOutput>(output, currency);
+                    });
+                });
+            }
+
+            void BitcoinLikeAccount::getUTXOCount(const std::function<void(std::experimental::optional<int32_t>, std::experimental::optional<api::Error>)> & callback) {
+                getUTXOCount().callback(getMainExecutionContext(), callback);
+            }
+
+            bool BitcoinLikeAccount::putBlock(soci::session &sql, const BitcoinLikeBlockchainExplorer::Block& block) {
+                api::Block abstractBlock;
+                abstractBlock.blockHash = block.blockHash;
+                abstractBlock.currencyName = getWallet()->getCurrency().name;
+                abstractBlock.height = block.height;
+                abstractBlock.time = block.time;
+                if (BlockDatabaseHelper::putBlock(sql, abstractBlock)) {
+                    BitcoinLikeBlockDatabaseHelper::putBlock(sql, block);
+                    emitNewBlockEvent(abstractBlock);
+                    return true;
+                }
+                return false;
+            }
+
+            Future<int32_t> BitcoinLikeAccount::getUTXOCount() {
+                auto self = getSelf();
+                return async<int32_t>([=] () -> int32_t {
+                    auto keychain = self->getKeychain();
+                    soci::session sql(self->getWallet()->getDatabase()->getPool());
+                    return (int32_t) BitcoinLikeUTXODatabaseHelper::UTXOcount(sql, self->getAccountUid(), [keychain] (const std::string& addr) -> bool {
+                        return keychain->contains(addr);
+                    });
+                });
+            }
+
+            std::shared_ptr<api::OperationQuery> BitcoinLikeAccount::queryOperations() {
+                auto query = std::make_shared<BitcoinLikeOperationQuery>(
+                        api::QueryFilter::accountEq(getAccountUid()),
+                        getWallet()->getDatabase(),
+                        getWallet()->getContext(),
+                        getWallet()->getMainExecutionContext()
+                );
+                query->registerAccount(shared_from_this());
+                return query;
+            }
+
+            bool BitcoinLikeAccount::checkIfWalletIsEmpty() {
+                return _keychain->isEmpty();
+            }
+
+            Future<AbstractAccount::AddressList> BitcoinLikeAccount::getFreshPublicAddresses() {
+                auto keychain = getKeychain();
+                return async<AbstractAccount::AddressList>([=] () -> AbstractAccount::AddressList {
+                    auto addrs = keychain->getFreshAddresses(BitcoinLikeKeychain::KeyPurpose::RECEIVE, keychain->getObservableRangeSize());
+                    AbstractAccount::AddressList result(addrs.size());
+                    auto i = 0;
+                    for (auto& addr : addrs) {
+                        result[i] = std::dynamic_pointer_cast<api::Address>(addr);
+                        i += 1;
+                    }
+                    return result;
+                });
+            }
+
+            Future<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>> BitcoinLikeAccount::getUTXO() {
+                auto self = std::dynamic_pointer_cast<BitcoinLikeAccount>(shared_from_this());
+                return getUTXOCount().flatMap<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>>(getContext(), [=] (const int32_t& count) -> Future<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>> {
+                    return self->getUTXO(0, count);
+                });
+            }
+
+            FuturePtr<ledger::core::Amount> BitcoinLikeAccount::getBalance() {
+                auto self = std::dynamic_pointer_cast<BitcoinLikeAccount>(shared_from_this());
+                return async<std::shared_ptr<Amount>>([=] () -> std::shared_ptr<Amount> {
+                    const int32_t BATCH_SIZE = 100;
+                    const auto& uid = self->getAccountUid();
+                    soci::session sql(self->getWallet()->getDatabase()->getPool());
+                    std::vector<BitcoinLikeBlockchainExplorerOutput> utxos;
+                    auto offset = 0;
+                    std::size_t count = 0;
+                    BigInt sum(0);
+                    auto keychain = self->getKeychain();
+                    std::function<bool (const std::string&)> filter = [&keychain] (const std::string addr) -> bool {
+                        return keychain->contains(addr);
+                    };
+                    for (; (count = BitcoinLikeUTXODatabaseHelper::queryUTXO(sql, uid, offset, BATCH_SIZE, utxos, filter)) == BATCH_SIZE; offset += count) {}
+                    for (const auto& utxo : utxos) {
+                        sum = sum + utxo.value;
+                    }
+                    return std::make_shared<Amount>(self->getWallet()->getCurrency(), 0, sum);
+                });
+            }
+
+            Future<std::vector<std::shared_ptr<api::Amount>>>
+            BitcoinLikeAccount::getBalanceHistory(const std::string &start,
+                                                const std::string &end,
+                                                api::TimePeriod precision) {
+                auto self = std::dynamic_pointer_cast<BitcoinLikeAccount>(shared_from_this());
+                return async<std::vector<std::shared_ptr<api::Amount>>>([=]() -> std::vector<std::shared_ptr<api::Amount>> {
+
+                    auto startDate = DateUtils::fromJSON(start);
+                    auto endDate = DateUtils::fromJSON(end);
+                    if (startDate >= endDate) {
+                        throw make_exception(api::ErrorCode::INVALID_DATE_FORMAT,
+                                            "Start date should be strictly greater than end date");
+                    }
+
+                    const auto &uid = self->getAccountUid();
+                    soci::session sql(self->getWallet()->getDatabase()->getPool());
+                    std::vector<BitcoinLikeOperation> operations;
+
+                    auto keychain = self->getKeychain();
+                    std::function<bool(const std::string &)> filter = [&keychain](const std::string addr) -> bool {
+                        return keychain->contains(addr);
+                    };
+
+                    //Get operations related to an account
+                    OperationDatabaseHelper::queryOperations(sql, uid, operations, filter);
+
+                    auto lowerDate = startDate;
+                    auto upperDate = DateUtils::incrementDate(startDate, precision);
+
+                    std::vector<std::shared_ptr<api::Amount>> amounts;
+                    std::size_t operationsCount = 0;
+                    BigInt sum;
+                    while (lowerDate <= endDate && operationsCount < operations.size()) {
+
+                        auto operation = operations[operationsCount];
+                        while (operation.date > upperDate && lowerDate < endDate) {
+                            lowerDate = DateUtils::incrementDate(lowerDate, precision);
+                            upperDate = DateUtils::incrementDate(upperDate, precision);
+                            amounts.emplace_back(
+                                    std::make_shared<ledger::core::Amount>(self->getWallet()->getCurrency(), 0, sum));
+                        }
+
+                        if (operation.date <= upperDate) {
+                            switch (operation.type) {
+                                case api::OperationType::RECEIVE: {
+                                    sum = sum + operation.amount;
+                                    break;
+                                }
+                                case api::OperationType::SEND: {
+                                    sum = sum - (operation.amount + operation.fees.getValueOr(BigInt::ZERO));
+                                    break;
+                                }
+                                case api::OperationType::NONE:
+                                    break;
+                            }
+                        }
+                        operationsCount += 1;
+                    }
+
+                    while (lowerDate < endDate) {
+                        lowerDate = DateUtils::incrementDate(lowerDate, precision);
+                        amounts.emplace_back(
+                                std::make_shared<ledger::core::Amount>(self->getWallet()->getCurrency(), 0, sum));
+                    }
+
+                    return amounts;
+                });
+            }
+
+            std::shared_ptr<BitcoinLikeAccount> BitcoinLikeAccount::getSelf() {
+                return std::dynamic_pointer_cast<BitcoinLikeAccount>(shared_from_this());
+            }
+
+            void BitcoinLikeAccount::startBlockchainObservation() {
+                _observer->registerAccount(getSelf());
+            }
+
+            void BitcoinLikeAccount::stopBlockchainObservation() {
+                _observer->unregisterAccount(getSelf());
+            }
+
+            bool BitcoinLikeAccount::isObservingBlockchain() {
+                return _observer->isRegistered(getSelf());
+            }
+
+            Future<std::string> BitcoinLikeAccount::broadcastTransaction(const std::vector<uint8_t> &transaction) {
+                return _explorer->pushTransaction(transaction).map<std::string>(getContext(), [] (const String& hash) -> std::string {
+                    return hash.str();
+                });
+            }
+
+            // This method is used to get a block height only used to know which
+            // update/fork (activated at certain block height) is used.
+            // This explains why we take LLONG_MAX is we have no block in DB for
+            // certain currency
+            // WARNING: please don't use this method if you need an accurate value
+            // of last block
+            static uint64_t getLastBlockFromDB(soci::session &sql, const std::string &currencyName) {
+                //Get last block from DB
+                auto lastBlock = BlockDatabaseHelper::getLastBlock(sql, currencyName);
+                // If we can not retrieve a last block for currency,
+                // we set the returned block height to LLONG_MAX in order to
+                // activate/apply last BIP/update/fork for this currency.
+                return lastBlock.hasValue() ? static_cast<uint64_t >(lastBlock->height) : LLONG_MAX;
+            }
+
+            void BitcoinLikeAccount::broadcastRawTransaction(const std::vector<uint8_t> &transaction,
+                                                             const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<::ledger::core::api::Error>)> & callback) {
+                auto self = getSelf();
+                _explorer->pushTransaction(transaction).map<std::string>(getContext(), [self, transaction] (const String& seq) -> std::string {
+                    //Store newly broadcasted tx in db
+                    //First parse it
+                    auto txHash = seq.str();
+                    auto optimisticUpdate = Try<int>::from([&] () -> int {
+                        //Get last block from DB
+                        soci::session sql(self->getWallet()->getDatabase()->getPool());
+                        auto lastBlockHeight = getLastBlockFromDB(sql, self->getWallet()->getCurrency().name);
+
+                        auto tx = BitcoinLikeTransaction::parseRawSignedTransaction(self->getWallet()->getCurrency(), transaction, lastBlockHeight);
+
+                        //Get a BitcoinLikeBlockchainExplorerTransaction from a BitcoinLikeTransaction
+                        BitcoinLikeBlockchainExplorerTransaction txExplorer;
+                        txExplorer.hash = txHash;
+                        txExplorer.lockTime = tx->getLockTime();
+                        txExplorer.receivedAt = std::chrono::system_clock::now();
+                        txExplorer.version = tx->getVersion();
+                        txExplorer.confirmations = 0;
+
+                        //Inputs
+                        auto inputCount = tx->getInputs().size();
+                        for (auto index = 0; index < inputCount; index++) {
+                            auto input = tx->getInputs()[index];
+                            BitcoinLikeBlockchainExplorerInput in;
+                            in.index = index;
+                            auto prevTxHash = input->getPreviousTxHash().value_or("");
+                            auto prevTxOutputIndex = input->getPreviousOutputIndex().value_or(0);
+                            BitcoinLikeBlockchainExplorerTransaction prevTx;
+                            if (!BitcoinLikeTransactionDatabaseHelper::getTransactionByHash(sql, prevTxHash, self->getAccountUid(), prevTx) || prevTxOutputIndex >= prevTx.outputs.size()) {
+                                throw make_exception(api::ErrorCode::TRANSACTION_NOT_FOUND, "Transaction {} not found while broadcasting", prevTxHash);
+                            }
+                            in.value = prevTx.outputs[prevTxOutputIndex].value;
+                            in.signatureScript = hex::toString(input->getScriptSig());
+                            in.previousTxHash = prevTxHash;
+                            in.previousTxOutputIndex = prevTxOutputIndex;
+                            in.sequence = input->getSequence();
+                            in.address = prevTx.outputs[prevTxOutputIndex].address.getValueOr("");
+                            txExplorer.inputs.push_back(in);
+                        }
+
+                        //Outputs
+                        auto keychain = self->getKeychain();
+                        auto nodeIndex = keychain->getFullDerivationScheme().getPositionForLevel(DerivationSchemeLevel::NODE);
+                        auto outputCount = tx->getOutputs().size();
+                        for (auto index = 0; index < outputCount; index++) {
+                            auto output = tx->getOutputs()[index];
+                            BitcoinLikeBlockchainExplorerOutput out;
+                            out.value = BigInt(output->getValue()->toString());
+                            out.time = DateUtils::toJSON(std::chrono::system_clock::now());
+                            out.transactionHash = output->getTransactionHash();
+                            out.index = output->getOutputIndex();
+                            out.script = hex::toString(output->getScript());
+                            out.address = output->getAddress().value_or("");
+                            txExplorer.outputs.push_back(out);
+                        }
+
+                        //Store in DB
+                        return self->putTransaction(sql, txExplorer);
+                    });
+
+                    // Failing optimistic update should not throw an exception
+                    // because the tx was successfully broadcasted to the network,
+                    // and the update will occur at next synchro ...
+                    // But still let's log that !
+                    if (optimisticUpdate.isFailure()) {
+                        self->logger()->warn(" Optimistic update failed for broadcasted transaction : {}", txHash);
+                    }
+
+                    return txHash;
+                }).callback(getContext(), callback);
+            }
+
+            void BitcoinLikeAccount::broadcastTransaction(const std::shared_ptr<api::BitcoinLikeTransaction> &transaction,
+                                                          const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<::ledger::core::api::Error>)> & callback) {
+                broadcastRawTransaction(transaction->serialize(), callback);
+            }
+
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder> BitcoinLikeAccount::buildTransaction(std::experimental::optional<bool> partial) {
+                auto self = std::dynamic_pointer_cast<BitcoinLikeAccount>(shared_from_this());
+                auto getUTXO = [self] () -> Future<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>> {
+                    return self->getUTXO();
+                };
+                auto getTransaction = [self] (const std::string& hash) -> FuturePtr<BitcoinLikeBlockchainExplorerTransaction> {
+                    return self->getTransaction(hash);
+                };
+
+                soci::session sql(self->getWallet()->getDatabase()->getPool());
+                auto lastBlockHeight = getLastBlockFromDB(sql, self->getWallet()->getCurrency().name);
+
+                return std::make_shared<BitcoinLikeTransactionBuilder>(
+                        getContext(),
+                        getWallet()->getCurrency(),
+                        logger(),
+                        _picker->getBuildFunction(getUTXO,
+                                                getTransaction,
+                                                _explorer,
+                                                _keychain,
+                                                lastBlockHeight,
+                                                logger(),
+                                                partial.value_or(false))
+                );
+            }
+
+            const std::shared_ptr<BitcoinLikeBlockchainExplorer> &BitcoinLikeAccount::getExplorer() const {
+                return _explorer;
+            }
+
+            FuturePtr<ledger::core::BitcoinLikeBlockchainExplorerTransaction> BitcoinLikeAccount::getTransaction(const std::string& hash) {
+                auto self = std::dynamic_pointer_cast<BitcoinLikeAccount>(shared_from_this());
+                return async<std::shared_ptr<BitcoinLikeBlockchainExplorerTransaction>>([=] () -> std::shared_ptr<BitcoinLikeBlockchainExplorerTransaction> {
+                    auto tx = std::make_shared<BitcoinLikeBlockchainExplorerTransaction>();
+                    soci::session sql(self->getWallet()->getDatabase()->getPool());
+                    if (!BitcoinLikeTransactionDatabaseHelper::getTransactionByHash(sql, hash, self->getAccountUid(), *tx)) {
+                        throw make_exception(api::ErrorCode::TRANSACTION_NOT_FOUND, "Transaction {} not found", hash);
+                    }
+                    return tx;
+                });
+            }
+
+            std::string BitcoinLikeAccount::getRestoreKey() {
+                return _keychain->getRestoreKey();
+            }
+
+            Future<api::ErrorCode> BitcoinLikeAccount::eraseDataSince(const std::chrono::system_clock::time_point & date) {
+                auto log = logger();
+
+                log->debug(" Start erasing data of account : {}", getAccountUid());
+                soci::session sql(getWallet()->getDatabase()->getPool());
+                //Update account's internal preferences (for synchronization)
+                auto savedState = getInternalPreferences()->getSubPreferences("BlockchainExplorerAccountSynchronizer")->getObject<BlockchainExplorerAccountSynchronizationSavedState>("state");
+                if (savedState.nonEmpty()) {
+                    //Reset batches to blocks mined before given date
+                    auto previousBlock = BlockDatabaseHelper::getPreviousBlockInDatabase(sql, getWallet()->getCurrency().name, date);
+                    for (auto& batch : savedState.getValue().batches) {
+                        if (previousBlock.nonEmpty() && batch.blockHeight > previousBlock.getValue().height) {
+                            batch.blockHeight = (uint32_t) previousBlock.getValue().height;
+                            batch.blockHash = previousBlock.getValue().blockHash;
+                        } else if (!previousBlock.nonEmpty()) {//if no previous block, sync should go back from genesis block
+                            batch.blockHeight = 0;
+                            batch.blockHash = "";
+                        }
+                    }
+                    getInternalPreferences()->getSubPreferences("BlockchainExplorerAccountSynchronizer")->editor()->putObject<BlockchainExplorerAccountSynchronizationSavedState>("state", savedState.getValue())->commit();
+                }
+                auto accountUid = getAccountUid();
+                sql << "DELETE FROM operations WHERE account_uid = :account_uid AND date >= :date ", soci::use(accountUid), soci::use(date);
+                return Future<api::ErrorCode>::successful(api::ErrorCode::FUTURE_WAS_SUCCESSFULL);
+            }
+
+            void BitcoinLikeAccount::getFees(const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::BigInt>>>, std::experimental::optional<api::Error>)> & callback) {
+                return _explorer->getFees().callback(getContext(), callback);;
+            }
+
+        }
+    }

--- a/ledger-core-bitcoin/src/bitcoin/BitcoinLikeAddress.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/BitcoinLikeAddress.cpp
@@ -1,0 +1,260 @@
+/*
+ *
+ * BitcoinLikeAddress
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 12/12/2016.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/api/Configuration.hpp>
+#include <core/api/KeychainEngines.hpp>
+#include <core/bytes/BytesWriter.hpp>
+#include <core/collections/DynamicObject.hpp>
+#include <core/collections/Vector.hpp>
+#include <core/crypto/HashAlgorithm.hpp>
+#include <core/crypto/HASH160.hpp>
+#include <core/math/Base58.hpp>
+#include <core/utils/DjinniHelpers.hpp>
+#include <core/utils/Exception.hpp>
+
+#include <bitcoin/BitcoinLikeAddress.hpp>
+#include <bitcoin/BitcoinNetworks.hpp>
+#include <bitcoin/bech32/Bech32.hpp>
+#include <bitcoin/bech32/Bech32Factory.hpp>
+#include <bitcoin/scripts/BitcoinLikeScriptOperators.hpp>
+
+
+namespace ledger {
+    namespace core {
+        BitcoinLikeAddress::BitcoinLikeAddress(const ledger::core::api::Currency &currency,
+                                               const std::vector<uint8_t>& hash160,
+                                               const std::string &keychainEngine,
+                                               const Option<std::string>& derivationPath) :
+                _params(networks::getBitcoinLikeNetworkParameters(currency.name)),
+                _derivationPath(derivationPath),
+                _keychainEngine(keychainEngine),
+                _hash160(hash160),
+                Address(currency, derivationPath)
+        {
+
+        }
+
+        std::vector<uint8_t> BitcoinLikeAddress::getVersion() {
+            return getVersionFromKeychainEngine(_keychainEngine, _params);
+        }
+
+        std::vector<uint8_t> BitcoinLikeAddress::getVersionFromKeychainEngine(const std::string &keychainEngine, 
+                                                                              const api::BitcoinLikeNetworkParameters &params) const {
+
+            if (keychainEngine == api::KeychainEngines::BIP32_P2PKH) {
+                return params.P2PKHVersion;
+            } else if (keychainEngine == api::KeychainEngines::BIP49_P2SH) {
+                return params.P2SHVersion;
+            } else if (keychainEngine == api::KeychainEngines::BIP173_P2WPKH) {
+                auto bech32Params = Bech32Parameters::getBech32Params(params.Identifier);
+                return bech32Params.P2WPKHVersion;
+            } else if (keychainEngine == api::KeychainEngines::BIP173_P2WSH) {
+                auto bech32Params = Bech32Parameters::getBech32Params(params.Identifier);
+                return bech32Params.P2WSHVersion;
+            }
+            throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Invalid Keychain Engine: ", keychainEngine);
+        };
+
+        std::vector<uint8_t> BitcoinLikeAddress::getHash160() {
+            return _hash160;
+        }
+
+        ledger::core::api::BitcoinLikeNetworkParameters BitcoinLikeAddress::getNetworkParameters() {
+            return _params;
+        }
+
+        std::string BitcoinLikeAddress::toBase58() {
+            auto config = std::make_shared<DynamicObject>();
+            config->putString("networkIdentifier", _params.Identifier);
+            return Base58::encodeWithChecksum(vector::concat(getVersionFromKeychainEngine(_keychainEngine, _params), _hash160), config);
+        }
+
+        std::string toBech32Helper(const std::string &keychainEngine,
+                                   const std::vector<uint8_t> &hash160,
+                                   const api::BitcoinLikeNetworkParameters &params) {
+
+            auto bech32 = Bech32Factory::newBech32Instance(params.Identifier).getValue();
+            auto witnessVersion = (keychainEngine == api::KeychainEngines::BIP173_P2WPKH) ? bech32->getBech32Params().P2WPKHVersion : bech32->getBech32Params().P2WSHVersion;
+            return bech32->encode(hash160, witnessVersion);
+        }
+
+        std::string BitcoinLikeAddress::toBech32() {
+            return toBech32Helper(_keychainEngine, _hash160, _params);
+        }
+
+        bool BitcoinLikeAddress::isP2SH() {
+            return _keychainEngine == api::KeychainEngines::BIP49_P2SH;
+        }
+
+        bool BitcoinLikeAddress::isP2PKH() {
+            return _keychainEngine == api::KeychainEngines::BIP32_P2PKH;
+        }
+
+        bool BitcoinLikeAddress::isP2WSH() {
+            return _keychainEngine == api::KeychainEngines::BIP173_P2WSH;
+        }
+
+        bool BitcoinLikeAddress::isP2WPKH() {
+            return _keychainEngine == api::KeychainEngines::BIP173_P2WPKH;
+        }
+
+        std::experimental::optional<std::string> BitcoinLikeAddress::getDerivationPath() {
+            return _derivationPath.toOptional();
+        }
+
+        std::string BitcoinLikeAddress::toBase58() const {
+            if (_keychainEngine != api::KeychainEngines::BIP32_P2PKH && _keychainEngine != api::KeychainEngines::BIP49_P2SH) {
+                throw Exception(api::ErrorCode::INVALID_BASE58_FORMAT, "Base58 format only available for api::KeychainEngines::BIP32_P2PKH and api::KeychainEngines::BIP49_P2SH");
+            }
+            auto config = std::make_shared<DynamicObject>();
+            config->putString("networkIdentifier", _params.Identifier);
+            return Base58::encodeWithChecksum(vector::concat(getVersionFromKeychainEngine(_keychainEngine, _params), _hash160), config);
+        }
+
+        std::string BitcoinLikeAddress::toBech32() const {
+            return toBech32Helper(_keychainEngine, _hash160, _params);
+        }
+
+        std::shared_ptr<Address>
+        BitcoinLikeAddress::parse(const std::string &address,
+                                  const ledger::core::api::Currency &currency,
+                                  const Option<std::string>& derivationPath) {
+            auto result = Try<std::shared_ptr<Address>>::from([&] () {
+                auto bech32 = Bech32Factory::newBech32Instance(networks::getBitcoinLikeNetworkParameters(currency.name).Identifier);
+                auto isBech32 = bech32.hasValue() && (bech32.getValue()->getBech32Params().hrp == address.substr(0, bech32.getValue()->getBech32Params().hrp.size()));
+                return isBech32 ? fromBech32(address, currency, derivationPath) : fromBase58(address, currency, derivationPath);
+            });
+            return std::dynamic_pointer_cast<Address>(result.toOption().getValueOr(nullptr));
+        }
+
+        std::string BitcoinLikeAddress::toString() {
+            return getStringAddress();
+        }
+
+        std::string BitcoinLikeAddress::getStringAddress() const {
+            if (_keychainEngine == api::KeychainEngines::BIP173_P2WPKH || _keychainEngine == api::KeychainEngines::BIP173_P2WSH) {
+                return toBech32();
+            }
+            return toBase58();
+        }
+
+        std::shared_ptr<BitcoinLikeAddress> BitcoinLikeAddress::fromBase58(const std::string &address,
+                                                                           const api::Currency &currency,
+                                                                           const Option<std::string>& derivationPath) {
+            auto& params = networks::getBitcoinLikeNetworkParameters(currency.name);
+            auto config = std::make_shared<DynamicObject>();
+            config->putString("networkIdentifier", params.Identifier);
+            auto decoded = Base58::checkAndDecode(address, config);
+            if (decoded.isFailure()) {
+                throw decoded.getFailure();
+            }
+            auto value = decoded.getValue();
+
+            //Check decoded address size
+            if (value.size() <= 20) {
+                throw Exception(api::ErrorCode::INVALID_BASE58_FORMAT, "Invalid address : Invalid base 58 format");
+            }
+
+            std::vector<uint8_t> hash160(value.end() - 20, value.end());
+            std::vector<uint8_t> version(value.begin(), value.end() - 20);
+            if (version != params.P2PKHVersion && version != params.P2SHVersion) {
+                throw Exception(api::ErrorCode::INVALID_VERSION, "Address version doesn't belong to the given network parameters");
+            }
+            auto keychainEngine = (version == params.P2PKHVersion) ? api::KeychainEngines::BIP32_P2PKH : api::KeychainEngines::BIP49_P2SH;
+            return std::make_shared<ledger::core::BitcoinLikeAddress>(currency, hash160, keychainEngine, derivationPath);
+        }
+
+        std::shared_ptr<BitcoinLikeAddress> BitcoinLikeAddress::fromBech32(const std::string& address,
+                                                                           const api::Currency& currency,
+                                                                           const Option<std::string>& derivationPath) {
+            auto& params = networks::getBitcoinLikeNetworkParameters(currency.name);
+            auto bech32 = Bech32Factory::newBech32Instance(params.Identifier).getValue();
+            auto decoded = bech32->decode(address);
+            auto keychainEngine = (decoded.second.size() == 32 || decoded.first == bech32->getBech32Params().P2WSHVersion) ? api::KeychainEngines::BIP173_P2WSH : api::KeychainEngines::BIP173_P2WPKH;
+            return std::make_shared<ledger::core::BitcoinLikeAddress>(currency,
+                                                                      decoded.second,
+                                                                      keychainEngine,
+                                                                      derivationPath);
+        }
+
+        std::string BitcoinLikeAddress::fromPublicKey(const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &pubKey,
+                                                      const api::Currency &currency,
+                                                      const std::string &derivationPath,
+                                                      const std::string &keychainEngine) {
+            if (keychainEngine == api::KeychainEngines::BIP32_P2PKH || keychainEngine == api::KeychainEngines::BIP173_P2WPKH) {
+                return std::dynamic_pointer_cast<BitcoinLikeAddress>(pubKey->derive(derivationPath))->toString();
+            } else if (keychainEngine == api::KeychainEngines::BIP49_P2SH || keychainEngine == api::KeychainEngines::BIP173_P2WSH) {
+                auto hash160 = fromPublicKeyToHash160(pubKey->derivePublicKey(derivationPath), pubKey->deriveHash160(derivationPath), currency, keychainEngine);
+                return BitcoinLikeAddress(currency, hash160, keychainEngine).toString();
+
+            }
+            throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Invalid Keychain Engine: ", keychainEngine);
+        }
+
+        std::vector<uint8_t> BitcoinLikeAddress::fromPublicKeyToHash160(const std::vector<uint8_t> &pubKey,
+                                                                        const std::vector<uint8_t> &pubKeyHash160,
+                                                                        const api::Currency &currency,
+                                                                        const std::string &keychainEngine) {
+            if (keychainEngine == api::KeychainEngines::BIP49_P2SH) {
+                //Script
+                std::vector<uint8_t> script = {0x00, 0x14};
+                //Insert hash160 of public key
+                script.insert(script.end(), pubKeyHash160.begin(), pubKeyHash160.end());
+                //Hash script
+                HashAlgorithm hashAlgorithm(networks::getBitcoinLikeNetworkParameters(currency.name).Identifier);
+                return HASH160::hash(script, hashAlgorithm);
+            } else if (keychainEngine == api::KeychainEngines::BIP173_P2WSH) {
+                // Reference https://bitcoincore.org/en/segwit_wallet_dev
+                // Here scriptHash = SHA256(witnessScript) = SHA256(pubKeyHash160 + OP_CHECKSIG)
+                const auto& params = networks::getBitcoinLikeNetworkParameters(currency.name);
+                std::vector<uint8_t> witnessScript;
+                //Hash160 of public key
+                witnessScript.insert(witnessScript.end(), pubKey.begin(), pubKey.end());
+                witnessScript.push_back(btccore::OP_CHECKSIG);
+                return SHA256::bytesToBytesHash(witnessScript);
+            }
+            throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Invalid Keychain Engine: ", keychainEngine);
+        }
+
+        std::vector<uint8_t> BitcoinLikeAddress::fromPublicKeyToHash160(const std::vector<uint8_t> &pubKey,
+                                                                        const api::Currency &currency,
+                                                                        const std::string &keychainEngine) {
+            HashAlgorithm hashAlgorithm(networks::getBitcoinLikeNetworkParameters(currency.name).Identifier);
+            auto publicKeyHash160 = HASH160::hash(pubKey, hashAlgorithm);
+            if (keychainEngine == api::KeychainEngines::BIP32_P2PKH || keychainEngine == api::KeychainEngines::BIP173_P2WPKH) {
+                return publicKeyHash160;
+            } else if (keychainEngine == api::KeychainEngines::BIP49_P2SH || keychainEngine == api::KeychainEngines::BIP173_P2WSH) {
+                return fromPublicKeyToHash160(pubKey, publicKeyHash160, currency, keychainEngine);
+            }
+            throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Invalid Keychain Engine: ", keychainEngine);
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/BitcoinLikeCurrencies.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/BitcoinLikeCurrencies.cpp
@@ -1,0 +1,218 @@
+/*
+ *
+ * RippleLikeCurrencies
+ *
+ * Created by Alexis Le Provost on 2019/12/12
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/wallet/CurrencyBuilder.hpp>
+
+#include <bitcoin/BitcoinLikeCoinID.hpp>
+#include <bitcoin/BitcoinLikeCurrencies.hpp>
+
+namespace ledger {
+    namespace core {
+        namespace currencies {
+            const api::Currency BITCOIN =
+                CurrencyBuilder("bitcoin")
+                .bip44(BITCOIN_COIN_ID)
+                .paymentUri("bitcoin")
+                    .unit("satoshi", 0, "satoshi")
+                    .unit("bitcoin", 8, "BTC")
+                    .unit("milli-bitcoin", 5, "mBTC")
+                    .unit("micro-bitcoin", 2, "μBTC");
+
+            const api::Currency BITCOIN_TESTNET =
+                    CurrencyBuilder("bitcoin_testnet")
+                            .bip44(BITCOIN_TESTNET_COIN_ID)
+                            .paymentUri("bitcoin")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("bitcoin", 8, "BTC")
+                            .unit("milli-bitcoin", 5, "mBTC")
+                            .unit("micro-bitcoin", 2, "μBTC");
+
+            const api::Currency BITCOIN_CASH =
+                    CurrencyBuilder("bitcoin_cash")
+                            .bip44(BITCOIN_CASH_COIN_ID)
+                            .paymentUri("bitcoin_cash")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("bitcoin cash", 8, "BCH")
+                            .unit("mBCH", 5, "mBCH")
+                            .unit("bit", 2, "bit");
+
+            const api::Currency BITCOIN_GOLD =
+                    CurrencyBuilder("bitcoin_gold")
+                            .bip44(BITCOIN_GOLD_COIN_ID)
+                            .paymentUri("bitcoin_gold")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("bitcoin gold", 8, "BTG")
+                            .unit("mBTG", 5, "mBTG")
+                            .unit("bit", 2, "bit");
+
+            const api::Currency ZCASH =
+                    CurrencyBuilder("zcash")
+                            .bip44(133)
+                            .paymentUri("zcash")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("zcash", 8, "ZEC");
+
+            const api::Currency ZENCASH =
+                    CurrencyBuilder("zencash")
+                            .bip44(ZCASH_COIN_ID)
+                            .paymentUri("zencash")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("zencash", 8, "ZEN");
+
+            const api::Currency LITECOIN =
+                    CurrencyBuilder("litecoin")
+                            .bip44(LITE_COIN_ID)
+                            .paymentUri("litecoin")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("litecoin", 8, "LTC")
+                            .unit("milli-litecoin", 5, "mLTC")
+                            .unit("micro-litecoin", 2, "μLTC");
+
+            const api::Currency PEERCOIN =
+                    CurrencyBuilder("peercoin")
+                            .bip44(PEERCOIN_COIN_ID)
+                            .paymentUri("peercoin")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("peercoin", 6, "PPC")
+                            .unit("milli-peercoin", 3, "mPPC");
+
+            const api::Currency DIGIBYTE =
+                    CurrencyBuilder("digibyte")
+                            .bip44(DIGIBYTE_COIN_ID)
+                            .paymentUri("digibyte")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("digibyte", 8, "DGB");
+
+            const api::Currency HCASH =
+                    CurrencyBuilder("hcash")
+                            .bip44(HCASH_COIN_ID)
+                            .paymentUri("hcash")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("hshare", 8, "HSR");
+
+            const api::Currency QTUM =
+                    CurrencyBuilder("qtum")
+                            .bip44(QTUM_COIN_ID)
+                            .paymentUri("qtum")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("qtum", 8, "QTUM");
+
+            const api::Currency STEALTHCOIN =
+                    CurrencyBuilder("stealthcoin")
+                            .bip44(STEALTHCOIN_COIN_ID)
+                            .paymentUri("stealthcoin")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("stealthcoin", 6, "XST")
+                            .unit("milli-stealthcoin", 3, "mXST");
+
+            const api::Currency VERTCOIN =
+                    CurrencyBuilder("vertcoin")
+                            .bip44(VERTCOIN_COIN_ID)
+                            .paymentUri("vertcoin")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("vertcoin", 8, "VTC")
+                            .unit("milli-vertcoin", 5, "mVTC");
+
+            const api::Currency VIACOIN =
+                    CurrencyBuilder("viacoin")
+                            .bip44(VIACOIN_COIN_ID)
+                            .paymentUri("viacoin")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("viacoin", 8, "VIA")
+                            .unit("milli-viacoin", 5, "mVIA");
+
+            const api::Currency DASH =
+                    CurrencyBuilder("dash")
+                            .bip44(DASH_COIN_ID)
+                            .paymentUri("dash")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("dash", 8, "DASH");
+
+            const api::Currency DOGECOIN =
+                    CurrencyBuilder("dogecoin")
+                            .bip44(DOGECOIN_COIN_ID)
+                            .paymentUri("dogecoin")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("dogecoin", 8, "DOGE")
+                            .unit("milli-dogecoin", 5, "mDOGE");
+
+            const api::Currency STRATIS =
+                    CurrencyBuilder("stratis")
+                            .bip44(STRATIS_COIN_ID)
+                            .paymentUri("stratis")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("stratis", 8, "STRAT");
+
+            const api::Currency KOMODO =
+                    CurrencyBuilder("komodo")
+                            .bip44(KOMODO_COIN_ID)
+                            .paymentUri("komodo")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("komodo", 8, "KMD");
+
+            const api::Currency POSWALLET =
+                    CurrencyBuilder("poswallet")
+                            .bip44(POSWALLET_COIN_ID)
+                            .paymentUri("poswallet")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("poswallet", 8, "POSW");
+
+            const api::Currency PIVX =
+                    CurrencyBuilder("pivx")
+                            .bip44(PIVX_COIN_ID)
+                            .paymentUri("pivx")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("pivx", 8, "PIVX")
+                            .unit("milli-pivx", 5, "mPIVX");
+
+            const api::Currency CLUBCOIN =
+                    CurrencyBuilder("clubcoin")
+                            .bip44(CLUBCOIN_COIN_ID)
+                            .paymentUri("clubcoin")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("clubcoin", 8, "CLUB");
+
+            const api::Currency DECRED =
+                    CurrencyBuilder("decred")
+                            .bip44(DECRED_COIN_ID)
+                            .paymentUri("decred")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("decred", 8, "DCR")
+                            .unit("milli-decred", 5, "mDCR");
+
+            const api::Currency STAKENET =
+                    CurrencyBuilder("stakenet")
+                            .bip44(STAKENET_COIN_ID)
+                            .paymentUri("stakenet")
+                            .unit("satoshi", 0, "satoshi")
+                            .unit("stakenet", 8, "XSN");
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/BitcoinLikeExtendedPublicKey.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/BitcoinLikeExtendedPublicKey.cpp
@@ -1,0 +1,112 @@
+/*
+ *
+ * BitcoinLikeExtendedPublicKey
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 14/12/2016.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+
+#include <core/api/Configuration.hpp>
+#include <core/api/KeychainEngines.hpp>
+#include <core/bytes/BytesReader.hpp>
+#include <core/bytes/BytesWriter.hpp>
+#include <core/crypto/HASH160.hpp>
+#include <core/crypto/SECP256k1Point.hpp>
+#include <core/debug/Benchmarker.hpp>
+#include <core/math/Base58.hpp>
+#include <core/utils/DerivationPath.hpp>
+#include <core/utils/DjinniHelpers.hpp>
+
+#include <bitcoin/BitcoinLikeAddress.hpp>
+#include <bitcoin/BitcoinLikeExtendedPublicKey.hpp>
+
+namespace ledger {
+    namespace core {
+
+        BitcoinLikeExtendedPublicKey::BitcoinLikeExtendedPublicKey(const api::Currency &currency,
+                                                                   const DeterministicPublicKey& key,
+                                                                   const std::shared_ptr<DynamicObject> &configuration,
+                                                                   const DerivationPath& path) :
+            _currency(currency), _key(key), _configuration(configuration), _path(path)
+        {}
+
+        std::shared_ptr<api::BitcoinLikeAddress> BitcoinLikeExtendedPublicKey::derive(const std::string &path) {
+            DerivationPath p(path);
+            auto key = _derive(0, p.toVector(), _key);
+            auto keychainEngine = _configuration->getString(api::Configuration::KEYCHAIN_ENGINE).value_or(api::KeychainEngines::BIP32_P2PKH);
+            return std::make_shared<BitcoinLikeAddress>(_currency,
+                                                        key.getPublicKeyHash160(),
+                                                        keychainEngine,
+                                                        optional<std::string>((_path + p).toString()));
+        }
+
+        std::shared_ptr<BitcoinLikeExtendedPublicKey> BitcoinLikeExtendedPublicKey::derive(const DerivationPath &path) {
+            auto dpk = _derive(0, path.toVector(), _key);
+            return std::make_shared<BitcoinLikeExtendedPublicKey>(_currency, dpk, _configuration, _path + path);
+        }
+
+        std::string BitcoinLikeExtendedPublicKey::toBase58() {
+            return BitcoinExtendedPublicKey::toBase58();
+        }
+
+        std::shared_ptr<BitcoinLikeExtendedPublicKey>
+        BitcoinLikeExtendedPublicKey::fromRaw(const api::Currency &currency,
+                                              const optional<std::vector<uint8_t>> &parentPublicKey,
+                                              const std::vector<uint8_t> &publicKey,
+                                              const std::vector<uint8_t> &chainCode,
+                                              const std::string &path,
+                                              const std::shared_ptr<DynamicObject> &configuration) {
+            auto& params = networks::getBitcoinLikeNetworkParameters(currency.name);
+            DeterministicPublicKey k = BitcoinExtendedPublicKey::fromRaw(currency, params, parentPublicKey, publicKey, chainCode, path);
+            DerivationPath p(path);
+            return std::make_shared<BitcoinLikeExtendedPublicKey>(currency, k, configuration, p);
+        }
+
+        std::string BitcoinLikeExtendedPublicKey::getRootPath() {
+            return _path.toString();
+        }
+
+        std::shared_ptr<BitcoinLikeExtendedPublicKey>
+        BitcoinLikeExtendedPublicKey::fromBase58(const api::Currency &currency,
+                                                 const std::string &xpubBase58,
+                                                 const Option<std::string> &path,
+                                                 const std::shared_ptr<DynamicObject> &configuration) {
+            auto& params = networks::getBitcoinLikeNetworkParameters(currency.name);
+            DeterministicPublicKey k = BitcoinExtendedPublicKey::fromBase58(currency, params, xpubBase58, path);
+            return std::make_shared<ledger::core::BitcoinLikeExtendedPublicKey>(currency, k, configuration, DerivationPath(path.getValueOr("m")));
+        }
+
+        std::vector<uint8_t> BitcoinLikeExtendedPublicKey::derivePublicKey(const std::string &path) {
+            return BitcoinExtendedPublicKey::derivePublicKey(path);
+        }
+
+        std::vector<uint8_t> BitcoinLikeExtendedPublicKey::deriveHash160(const std::string &path) {
+            return BitcoinExtendedPublicKey::deriveHash160(path);
+        }
+
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/BitcoinLikeWallet.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/BitcoinLikeWallet.cpp
@@ -1,0 +1,239 @@
+/*
+ *
+ * BitcoinLikeWallet
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 19/12/2016.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+#include <algorithm>
+
+#include <core/api/ErrorCode.hpp>
+#include <core/wallet/AccountDatabaseHelper.hpp>
+#include <core/api/ConfigurationDefaults.hpp>
+#include <core/api/KeychainEngines.hpp>
+#include <core/async/Wait.hpp>
+
+#include <bitcoin/BitcoinLikeAccount.hpp>
+#include <bitcoin/BitcoinLikeWallet.hpp>
+#include <bitcoin/database/BitcoinLikeAccountDatabaseHelper.hpp>
+
+namespace ledger {
+    namespace core {
+
+        BitcoinLikeWallet::BitcoinLikeWallet(const std::string &name,
+                                             const std::shared_ptr<BitcoinLikeBlockchainExplorer>& explorer,
+                                             const std::shared_ptr<BitcoinLikeBlockchainObserver> &observer,
+                                             const std::shared_ptr<BitcoinLikeKeychainFactory> &keychainFactory,
+                                             const BitcoinLikeAccountSynchronizerFactory &synchronizer,
+                                             const std::shared_ptr<Services> &services, const api::Currency &network,
+                                             const std::shared_ptr<DynamicObject>& configuration,
+                                             const DerivationScheme& scheme
+        )
+        : AbstractWallet(name, network, services, configuration, scheme) {
+            _explorer = explorer;
+            _observer = observer;
+            _keychainFactory = keychainFactory;
+            _synchronizerFactory = synchronizer;
+        }
+
+        bool BitcoinLikeWallet::isSynchronizing() {
+            return false;
+        }
+
+        std::shared_ptr<api::EventBus> BitcoinLikeWallet::synchronize() {
+            return nullptr;
+        }
+
+        FuturePtr<ledger::core::api::Account>
+        BitcoinLikeWallet::newAccountWithInfo(const api::AccountCreationInfo &info) {
+            // TODO: Update data structure to be able to do P2SH with mixed HD and Solo keys.
+            // Right now we only handle Full HD P2SH wallet.
+            // For each owner
+                // Get the pair of keys
+                // Create extended key
+                // Serialize and store
+            auto self = getSelf();
+            return async<api::ExtendedKeyAccountCreationInfo>([self, info] () -> api::ExtendedKeyAccountCreationInfo {
+                if (info.owners.size() != info.derivations.size() || info.owners.size() != info.chainCodes.size() ||
+                    info.publicKeys.size() != info.owners.size())
+                    throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Account creation info are inconsistent (size of arrays differs)");
+                api::ExtendedKeyAccountCreationInfo result;
+                std::set<std::string> ownersSet(info.owners.begin(), info.owners.end());
+                auto ownersIterator = ownersSet.begin();
+                auto ownersEndIterator = ownersSet.end();
+                auto size = info.owners.size();
+                while (ownersIterator != ownersEndIterator) {
+                    int32_t firstOccurence = -1;
+                    int32_t secondOccurence = -1;
+
+                    for (auto i = 0; i < size; i++) {
+                        if (info.owners[i] != *ownersIterator) continue;
+                        if (info.publicKeys[i].size() != 33 && info.publicKeys[i].size() != 65)
+                            throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Account creation info are inconsistent (contains invalid public key(s))");
+                        if (firstOccurence == -1) {
+                            firstOccurence = i;
+                        } else {
+                            secondOccurence = i;
+                            break;
+                        }
+                    }
+                    if (firstOccurence == -1 || secondOccurence == -1)
+                        throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Account creation info are inconsistent (missing derivation(s))");
+                    DerivationPath firstOccurencePath(info.derivations[firstOccurence]);
+                    DerivationPath secondOccurencePath(info.derivations[secondOccurence]);
+                    if (secondOccurencePath.getParent() != firstOccurencePath) {
+                        std::swap(firstOccurencePath, secondOccurencePath);
+                        std::swap(firstOccurence, secondOccurence);
+                    }
+                    if (secondOccurencePath.getParent() != firstOccurencePath)
+                        throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Account creation info are inconsistent (wrong paths)");
+                    auto xpub = BitcoinLikeExtendedPublicKey::fromRaw(self->getCurrency(),
+                                                                      Option<std::vector<uint8_t>>(info.publicKeys[firstOccurence]).toOptional(),
+                                                                      info.publicKeys[secondOccurence],
+                                                                      info.chainCodes[secondOccurence],
+                                                                      info.derivations[secondOccurence],
+                                                                      self->getConfig());
+                    result.owners.push_back(*ownersIterator);
+                    result.derivations.push_back(info.derivations[secondOccurence]);
+                    result.extendedKeys.push_back(xpub->toBase58());
+                    ownersIterator++;
+                }
+                result.index = info.index;
+                return result;
+            }).flatMap<std::shared_ptr<ledger::core::api::Account>>(getContext(), [self] (const api::ExtendedKeyAccountCreationInfo& info) -> Future<std::shared_ptr<ledger::core::api::Account>> {
+                return self->newAccountWithExtendedKeyInfo(info);
+            });
+        }
+
+        FuturePtr<ledger::core::api::Account>
+        BitcoinLikeWallet::newAccountWithExtendedKeyInfo(const api::ExtendedKeyAccountCreationInfo &info) {
+            auto self = getSelf();
+            auto scheme = getDerivationScheme();
+            scheme.setCoinType(getCurrency().bip44CoinType).setAccountIndex(info.index);
+            auto xpubPath = scheme.getSchemeTo(DerivationSchemeLevel::ACCOUNT_INDEX).getPath();
+            auto index = info.index;
+            return async<std::shared_ptr<api::Account> >([=] () -> std::shared_ptr<api::Account> {
+                auto keychain = self->_keychainFactory->build(
+                        index,
+                        xpubPath,
+                        getConfig(),
+                        info,
+                        getAccountInternalPreferences(index),
+                        getCurrency()
+                );
+                soci::session sql(self->getDatabase()->getPool());
+                soci::transaction tr(sql);
+                auto accountUid = AccountDatabaseHelper::createAccountUid(self->getWalletUid(), index);
+                if (AccountDatabaseHelper::accountExists(sql, self->getWalletUid(), index))
+                    throw make_exception(api::ErrorCode::ACCOUNT_ALREADY_EXISTS, "Account {}, for wallet '{}', already exists", index, self->getWalletUid());
+                AccountDatabaseHelper::createAccount(sql, self->getWalletUid(), index);
+                BitcoinLikeAccountDatabaseHelper::createAccount(sql, self->getWalletUid(), index, keychain->getRestoreKey());
+                tr.commit();
+                auto account = std::static_pointer_cast<api::Account>(std::make_shared<BitcoinLikeAccount>(
+                        self->shared_from_this(),
+                        index,
+                        self->_explorer,
+                        self->_observer,
+                        self->_synchronizerFactory(),
+                        keychain
+                ));
+                self->addAccountInstanceToInstanceCache(std::dynamic_pointer_cast<AbstractAccount>(account));
+                return account;
+            });
+        }
+
+        Future<api::ExtendedKeyAccountCreationInfo>
+        BitcoinLikeWallet::getExtendedKeyAccountCreationInfo(int32_t accountIndex) {
+            auto self = std::dynamic_pointer_cast<BitcoinLikeWallet>(shared_from_this());
+            return async<api::ExtendedKeyAccountCreationInfo>([self, accountIndex] () -> api::ExtendedKeyAccountCreationInfo {
+                api::ExtendedKeyAccountCreationInfo info;
+                info.index = accountIndex;
+                auto scheme = self->getDerivationScheme();
+                scheme.setCoinType(self->getCurrency().bip44CoinType).setAccountIndex(accountIndex);;
+                auto keychainEngine = self->getConfiguration()->getString(api::Configuration::KEYCHAIN_ENGINE).value_or(api::ConfigurationDefaults::DEFAULT_KEYCHAIN);
+                if (keychainEngine == api::KeychainEngines::BIP32_P2PKH ||
+                    keychainEngine == api::KeychainEngines::BIP49_P2SH ||
+                    keychainEngine == api::KeychainEngines::BIP173_P2WPKH ||
+                    keychainEngine == api::KeychainEngines::BIP173_P2WSH) {
+                    auto xpubPath = scheme.getSchemeTo(DerivationSchemeLevel::ACCOUNT_INDEX).getPath();
+                    info.derivations.push_back(xpubPath.toString());
+                    info.owners.push_back(std::string("main"));
+                } else {
+                    throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "No implementation found found for keychain {}", keychainEngine);
+                }
+
+                return info;
+            });
+        }
+
+        Future<api::AccountCreationInfo> BitcoinLikeWallet::getAccountCreationInfo(int32_t accountIndex) {
+            auto self = std::dynamic_pointer_cast<BitcoinLikeWallet>(shared_from_this());
+            return getExtendedKeyAccountCreationInfo(accountIndex).map<api::AccountCreationInfo>(getContext(), [self, accountIndex] (const api::ExtendedKeyAccountCreationInfo info) -> api::AccountCreationInfo {
+                api::AccountCreationInfo result;
+                result.index = accountIndex;
+                auto length = info.derivations.size();
+                for (auto i = 0; i < length; i++) {
+                    DerivationPath path(info.derivations[i]);
+                    auto owner = info.owners[i];
+                    result.derivations.push_back(path.getParent().toString());
+                    result.derivations.push_back(path.toString());
+                    result.owners.push_back(owner);
+                    result.owners.push_back(owner);
+                }
+                return result;
+            });
+        }
+
+        std::shared_ptr<BitcoinLikeWallet> BitcoinLikeWallet::getSelf() {
+            return std::dynamic_pointer_cast<BitcoinLikeWallet>(shared_from_this());
+        }
+
+        std::shared_ptr<AbstractAccount>
+        BitcoinLikeWallet::createAccountInstance(soci::session &sql, const std::string &accountUid) {
+            BitcoinLikeAccountDatabaseEntry entry;
+            BitcoinLikeAccountDatabaseHelper::queryAccount(sql, accountUid, entry);
+            auto scheme = getDerivationScheme();
+            scheme.setCoinType(getCurrency().bip44CoinType).setAccountIndex(entry.index);
+            auto xpubPath = scheme.getSchemeTo(DerivationSchemeLevel::ACCOUNT_INDEX).getPath();
+            auto keychain = _keychainFactory->restore(entry.index, xpubPath, getConfig(), entry.xpub,
+            getAccountInternalPreferences(entry.index), getCurrency());
+            return std::make_shared<BitcoinLikeAccount>(shared_from_this(),
+                                                        entry.index,
+                                                        _explorer,
+                                                        _observer,
+                                                        _synchronizerFactory(),
+                                                        keychain);
+        }
+
+        std::shared_ptr<BitcoinLikeBlockchainExplorer> BitcoinLikeWallet::getBlockchainExplorer() {
+            return _explorer;
+        }
+
+        bool BitcoinLikeWallet::hasMultipleAddresses() const {
+            return true;
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/BitcoinNetworks.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/BitcoinNetworks.cpp
@@ -1,0 +1,461 @@
+/*
+ *
+ * networks
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 27/01/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/utils/Exception.hpp>
+
+#include <bitcoin/BitcoinNetworks.hpp>
+
+namespace ledger {
+    namespace core {
+
+        namespace networks {
+
+            const BIP115Parameters BIP115_PARAMETERS = {
+                    "9ec9845acb02fab24e1c0368b3b517c1a4488fba97f0e3459ac053ea01000000",
+                    {0xC0,0x1F,0x02}
+            };
+
+            //Zcash overwinter
+            const ZIPParameters ZIP143_PARAMETERS = {
+                    3,
+                    {0x80},
+                    {0x03, 0xC4, 0x82, 0x70},
+                    347500
+            };
+            //Zcash Sapling (starting from block 419200)
+            const ZIPParameters ZIP_SAPLING_PARAMETERS = {
+                    4,
+                    {0x80},
+                    {0x89, 0x2F, 0x20, 0x85},
+                    419200
+            };
+
+            const api::BitcoinLikeNetworkParameters getBitcoinLikeNetworkParameters(const std::string &networkName, int version) {
+                if (networkName == "bitcoin") {
+                    static const api::BitcoinLikeNetworkParameters BITCOIN(
+                            "btc",
+                            {0x00},
+                            {0x05},
+                            {0x04, 0x88, 0xB2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            546,
+                            "Bitcoin signed message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return BITCOIN;
+                } else if (networkName == "bitcoin_testnet") {
+                    static const api::BitcoinLikeNetworkParameters BITCOIN_TESTNET(
+                            "btc_testnet",
+                            {0x6F},
+                            {0xC4},
+                            {0x04, 0x35, 0x87, 0xCF},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            546,
+                            "Bitcoin signed message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return BITCOIN_TESTNET;
+                } else if (networkName == "bitcoin_cash") {
+                    static const api::BitcoinLikeNetworkParameters BITCOIN_CASH(
+                            "abc",
+                            {0x00},
+                            {0x05},
+                            {0x04, 0x88, 0xB2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            5430,
+                            "Bitcoin signed message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL | sigHashType::SIGHASH_FORKID},
+                            {}
+                    );
+                    return BITCOIN_CASH;
+                } else if (networkName == "bitcoin_gold") {
+                    static const api::BitcoinLikeNetworkParameters BITCOIN_GOLD(
+                            "btg",
+                            {0x26},
+                            {0x17},
+                            {0x04, 0x88, 0xB2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            5430,
+                            "Bitcoin gold signed message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL | sigHashType::SIGHASH_FORKID},
+                            {}
+                    );
+                    return BITCOIN_GOLD;
+                } else if (networkName == "zcash") {
+                    static const api::BitcoinLikeNetworkParameters ZCASH(
+                            "zec",
+                            {0x1C, 0xB8},
+                            {0x1C, 0xBD},
+                            {0x04, 0x88, 0xB2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "Zcash Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {"ZIP"}
+                    );
+                    return ZCASH;
+                } else if (networkName == "zencash") {
+                    static const api::BitcoinLikeNetworkParameters ZENCASH(
+                            "zen",
+                            {0x20, 0x89},
+                            {0x20, 0x96},
+                            {0x04, 0x88, 0xB2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "Zencash Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {"BIP115"}
+                    );
+                    return ZENCASH;
+                } else if (networkName == "litecoin") {
+                    static const api::BitcoinLikeNetworkParameters LITECOIN(
+                            "ltc",
+                            {0x30},
+                            {0x32},
+                            {0x01, 0x9D, 0xA4, 0x62},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "Litecoin Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return LITECOIN;
+                } else if (networkName == "peercoin") {
+                    static const api::BitcoinLikeNetworkParameters PEERCOIN(
+                            "ppc",
+                            {0x37},
+                            {0x75},
+                            {0xE6, 0xE8, 0xE9, 0xE5},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "PPCoin Signed Message:\n",
+                            true,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return PEERCOIN;
+                } else if (networkName == "digibyte") {
+                    static const api::BitcoinLikeNetworkParameters DIGIBYTE(
+                            "dgb",
+                            {0x1E},
+                            {0x3F},
+                            {0x04, 0x88, 0xB2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "DigiByte Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return DIGIBYTE;
+                } else if (networkName == "hcash") {
+                    static const api::BitcoinLikeNetworkParameters HCASH(
+                            "hsr",
+                            {0x28},
+                            {0x78},
+                            {0x04, 0x88, 0xC2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "HShare Signed Message:\n",
+                            true,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return HCASH;
+                } else if (networkName == "qtum") {
+                    static const api::BitcoinLikeNetworkParameters QTUM(
+                            "qtum",
+                            {0x3A},
+                            {0x32},
+                            {0x04, 0x88, 0xB2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "Qtum Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return QTUM;
+                } else if (networkName == "stealthcoin") {
+                    api::BitcoinLikeNetworkParameters STEALTHCOIN(
+                            "xst",
+                            {0x3E},
+                            {0x55},
+                            {0x8F, 0x62, 0x4B, 0x66},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "StealthCoin Signed Message:\n",
+                            true,
+                            15,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    migrateParameters(STEALTHCOIN, 1, version);
+                    return STEALTHCOIN;
+                } else if (networkName == "vertcoin") {
+                    static const api::BitcoinLikeNetworkParameters VERTCOIN(
+                            "vtc",
+                            {0x47},
+                            {0x05},
+                            {0x04, 0x88, 0xB2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "VertCoin Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return VERTCOIN;
+                } else if (networkName == "viacoin") {
+                    static const api::BitcoinLikeNetworkParameters VIACOIN(
+                            "via",
+                            {0x47},
+                            {0x21},
+                            {0x04, 0x88, 0xB2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "ViaCoin Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return VIACOIN;
+                } else if (networkName == "dash") {
+                    static const api::BitcoinLikeNetworkParameters DASH(
+                            "dash",
+                            {0x4C},
+                            {0x01},
+                            {0x02, 0xFE, 0x52, 0xF8},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "DarkCoin Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return DASH;
+                } else if (networkName == "dogecoin") {
+                    static const api::BitcoinLikeNetworkParameters DOGECOIN(
+                            "doge",
+                            {0x1E},
+                            {0x16},
+                            {0x02, 0xFA, 0xCA, 0xFD},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "DogeCoin Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return DOGECOIN;
+                } else if (networkName == "stratis") {
+                    static const api::BitcoinLikeNetworkParameters STRATIS(
+                            "strat",
+                            {0x3F},
+                            {0x7D},
+                            {0x04, 0x88, 0xC2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "Stratis Signed Message:\n",
+                            true,
+                            15,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return STRATIS;
+                } else if (networkName == "komodo") {
+                    static const api::BitcoinLikeNetworkParameters KOMODO(
+                            "kmd",
+                            {0x3C},
+                            {0x55},
+                            {0xF9, 0xEE, 0xE4, 0x8D},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "Komodo Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {"ZIP"}
+                    );
+                    return KOMODO;
+                } else if (networkName == "poswallet") {
+                    static const api::BitcoinLikeNetworkParameters POSWALLET(
+                            "posw",
+                            {0x37},
+                            {0x55},
+                            {0x04, 0x88, 0xB2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "PosWallet Signed Message:\n",
+                            true,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return POSWALLET;
+                } else if (networkName == "pivx") {
+                    static const api::BitcoinLikeNetworkParameters PIVX(
+                            "pivx",
+                            {0x1E},
+                            {0x0D},
+                            {0x02, 0x2D, 0x25, 0x33},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "DarkNet Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return PIVX;
+                } else if (networkName == "clubcoin") {
+                    static const api::BitcoinLikeNetworkParameters CLUBCOIN(
+                            "club",
+                            {0x1C},
+                            {0x55},
+                            {0x04, 0x88, 0xB2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "Clubcoin Signed Message:\n",
+                            true,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return CLUBCOIN;
+                } else if (networkName == "decred") {
+                    //02fda926
+                    static const api::BitcoinLikeNetworkParameters DECRED(
+                            "dcr",
+                            {0x07, 0x3F},
+                            {0x07, 0x1A},
+                            {0x02, 0xFD, 0xA9, 0x26},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "Decred Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return DECRED;
+                } else if (networkName == "stakenet") {
+                    static const api::BitcoinLikeNetworkParameters STAKENET(
+                            "xsn",
+                            {0x4C},
+                            {0x10},
+                            {0x04, 0x88, 0xB2, 0x1E},
+                            api::BitcoinLikeFeePolicy::PER_BYTE,
+                            10000,
+                            "Stakenet Signed Message:\n",
+                            false,
+                            0,
+                            {sigHashType::SIGHASH_ALL},
+                            {}
+                    );
+                    return STAKENET;
+                }
+
+                throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "No network parameters set for {}", networkName);
+            }
+
+            template <> void migrateParameters<1>(api::BitcoinLikeNetworkParameters &params) {}
+
+            template <> void migrateParameters<2>(api::BitcoinLikeNetworkParameters &params) {
+                if (params.Identifier == "xst") {
+                    params.UsesTimestampedTransaction = false;
+                }
+            }
+
+            void migrateParameters(api::BitcoinLikeNetworkParameters &params, int migration) {
+                switch (migration) {
+                    case 1:
+                        migrateParameters<1>(params);
+                    case 2:
+                        migrateParameters<2>(params);
+                    default:
+                        return;
+                }
+            };
+
+            const std::vector<api::BitcoinLikeNetworkParameters> ALL_BITCOIN
+            ({
+                getBitcoinLikeNetworkParameters("bitcoin"),
+                getBitcoinLikeNetworkParameters("bitcoin_testnet"),
+                getBitcoinLikeNetworkParameters("bitcoin_cash"),
+                getBitcoinLikeNetworkParameters("bitcoin_gold"),
+                getBitcoinLikeNetworkParameters("zcash"),
+                getBitcoinLikeNetworkParameters("zencash"),
+                getBitcoinLikeNetworkParameters("litecoin"),
+                getBitcoinLikeNetworkParameters("peercoin"),
+                getBitcoinLikeNetworkParameters("digibyte"),
+                getBitcoinLikeNetworkParameters("hcash"),
+                getBitcoinLikeNetworkParameters("qtum"),
+                getBitcoinLikeNetworkParameters("stealthcoin"),
+                getBitcoinLikeNetworkParameters("vertcoin"),
+                getBitcoinLikeNetworkParameters("viacoin"),
+                getBitcoinLikeNetworkParameters("dash"),
+                getBitcoinLikeNetworkParameters("dogecoin"),
+                getBitcoinLikeNetworkParameters("stratis"),
+                getBitcoinLikeNetworkParameters("komodo"),
+                getBitcoinLikeNetworkParameters("poswallet"),
+                getBitcoinLikeNetworkParameters("pivx"),
+                getBitcoinLikeNetworkParameters("clubcoin"),
+                getBitcoinLikeNetworkParameters("decred"),
+                getBitcoinLikeNetworkParameters("stakenet")
+            });
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/bech32/BCHBech32.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/bech32/BCHBech32.cpp
@@ -1,0 +1,96 @@
+/*
+ *
+ * BCHBech32
+ *
+ * Created by El Khalil Bellakrid on 18/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/utils/Exception.hpp>
+
+#include <bitcoin/bech32/BCHBech32.hpp>
+
+namespace ledger {
+    namespace core {
+        uint64_t BCHBech32::polymod(const std::vector<uint8_t>& values) {
+            uint64_t chk = 1;
+            for (size_t i = 0; i < values.size(); ++i) {
+                uint64_t top = chk >> 35;
+                chk = (chk & 0x07ffffffff) << 5 ^ values[i];
+                size_t index = 0;
+                for (auto& gen : _bech32Params.generator) {
+                    chk ^= (-((top >> index) & 1) & gen);
+                    index++;
+                }
+            }
+            return chk;
+        }
+
+        std::vector<uint8_t> BCHBech32::expandHrp(const std::string& hrp) {
+            std::vector<uint8_t> ret;
+            ret.resize(hrp.size() + 1);
+            for (size_t i = 0; i < hrp.size(); ++i) {
+                unsigned char c = hrp[i];
+                ret[i] = c & 0x1f;
+            }
+            ret[hrp.size()] = 0;
+            return ret;
+        }
+
+        std::string BCHBech32::encode(const std::vector<uint8_t>& hash,
+                                      const std::vector<uint8_t>& version) {
+            std::vector<uint8_t> data(version);
+            data.insert(data.end(), hash.begin(), hash.end());
+            int fromBits = 8, toBits = 5;
+            bool pad = true;
+            std::vector<uint8_t> converted;
+            Bech32::convertBits(data, fromBits, toBits, pad, converted);
+            return encodeBech32(converted);
+        }
+
+        std::pair<std::vector<uint8_t>, std::vector<uint8_t>>
+        BCHBech32::decode(const std::string& str) {
+            auto decoded = decodeBech32(str);
+            if (decoded.first != _bech32Params.hrp || decoded.second.size() < 1) {
+                throw Exception(api::ErrorCode::INVALID_BECH32_FORMAT, "Invalid address : Invalid bech 32 format");
+            }
+            std::vector<uint8_t> converted;
+            int fromBits = 5, toBits = 8;
+            bool pad = false;
+            auto result = Bech32::convertBits(decoded.second,
+                                              fromBits,
+                                              toBits,
+                                              pad,
+                                              converted);
+            if (!result || converted.size() < 2 ||
+                converted.size() > 42 || decoded.second[0] > 16 ||
+                (decoded.second[0] == 0 && converted.size() != 21 && converted.size() != 33)) {
+                throw Exception(api::ErrorCode::INVALID_BECH32_FORMAT, "Invalid address : Invalid bech 32 format");
+            }
+            std::vector<uint8_t> version{converted[0]};
+            return std::make_pair(version, std::vector<uint8_t>(converted.begin() + 1, converted.end()));
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/bech32/BTCBech32.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/bech32/BTCBech32.cpp
@@ -1,0 +1,97 @@
+/*
+ *
+ * BTCBech32
+ *
+ * Created by El Khalil Bellakrid on 18/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/utils/Exception.hpp>
+
+#include <bitcoin/bech32/BTCBech32.hpp>
+
+namespace ledger {
+    namespace core {
+        uint64_t BTCBech32::polymod(const std::vector<uint8_t>& values) {
+            uint32_t chk = 1;
+            for (size_t i = 0; i < values.size(); ++i) {
+                uint8_t top = chk >> 25;
+                chk = (chk & 0x1ffffff) << 5 ^ values[i];
+                auto index = 0;
+                for (auto& gen : _bech32Params.generator) {
+                    chk ^= (-((top >> index) & 1) & gen);
+                    index++;
+                }
+            }
+            return chk;
+        }
+
+        std::vector<uint8_t> BTCBech32::expandHrp(const std::string& hrp) {
+            std::vector<uint8_t> ret;
+            ret.resize(hrp.size() * 2 + 1);
+            for (size_t i = 0; i < hrp.size(); ++i) {
+                unsigned char c = hrp[i];
+                ret[i] = c >> 5;
+                ret[i + hrp.size() + 1] = c & 0x1f;
+            }
+            ret[hrp.size()] = 0;
+            return ret;
+        }
+
+        std::string BTCBech32::encode(const std::vector<uint8_t>& hash,
+                                      const std::vector<uint8_t>& version) {
+            std::vector<uint8_t> data(hash);
+            int fromBits = 8, toBits = 5;
+            bool pad = true;
+            std::vector<uint8_t> converted;
+            converted.insert(converted.end(), version.begin(), version.end());
+            Bech32::convertBits(data, fromBits, toBits, pad, converted);
+            return encodeBech32(converted);
+        }
+
+        std::pair<std::vector<uint8_t>, std::vector<uint8_t>>
+        BTCBech32::decode(const std::string& str) {
+            auto decoded = decodeBech32(str);
+            if (decoded.first != _bech32Params.hrp || decoded.second.size() < 1) {
+                throw Exception(api::ErrorCode::INVALID_BECH32_FORMAT, "Invalid address : Invalid bech 32 format");
+            }
+            std::vector<uint8_t> converted;
+            int fromBits = 5, toBits = 8;
+            bool pad = false;
+            auto result = Bech32::convertBits(std::vector<uint8_t>(decoded.second.begin() + 1, decoded.second.end()),
+                                              fromBits,
+                                              toBits,
+                                              pad,
+                                              converted);
+            if (!result || converted.size() < 2 ||
+                converted.size() > 40 || decoded.second[0] > 16 ||
+                (decoded.second[0] == 0 && converted.size() != 20 && converted.size() != 32)) {
+                throw Exception(api::ErrorCode::INVALID_BECH32_FORMAT, "Invalid address : Invalid bech 32 format");
+            }
+            std::vector<uint8_t> version{decoded.second[0]};
+            return std::make_pair(version, converted);
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/bech32/Bech32.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/bech32/Bech32.cpp
@@ -1,0 +1,155 @@
+/*
+ *
+ * Bech32
+ *
+ * Created by El Khalil Bellakrid on 13/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/collections/Vector.hpp>
+
+#include <bitcoin/bech32/Bech32.hpp>
+
+namespace ledger {
+    namespace core {
+
+        // The Bech32 character set for encoding.
+        const char* charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+        // The Bech32 character set for decoding.
+        const int8_t charsetRev[128] = {
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                15, -1, 10, 17, 21, 20, 26, 30,  7,  5, -1, -1, -1, -1, -1, -1,
+                -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+                1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1,
+                -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+                1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1
+        };
+
+        // Verify a checksum.
+        bool Bech32::verifyChecksum(const std::vector<uint8_t>& values) {
+            return polymod(vector::concat(expandHrp(_bech32Params.hrp), values)) == 1;
+        }
+
+        // Create a checksum.
+        std::vector<uint8_t> Bech32::createChecksum(const std::vector<uint8_t>& values) {
+            std::vector<uint8_t> enc = vector::concat(expandHrp(_bech32Params.hrp), values);
+            enc.resize(enc.size() + _bech32Params.checksumSize);
+            uint64_t mod = polymod(enc) ^ 1;
+            std::vector<uint8_t> ret;
+            ret.resize(_bech32Params.checksumSize);
+            // Can't use ssize_t because it's posix specific (problem with MSVC build) so let's
+            // just use int ...
+            for (int i = _bech32Params.checksumSize - 1; i >= 0; --i) {
+                ret[i] = mod & 31;
+                mod >>= 5;
+            }
+            return ret;
+        }
+        
+        std::string Bech32::encodeBech32(const std::vector<uint8_t>& values) {
+            // Values here should be concatenation of version + hash
+            std::vector<uint8_t> checksum = createChecksum(values);
+            std::vector<uint8_t> combined = vector::concat(values, checksum);
+            std::string ret = _bech32Params.hrp + _bech32Params.separator;
+            ret.reserve(ret.size() + combined.size());
+            for (size_t i = 0; i < combined.size(); ++i) {
+                // There is not check on size here because this method is called
+                // after calling Bech32::convertBits which basically guarantees
+                // combined[i] being in range
+                ret += charset[combined[i]];
+            }
+            return ret;
+        }
+
+        std::pair<std::string, std::vector<uint8_t>>
+        Bech32::decodeBech32(const std::string& str) {
+            bool lower = false, upper = false;
+            bool ok = true;
+            for (size_t i = 0; ok && i < str.size(); ++i) {
+                unsigned char c = str[i];
+                if (c < 33 || c > 126) ok = false;
+                if (c >= 'a' && c <= 'z') lower = true;
+                if (c >= 'A' && c <= 'Z') upper = true;
+            }
+            if (lower && upper) ok = false;
+            size_t pos = str.rfind(_bech32Params.separator);
+            if (ok && str.size() <= 90 && pos != str.npos && pos >= 1 && pos + _bech32Params.checksumSize + 1 <= str.size()) {
+                std::vector<uint8_t> values;
+                values.resize(str.size() - 1 - pos);
+                for (size_t i = 0; i < str.size() - 1 - pos; ++i) {
+                    unsigned char c = str[i + pos + 1];
+                    if (charsetRev[c] == -1) ok = false;
+                    values[i] = charsetRev[c];
+                }
+                if (ok) {
+                    std::string hrp;
+                    for (size_t i = 0; i < pos; ++i) {
+                        hrp += toLowerCase(str[i]);
+                    }
+                    if (verifyChecksum(values)) {
+                        return std::make_pair(hrp, std::vector<uint8_t>(values.begin(), values.end() - _bech32Params.checksumSize));
+                    }
+                }
+            }
+            return std::make_pair(std::string(), std::vector<uint8_t>());
+        }
+
+        // Convert to lower case.
+        unsigned char Bech32::toLowerCase(unsigned char c) {
+            return (c >= 'A' && c <= 'Z') ? (c - 'A') + 'a' : c;
+        }
+
+        // Convert from one power-of-2 number base to another. */
+        bool Bech32::convertBits(const std::vector<uint8_t>& in,
+                                 int fromBits,
+                                 int toBits,
+                                 bool pad,
+                                 std::vector<uint8_t>& out) {
+            int acc = 0;
+            int bits = 0;
+            const int maxv = (1 << toBits) - 1;
+            const int max_acc = (1 << (fromBits + toBits - 1)) - 1;
+            for (size_t i = 0; i < in.size(); ++i) {
+                int value = in[i];
+                acc = ((acc << fromBits) | value) & max_acc;
+                bits += fromBits;
+                while (bits >= toBits) {
+                    bits -= toBits;
+                    out.push_back((acc >> bits) & maxv);
+                }
+            }
+            if (pad) {
+                if (bits) out.push_back((acc << (toBits - bits)) & maxv);
+            } else if (bits >= fromBits || ((acc << (toBits - bits)) & maxv)) {
+                return false;
+            }
+            return true;
+        }
+
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/bech32/Bech32Factory.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/bech32/Bech32Factory.cpp
@@ -1,0 +1,48 @@
+/*
+ *
+ * Bech32Factory
+ *
+ * Created by El Khalil Bellakrid on 18/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/utils/Exception.hpp>
+
+#include <bitcoin/bech32/Bech32Factory.hpp>
+#include <bitcoin/bech32/BTCBech32.hpp>
+#include <bitcoin/bech32/BCHBech32.hpp>
+
+namespace ledger {
+    namespace core {
+        Option<std::shared_ptr<Bech32>> Bech32Factory::newBech32Instance(const std::string &networkIdentifier) {
+            if (networkIdentifier == "btc" || networkIdentifier == "btc_testnet") {
+                return Option<std::shared_ptr<Bech32>>(std::make_shared<BTCBech32>(networkIdentifier));
+            } else if (networkIdentifier == "abc") {
+                return Option<std::shared_ptr<Bech32>>(std::make_shared<BCHBech32>());
+            }
+            return Option<std::shared_ptr<Bech32>>();
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/bech32/Bech32Parameters.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/bech32/Bech32Parameters.cpp
@@ -1,0 +1,119 @@
+/*
+ *
+ * Bech32Parameters
+ *
+ * Created by El Khalil Bellakrid on 14/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/api/ErrorCode.hpp>
+#include <core/collections/Strings.hpp>
+#include <core/math/BigInt.hpp>
+#include <core/utils/Exception.hpp>
+#include <core/utils/Hex.hpp>
+
+#include <bitcoin/bech32/Bech32Parameters.hpp>
+
+using namespace soci;
+namespace ledger {
+    namespace core {
+        namespace Bech32Parameters {
+            const Bech32Struct getBech32Params(const std::string &networkIdentifier) {
+                if (networkIdentifier == "btc") {
+                    static const Bech32Struct BITCOIN = {
+                            "bitcoin",
+                            "bc",
+                            "1",
+                            6,
+                            {0x3b6a57b2ULL, 0x26508e6dULL, 0x1ea119faULL, 0x3d4233ddULL, 0x2a1462b3ULL},
+                            {0x00},
+                            {0x00}
+                    };
+                    return BITCOIN;
+                } else if (networkIdentifier == "btc_testnet") {
+                    static const Bech32Struct BITCOIN_TESTNET = {
+                            "bitcoin_testnet",
+                            "tb",
+                            "1",
+                            6,
+                            {0x3b6a57b2ULL, 0x26508e6dULL, 0x1ea119faULL, 0x3d4233ddULL, 0x2a1462b3ULL},
+                            {0x00},
+                            {0x00}
+                    };
+                    return BITCOIN_TESTNET;
+                } else if (networkIdentifier == "abc") {
+                    static const Bech32Struct BITCOIN_CASH = {
+                            "bitcoin_cash",
+                            "bitcoincash",
+                            ":",
+                            8,
+                            {0x98f2bc8e61ULL, 0x79b76d99e2ULL, 0xf33e5fb3c4ULL, 0xae2eabe2a8ULL, 0x1e4f43e470ULL},
+                            {0x00},
+                            {0x08}
+                    };
+                    return BITCOIN_CASH;
+                }
+                throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "No Bech32 parameters set for {}", networkIdentifier);
+            }
+
+            const std::vector<Bech32Struct> ALL(
+                    {
+                            getBech32Params("btc"),
+                            getBech32Params("btc_testnet"),
+                            getBech32Params("abc")
+                    }
+            );
+
+            bool insertParameters(soci::session& sql, const Bech32Struct &params) {
+                auto count = 0;
+                sql << "SELECT COUNT(*) FROM bech32_parameters WHERE name = :name",
+                        soci::use(params.name),
+                        soci::into(count);
+                if (count == 0) {
+                    std::stringstream generator;
+                    std::vector<std::string> strGenerator;
+                    std::string separator(",");
+                    for (auto& g : params.generator) {
+                        BigInt bigIntG(g);
+                        strGenerator.push_back(bigIntG.toString());
+                    }
+                    strings::join(strGenerator, generator, separator);
+                    auto P2WPKHVersion = hex::toString(params.P2WPKHVersion);
+                    auto P2WSHVersion = hex::toString(params.P2WSHVersion);
+                    auto generatorStr = generator.str();
+                    sql << "INSERT INTO bech32_parameters VALUES(:name, :hrp, :separator, :generator, :p2wpkh_version, :p2wsh_version)",
+                            use(params.name),
+                            use(params.hrp),
+                            use(params.separator),
+                            use(generatorStr),
+                            use(P2WPKHVersion),
+                            use(P2WSHVersion);
+                    return true;
+                }
+                return false;
+            }
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/block/BitcoinLikeBlock.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/block/BitcoinLikeBlock.cpp
@@ -1,0 +1,48 @@
+/*
+ *
+ * BitcoinLikeBlock
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 12/07/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <bitcoin/block/BitcoinLikeBlock.hpp>
+
+std::string ledger::core::BitcoinLikeBlock::getHash() {
+    return _block.blockHash;
+}
+
+int64_t ledger::core::BitcoinLikeBlock::getHeight() {
+    return _block.height;
+}
+
+std::chrono::system_clock::time_point ledger::core::BitcoinLikeBlock::getTime() {
+    return _block.time;
+}
+
+ledger::core::BitcoinLikeBlock::BitcoinLikeBlock(const api::Block &block) {
+    _block = block;
+}

--- a/ledger-core-bitcoin/src/bitcoin/database/BitcoinLikeAccountDatabase.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/database/BitcoinLikeAccountDatabase.cpp
@@ -1,0 +1,49 @@
+/*
+ *
+ * BitcoinLikeAccountDatabase
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 29/05/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+#include <core/database/SociOption.hpp>
+#include <core/database/SociDate.hpp>
+#include <core/utils/DateUtils.hpp>
+#include <core/wallet/AccountDatabaseHelper.hpp>
+
+#include <bitcoin/database/BitcoinLikeAccountDatabase.hpp>
+
+using namespace soci;
+
+namespace ledger {
+    namespace core {
+
+        BitcoinLikeAccountDatabase::BitcoinLikeAccountDatabase(const std::string &walletUid, int32_t index) {
+            _accountUid = AccountDatabaseHelper::createAccountUid(walletUid, index);
+        }
+
+
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/database/BitcoinLikeAccountDatabaseHelper.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/database/BitcoinLikeAccountDatabaseHelper.cpp
@@ -1,0 +1,58 @@
+/*
+ *
+ * BitcoinLikeAccountDatabaseHelper
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 15/06/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+#include <core/wallet/AccountDatabaseHelper.hpp>
+
+#include <bitcoin/database/BitcoinLikeAccountDatabaseHelper.hpp>
+
+using namespace soci;
+
+namespace ledger {
+    namespace core {
+        void
+        BitcoinLikeAccountDatabaseHelper::createAccount(soci::session &sql, const std::string walletUid, int32_t index,
+                                                        const std::string &xpub) {
+            auto uid = AccountDatabaseHelper::createAccountUid(walletUid, index);
+            sql << "INSERT INTO bitcoin_accounts VALUES(:uid, :wallet, :idx, :xpub)", use(uid), use(walletUid),
+                    use(index), use(xpub);
+        }
+
+        bool BitcoinLikeAccountDatabaseHelper::queryAccount(soci::session &sql, const std::string &accountUid,
+                                                            BitcoinLikeAccountDatabaseEntry &entry) {
+            rowset<row> rows = (sql.prepare << "SELECT idx, xpub FROM bitcoin_accounts WHERE uid = :uid", use(accountUid));
+            for (auto& row : rows) {
+                entry.index = row.get<int32_t>(0);
+                entry.xpub = row.get<std::string>(1);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/database/BitcoinLikeBlockDatabaseHelper.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/database/BitcoinLikeBlockDatabaseHelper.cpp
@@ -1,0 +1,48 @@
+/*
+ *
+ * BitcoinLikeBlockDatabaseHelper.cpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 04/10/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <bitcoin/database/BitcoinLikeBlockDatabaseHelper.hpp>
+
+namespace ledger {
+    namespace core {
+
+        bool BitcoinLikeBlockDatabaseHelper::blockExists(soci::session &sql,
+                                                         const BitcoinLikeBlockchainExplorer::Block &block) {
+
+            return false;
+        }
+
+        bool BitcoinLikeBlockDatabaseHelper::putBlock(soci::session &sql,
+                                                      const BitcoinLikeBlockchainExplorer::Block &block) {
+            return false;
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.cpp
@@ -1,0 +1,254 @@
+/*
+ *
+ * BitcoinLikeTransactionDatabaseHelper
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 02/06/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <iostream>
+
+#include <core/crypto/SHA256.hpp>
+#include <core/database/SociOption.hpp>
+#include <core/database/SociDate.hpp>
+#include <core/database/SociNumber.hpp>
+#include <core/wallet/BlockDatabaseHelper.hpp>
+
+#include <bitcoin/database/BitcoinLikeTransactionDatabaseHelper.hpp>
+
+
+namespace ledger {
+    namespace core {
+        using namespace std;
+        using namespace soci;
+
+        bool BitcoinLikeTransactionDatabaseHelper::transactionExists(soci::session &sql, const std::string &btcTxUid) {
+            int32_t count = 0;
+            sql << "SELECT COUNT(*) FROM bitcoin_transactions WHERE transaction_uid = :btcTxUid", use(btcTxUid), into(count);
+            return count == 1;
+        }
+
+        std::string BitcoinLikeTransactionDatabaseHelper::createBitcoinTransactionUid(const std::string& accountUid, const std::string& txHash) {
+            auto result = SHA256::stringToHexHash(fmt::format("uid:{}+{}", accountUid, txHash));
+            return result;
+        }
+
+        std::string BitcoinLikeTransactionDatabaseHelper::putTransaction(soci::session &sql,
+                                                                  const std::string& accountUid,
+                                                                  const BitcoinLikeBlockchainExplorerTransaction &tx) {
+            auto blockUid = tx.block.map<std::string>([] (const BitcoinLikeBlockchainExplorer::Block& block) {
+                                   return block.uid;
+                               });
+
+            auto btcTxUid = createBitcoinTransactionUid(accountUid, tx.hash);
+
+            if (transactionExists(sql, btcTxUid)) {
+                // UPDATE (we only update block information)
+                if (tx.block.nonEmpty()) {
+                    sql << "UPDATE bitcoin_transactions SET block_uid = :uid WHERE hash = :tx_hash",
+                            use(blockUid), use(tx.hash);
+                    for (auto &out : tx.outputs) {
+                        auto blockHeight = tx.block.getValue().height;
+                        sql << "UPDATE bitcoin_outputs SET block_height = :height WHERE transaction_hash = :tx_hash",
+                                use(blockHeight), use(tx.hash);
+                    }
+                }
+                return btcTxUid;
+            } else {
+                // Insert
+                if (tx.block.nonEmpty()) {
+                    BlockDatabaseHelper::putBlock(sql, tx.block.getValue());
+                }
+                sql << "INSERT INTO bitcoin_transactions VALUES("
+                        ":tx_uid, :hash, :version, :block_uid, :time, :locktime"
+                        ")",
+                        use(btcTxUid),
+                        use(tx.hash),
+                        use(tx.version),
+                        use(blockUid),
+                        use(tx.receivedAt),
+                        use(tx.lockTime);
+                // Insert outputs
+                for (const auto& output : tx.outputs) {
+                    insertOutput(sql, btcTxUid, tx.hash, output);
+                }
+                // Insert inputs
+                for (const auto& input : tx.inputs) {
+                    insertInput(sql, btcTxUid, accountUid, tx.hash, input);
+                }
+                return btcTxUid;
+            }
+        }
+
+        void BitcoinLikeTransactionDatabaseHelper::insertOutput(soci::session &sql,
+                                                                const std::string& btcTxUid,
+                                                                const std::string& transactionHash,
+                                                                const BitcoinLikeBlockchainExplorerOutput &output) {
+            auto value = output.value.toUint64();
+            sql << "INSERT INTO bitcoin_outputs VALUES(:idx, :tx_uid, :hash, :amount, :script, :address, NULL, :block_height)",
+                    use(output.index), use(btcTxUid),
+                    use(transactionHash), use(value),
+                    use(output.script), use(output.address),
+                    use(output.blockHeight);
+        }
+
+        void BitcoinLikeTransactionDatabaseHelper::insertInput(soci::session &sql,
+                                                               const std::string& btcTxUid,
+                                                               const std::string& accountUid,
+                                                               const std::string& transactionHash,
+                                                               const BitcoinLikeBlockchainExplorerInput &input) {
+            /*
+             * In case transactions are issued with respect to zero knowledge protocol,
+             * previousTxHash is empty which causes conflict in bitcoin_inputs table
+             * Right now we generate a random 'hash' to compute inputUid, should be improved
+             * (e.g. use scriptSig of each input and sha256 it ...)
+            */
+            std::string hash;
+
+            //Returned by explorers when tx from zk protocol
+            std::string emptyPreviousTxHash = "0000000000000000000000000000000000000000000000000000000000000000";
+            auto previousTxHash = input.previousTxHash.getValueOr(emptyPreviousTxHash);
+            if (previousTxHash == emptyPreviousTxHash && input.signatureScript.nonEmpty()) {
+                previousTxHash =  SHA256::stringToHexHash(input.signatureScript.getValue());
+            }
+
+            auto uid = createInputUid(accountUid,
+                                      input.previousTxOutputIndex.getValueOr(0),
+                                      previousTxHash,
+                                      input.coinbase.getValueOr(""));
+
+            auto amount = input.value.map<uint64_t>([] (const BigInt& v) {
+                return v.toUint64();
+            });
+
+            std::string prevBtcTxUid;
+            if (input.previousTxHash.nonEmpty() && input.previousTxHash.getValue() != emptyPreviousTxHash) {
+                prevBtcTxUid = createBitcoinTransactionUid(accountUid, input.previousTxHash.getValue());
+            }
+
+            sql << "INSERT INTO bitcoin_inputs VALUES(:uid, :idx, :hash, :prev_tx_uid, :amount, :address, :coinbase, :sequence)",
+                    use(uid), use(input.previousTxOutputIndex), use(input.previousTxHash), use(prevBtcTxUid), use(amount),
+                    use(input.address), use(input.coinbase), use(input.sequence);
+            sql << "INSERT INTO bitcoin_transaction_inputs VALUES(:tx_uid, :tx_hash, :input_uid, :input_idx)",
+                    use(btcTxUid), use(transactionHash), use(uid), use(input.index);
+        }
+
+        std::string BitcoinLikeTransactionDatabaseHelper::createInputUid(const std::string& accountUid,
+                                                                         int32_t previousOutputIndex,
+                                                                         const std::string &previousTxHash,
+                                                                         const std::string &coinbase) {
+            return SHA256::stringToHexHash(fmt::format("uid:{}+{}+{}+{}", accountUid, previousOutputIndex, previousTxHash, coinbase));
+        }
+
+        bool BitcoinLikeTransactionDatabaseHelper::getTransactionByHash(soci::session &sql,
+                                                                        const std::string &hash,
+                                                                        const std::string &accountUid,
+                                                                        BitcoinLikeBlockchainExplorerTransaction &out) {
+            rowset<row> rows = (sql.prepare <<
+                    "SELECT  tx.hash, tx.version, tx.time, tx.locktime, "
+                            "block.hash, block.height, block.time, block.currency_name "
+                            "FROM bitcoin_transactions AS tx "
+                            "LEFT JOIN blocks AS block ON tx.block_uid = block.uid "
+                            "WHERE tx.hash = :hash", use(hash)
+            );
+            for (auto& row : rows) {
+                inflateTransaction(sql, row, accountUid, out);
+                return true;
+            }
+            return false;
+        }
+
+        bool BitcoinLikeTransactionDatabaseHelper::inflateTransaction(soci::session &sql,
+                                                                      const soci::row &row,
+                                                                      const std::string &accountUid,
+                                                                      BitcoinLikeBlockchainExplorerTransaction &out) {
+            out.hash = row.get<std::string>(0);
+            out.version = (uint32_t) row.get<int32_t>(1);
+            out.receivedAt = row.get<std::chrono::system_clock::time_point>(2);
+            out.lockTime = (uint64_t) row.get<int>(3);
+            if (row.get_indicator(4) != i_null) {
+                BitcoinLikeBlockchainExplorer::Block block;
+                block.blockHash = row.get<std::string>(4);
+                block.height = get_number<uint64_t>(row, 5);
+                block.time = row.get<std::chrono::system_clock::time_point>(6);
+                block.currencyName = row.get<std::string>(7);
+                out.block = block;
+            }
+            // Fetch inputs
+            rowset<soci::row> inputRows = (sql.prepare <<
+                "SELECT  ti.input_idx, i.previous_output_idx, i.previous_tx_hash, i.amount, i.address, i.coinbase,"
+                        "i.sequence "
+                "FROM bitcoin_transaction_inputs AS ti "
+                "JOIN bitcoin_inputs AS i ON ti.input_uid = i.uid "
+                "WHERE ti.transaction_hash = :hash ORDER BY ti.input_idx", use(out.hash)
+            );
+            for (auto& inputRow : inputRows) {
+                BitcoinLikeBlockchainExplorerInput input;
+                input.index = get_number<uint64_t>(inputRow, 0);
+                input.previousTxOutputIndex = inputRow.get<Option<int>>(1).map<uint32_t>([] (const int& v) {
+                    return (uint32_t) v;
+                });
+                input.previousTxHash = inputRow.get<Option<std::string>>(2);
+                input.value = inputRow.get<Option<long long>>(3).map<BigInt>([] (const unsigned long long& v) {
+                    return BigInt(v);
+                });
+                input.address = inputRow.get<Option<std::string>>(4);
+                input.coinbase = inputRow.get<Option<std::string>>(5);
+                input.sequence = get_number<uint32_t>(inputRow, 6);
+                out.inputs.push_back(input);
+            }
+
+            // Fetch outputs
+            rowset<soci::row> outputRows = (sql.prepare <<
+                    "SELECT idx, amount, script, address, transaction_uid, block_height FROM bitcoin_outputs WHERE transaction_hash = :hash "
+                    "ORDER BY idx", use(out.hash)
+            );
+
+            auto btcTxUid = BitcoinLikeTransactionDatabaseHelper::createBitcoinTransactionUid(accountUid, out.hash);
+            for (auto& outputRow : outputRows) {
+                //Check if the output belongs to this account
+                //solve case of 2 accounts in DB one as sender and one as receiver
+                //of same transaction (filter on account_uid won't solve the issue because
+                //bitcoin_outputs going to external accounts have NULL account_uid)
+                if (outputRow.get<std::string>(4) == btcTxUid) {
+                    BitcoinLikeBlockchainExplorerOutput output;
+                    output.index = (uint64_t) outputRow.get<int>(0);
+                    output.value.assignScalar(outputRow.get<long long>(1));
+                    output.script = outputRow.get<std::string>(2);
+                    output.address = outputRow.get<Option<std::string>>(3);
+                    if (outputRow.get_indicator(4) != i_null) {
+                        output.blockHeight = row.get<BigInt>(5).toUint64();
+                    }
+                    out.outputs.push_back(std::move(output));
+                }
+            }
+
+            // Enjoy the silence.
+            return true;
+        }
+
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/database/BitcoinLikeUTXODatabaseHelper.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/database/BitcoinLikeUTXODatabaseHelper.cpp
@@ -1,0 +1,95 @@
+/*
+ *
+ * BitcoinLikeUTXODatabaseHelper.cpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 25/09/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <bitcoin/database/BitcoinLikeUTXODatabaseHelper.hpp>
+#include <bitcoin/io/BitcoinLikeOutput.hpp>
+
+#include <core/database/SociOption.hpp>
+#include <core/database/SociNumber.hpp>
+
+
+namespace ledger {
+    namespace core {
+
+        using namespace soci;
+        
+        std::size_t BitcoinLikeUTXODatabaseHelper::UTXOcount(soci::session &sql, const std::string &accountUid,
+                                                             std::function<bool(const std::string &address)> filter) {
+            rowset<row> rows = (sql.prepare <<
+                                            "SELECT o.address FROM bitcoin_outputs AS o "
+                                                    " LEFT OUTER JOIN bitcoin_inputs AS i ON i.previous_tx_uid = o.transaction_uid "
+                                                    " AND i.previous_output_idx = o.idx"
+                                                    " WHERE i.previous_tx_uid IS NULL AND o.account_uid = :uid", use(accountUid));
+            std::size_t count = 0;
+            for (auto& row : rows) {
+                if (row.get_indicator(0) != i_null && filter(row.get<std::string>(0)))
+                    count += 1;
+            }
+            return count;
+        }
+
+        std::size_t
+        BitcoinLikeUTXODatabaseHelper::queryUTXO(soci::session &sql, const std::string &accountUid, int32_t offset,
+                                                 int32_t count, std::vector<BitcoinLikeBlockchainExplorerOutput> &out,
+                                                 std::function<bool(const std::string &address)> filter) {
+            rowset<row> rows = (sql.prepare <<
+                                            "SELECT o.address, o.idx, o.transaction_hash, o.amount, o.script, o.block_height"
+                                                    " FROM bitcoin_outputs AS o "
+                                                    " LEFT OUTER JOIN bitcoin_inputs AS i ON  i.previous_tx_uid = o.transaction_uid "
+                                                    " AND i.previous_output_idx = o.idx"
+                                                    " WHERE i.previous_tx_uid IS NULL AND o.account_uid = :uid", use(accountUid));
+
+            std::size_t c = 0;
+            std::size_t o = 0;
+            for (auto& row : rows) {
+                if (row.get_indicator(0) != i_null && filter(row.get<std::string>(0))) {
+                    if (o >= offset) {
+                        out.resize(out.size() + 1);
+                        auto& output = out[out.size() - 1];
+                        output.address = row.get<Option<std::string>>(0);
+                        output.index = get_number<uint64_t>(row, 1);
+                        output.transactionHash = row.get<std::string>(2);
+                        output.value = row.get<BigInt>(3);
+                        output.script = row.get<std::string>(4);
+                        if (row.get_indicator(5) != i_null) {
+                            output.blockHeight = row.get<BigInt>(5).toUint64();
+                        }
+                        c += 1;
+                    }
+                    o += 1;
+                }
+                if (c >= count)
+                    break;
+            }
+            return c;
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/database/BitcoinLikeWalletDatabase.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/database/BitcoinLikeWalletDatabase.cpp
@@ -1,0 +1,83 @@
+/*
+ *
+ * BitcoinLikeSociWallet
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 29/05/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <soci.h>
+
+#include <core/wallet/WalletDatabaseEntry.hpp>
+#include <core/wallet/AccountDatabaseHelper.hpp>
+
+#include <bitcoin/database/BitcoinLikeWalletDatabase.hpp>
+#include <bitcoin/database/BitcoinLikeAccountDatabaseHelper.hpp>
+
+using namespace soci;
+
+namespace ledger {
+    namespace core {
+
+        BitcoinLikeWalletDatabase::BitcoinLikeWalletDatabase(const std::shared_ptr<Services> &services,
+                                                     const std::string &walletName,
+                                                     const std::string& currencyName)
+                : _walletUid(WalletDatabaseEntry::createWalletUid(services->getTenant(), walletName)),
+                  _database(services->getDatabaseSessionPool()) {
+
+        }
+
+        int64_t BitcoinLikeWalletDatabase::getAccountsCount() const {
+            session sql(_database->getPool());
+            int64_t count = 0L;
+            sql << "SELECT COUNT(*) FROM bitcoin_accounts WHERE wallet_uid = :uid", use(_walletUid), into(count);
+            return count;
+        }
+
+        bool BitcoinLikeWalletDatabase::accountExists(int32_t index) const {
+            session sql(_database->getPool());
+            int64_t count = 0L;
+            auto uid = AccountDatabaseHelper::createAccountUid(_walletUid, index);
+            sql << "SELECT COUNT(*) FROM bitcoin_accounts WHERE uid = :uid", use(uid), into(count);
+            return count == 1;
+        }
+
+        void BitcoinLikeWalletDatabase::createAccount(int32_t index, const std::string &xpub) const {
+            session sql(_database->getPool());
+            BitcoinLikeAccountDatabaseHelper::createAccount(sql, getWalletUid(), index, xpub);
+        }
+
+        int32_t BitcoinLikeWalletDatabase::getNextAccountIndex() const {
+            session sql(_database->getPool());
+            return AccountDatabaseHelper::computeNextAccountIndex(sql, _walletUid);
+        }
+
+        const std::string &BitcoinLikeWalletDatabase::getWalletUid() const {
+            return _walletUid;
+        }
+
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/database/Migrations.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/database/Migrations.cpp
@@ -1,0 +1,155 @@
+#include <bitcoin/database/Migrations.hpp>
+
+namespace ledger {
+    namespace core {
+        int constexpr BitcoinMigration::COIN_ID;
+        uint32_t constexpr BitcoinMigration::CURRENT_VERSION;
+
+        template <> void migrate<1, BitcoinMigration>(soci::session& sql) {
+            // Bitcoin currency table
+            sql << "CREATE TABLE bitcoin_currencies("
+                "name VARCHAR(255) PRIMARY KEY NOT NULL REFERENCES currencies(name) ON DELETE CASCADE ON UPDATE CASCADE,"
+                "identifier VARCHAR(255) NOT NULL,"
+                "p2pkh_version VARCHAR(255) NOT NULL,"
+                "p2sh_version VARCHAR(255) NOT NULL,"
+                "xpub_version VARCHAR(255) NOT NULL,"
+                "dust_amount BIGINT NOT NULL,"
+                "fee_policy VARCHAR(20) NOT NULL,"
+                "message_prefix VARCHAR(255) NOT NULL,"
+                "has_timestamped_transaction INTEGER NOT NULL"
+            ")";
+
+            // Bitcoin transaction table
+            sql << "CREATE TABLE bitcoin_transactions("
+                "transaction_uid VARCHAR(255) PRIMARY KEY NOT NULL,"
+                "hash VARCHAR(255) NOT NULL,"
+                "version INTEGER,"
+                "block_uid VARCHAR(255) REFERENCES blocks(uid) ON DELETE CASCADE,"
+                "time VARCHAR(255),"
+                "locktime INTEGER"
+            ")";
+
+            // Bitcoin input table
+            sql << "CREATE TABLE bitcoin_inputs("
+                "uid VARCHAR(255) PRIMARY KEY NOT NULL," // accountId_idx_previoustxhash_coinbase
+                "previous_output_idx INTEGER,"
+                "previous_tx_hash VARCHAR(255),"
+                "previous_tx_uid VARCHAR(255),"
+                "amount  BIGINT,"
+                "address VARCHAR(255),"
+                "coinbase VARCHAR(255),"
+                "sequence BIGINT NOT NULL"
+            ")";
+
+            // Bitcoin output table
+            sql << "CREATE TABLE bitcoin_outputs("
+                "idx INTEGER NOT NULL,"
+                "transaction_uid VARCHAR(255) NOT NULL REFERENCES bitcoin_transactions(transaction_uid) ON DELETE CASCADE,"
+                "transaction_hash VARCHAR(255) NOT NULL,"
+                "amount BIGINT NOT NULL,"
+                "script TEXT NOT NULL,"
+                "address VARCHAR(255),"
+                "account_uid VARCHAR(255),"
+                "PRIMARY KEY (idx, transaction_uid)"
+                ")";
+
+            // Bitcoin transaction <-> input table
+            sql << "CREATE TABLE bitcoin_transaction_inputs("
+                "transaction_uid VARCHAR(255) NOT NULL REFERENCES bitcoin_transactions(transaction_uid) ON DELETE CASCADE,"
+                "transaction_hash VARCHAR(255) NOT NULL,"
+                "input_uid VARCHAR(255) NOT NULL REFERENCES bitcoin_inputs(uid) ON DELETE CASCADE,"
+                "input_idx INTEGER NOT NULL,"
+                "PRIMARY KEY (transaction_uid, input_uid)"
+                ")";
+
+            // Bitcoin account
+            sql << "CREATE TABLE bitcoin_accounts("
+                "uid VARCHAR(255) NOT NULL PRIMARY KEY REFERENCES accounts(uid) ON DELETE CASCADE ON UPDATE CASCADE,"
+                "wallet_uid VARCHAR(255) NOT NULL REFERENCES wallets(uid) ON DELETE CASCADE ON UPDATE CASCADE,"
+                "idx INTEGER NOT NULL,"
+                "xpub VARCHAR(255) NOT NULL"
+            ")";
+
+            // Bitcoin operation table
+            sql << "CREATE TABLE bitcoin_operations("
+                "uid VARCHAR(255) PRIMARY KEY NOT NULL REFERENCES operations(uid) ON DELETE CASCADE,"
+                "transaction_uid VARCHAR(255) NOT NULL REFERENCES bitcoin_transactions(transaction_uid),"
+                "transaction_hash VARCHAR(255) NOT NULL"
+                ")";
+        }
+
+        template <> void rollback<1, BitcoinMigration>(soci::session& sql) {
+            // Bitcoin operation table
+            sql << "DROP TABLE bitcoin_operations";
+
+            // Bitcoin account
+            sql << "DROP TABLE bitcoin_accounts";
+
+            // Bitcoin transaction <-> input table
+            sql << "DROP TABLE bitcoin_transaction_inputs";
+
+            // Bitcoin output table
+            sql << "DROP TABLE bitcoin_outputs";
+
+            // Bitcoin input table
+            sql << "DROP TABLE bitcoin_inputs";
+
+            // Bitcoin transaction table
+            sql << "DROP TABLE bitcoin_transactions";
+
+            // Bitcoin currency table
+            sql << "DROP TABLE bitcoin_currencies";
+        }
+
+        template <> void migrate<2, BitcoinMigration>(soci::session& sql) {
+            sql << "ALTER TABLE bitcoin_currencies ADD COLUMN timestamp_delay BIGINT DEFAULT 0";
+            sql << "ALTER TABLE bitcoin_currencies ADD COLUMN sighash_type VARCHAR(255) DEFAULT 01";
+        }
+
+        template <> void rollback<2, BitcoinMigration>(soci::session& sql) {
+            // not supported in standard ways by SQLite :(
+        }
+
+        template <> void migrate<3, BitcoinMigration>(soci::session& sql) {
+            sql << "ALTER TABLE bitcoin_currencies ADD COLUMN additional_BIPs TEXT DEFAULT ''";
+        }
+
+        template <> void rollback<3, BitcoinMigration>(soci::session& sql) {
+            // not supported in standard ways by SQLite :(
+        }
+
+        template <> void migrate<4, BitcoinMigration>(soci::session& sql) {
+            auto count = 0;
+            sql << "SELECT COUNT(*) FROM bitcoin_currencies WHERE identifier = 'dgb'", soci::into(count);
+            if (count > 0) {
+                sql << "UPDATE bitcoin_currencies SET p2sh_version = '3f' WHERE identifier = 'dgb' ";
+            }
+        }
+
+        template <> void rollback<4, BitcoinMigration>(soci::session& sql) {
+            // cannot rollback
+        }
+
+        template <> void migrate<5, BitcoinMigration>(soci::session& sql) {
+            sql << "CREATE TABLE bech32_parameters("
+                    "name VARCHAR(255) PRIMARY KEY NOT NULL REFERENCES bitcoin_currencies(name) ON DELETE CASCADE ON UPDATE CASCADE,"
+                    "hrp VARCHAR(255) NOT NULL,"
+                    "separator VARCHAR(255) NOT NULL,"
+                    "generator VARCHAR(255) NOT NULL,"
+                    "p2wpkh_version VARCHAR(255) NOT NULL,"
+                    "p2wsh_version VARCHAR(255) NOT NULL"
+                    ")";
+        }
+
+        template <> void rollback<5, BitcoinMigration>(soci::session& sql) {
+            sql << "DROP TABLE bech32_parameters";
+        }
+
+        template <> void migrate<6, BitcoinMigration>(soci::session& sql) {
+            sql << "ALTER TABLE bitcoin_outputs ADD COLUMN block_height BIGINT";
+        }
+
+        template <> void rollback<6, BitcoinMigration>(soci::session& sql) {
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/explorers/BitcoinLikeBlockchainExplorer.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/explorers/BitcoinLikeBlockchainExplorer.cpp
@@ -1,0 +1,40 @@
+/*
+ *
+ * BitcoinLikeBlockchainExplorer
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 17/01/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+#include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+
+namespace ledger {
+    namespace core {
+        BitcoinLikeBlockchainExplorer::BitcoinLikeBlockchainExplorer(const std::shared_ptr<ledger::core::api::DynamicObject> &configuration,
+                                                                     const std::vector<std::string> &matchableKeys) : ConfigurationMatchable(matchableKeys) {
+            setConfiguration(configuration);
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/explorers/LedgerApiBitcoinLikeBlockchainExplorer.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/explorers/LedgerApiBitcoinLikeBlockchainExplorer.cpp
@@ -1,0 +1,137 @@
+/*
+ *
+ * LedgerApiBitcoinLikeBlockchainExplorer
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 10/03/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/api/ErrorCode.hpp>
+#include <core/math/BigInt.hpp>
+
+#include <bitcoin/explorers/LedgerApiBitcoinLikeBlockchainExplorer.hpp>
+
+namespace ledger {
+    namespace core {
+
+        LedgerApiBitcoinLikeBlockchainExplorer::LedgerApiBitcoinLikeBlockchainExplorer(const std::shared_ptr<api::ExecutionContext> &context,
+                                                                                       const std::shared_ptr<HttpClient> &http,
+                                                                                       const api::BitcoinLikeNetworkParameters& parameters,
+                                                                                       const std::shared_ptr<api::DynamicObject>& configuration) :
+                DedicatedContext(context),
+                BitcoinLikeBlockchainExplorer(configuration, {api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT}) {
+            _http = http;
+            _parameters = parameters;
+            _explorerVersion = configuration->getString(api::Configuration::BLOCKCHAIN_EXPLORER_VERSION).value_or("v2");
+        }
+
+        Future<String> LedgerApiBitcoinLikeBlockchainExplorer::pushLedgerApiTransaction(const std::vector<uint8_t> &transaction) {
+            std::stringstream body;
+            body << "{" << "\"tx\":" << '"' << hex::toString(transaction) << '"' << "}";
+            auto bodyString = body.str();
+            return _http->POST(fmt::format("/blockchain/{}/{}/transactions/send", getExplorerVersion(), getNetworkParameters().Identifier),
+                               std::vector<uint8_t>(bodyString.begin(), bodyString.end())
+            ).json().template map<String>(getExplorerContext(), [] (const HttpRequest::JsonResult& result) -> String {
+                auto& json = *std::get<1>(result);
+                return json["result"].GetString();
+            });
+        }
+
+        Future<void *> LedgerApiBitcoinLikeBlockchainExplorer::startSession() {
+            return startLedgerApiSession();
+        }
+
+        Future<Unit> LedgerApiBitcoinLikeBlockchainExplorer::killSession(void *session) {
+            return killLedgerApiSession(session);
+        }
+
+        Future<String> LedgerApiBitcoinLikeBlockchainExplorer::pushTransaction(const std::vector<uint8_t> &transaction) {
+            return pushLedgerApiTransaction(transaction);
+        }
+
+        Future<Bytes> LedgerApiBitcoinLikeBlockchainExplorer::getRawTransaction(const String& transactionHash) {
+            return getLedgerApiRawTransaction(transactionHash);
+        }
+
+        FuturePtr<BitcoinLikeBlockchainExplorer::TransactionsBulk>
+        LedgerApiBitcoinLikeBlockchainExplorer::getTransactions(const std::vector<std::string> &addresses,
+                                                                Option<std::string> fromBlockHash,
+                                                                Option<void *> session) {
+            return getLedgerApiTransactions(addresses, fromBlockHash, session);
+        }
+
+        FuturePtr<BitcoinLikeBlockchainExplorer::Block> LedgerApiBitcoinLikeBlockchainExplorer::getCurrentBlock() const {
+            return getLedgerApiCurrentBlock();
+        }
+
+        FuturePtr<BitcoinLikeBlockchainExplorerTransaction>
+        LedgerApiBitcoinLikeBlockchainExplorer::getTransactionByHash(const String &transactionHash) const {
+            return getLedgerApiTransactionByHash(transactionHash);
+        }
+
+        Future<int64_t > LedgerApiBitcoinLikeBlockchainExplorer::getTimestamp() const {
+            return getLedgerApiTimestamp();
+        }
+
+        std::shared_ptr<api::ExecutionContext> LedgerApiBitcoinLikeBlockchainExplorer::getExplorerContext() const {
+            return _executionContext;
+        }
+
+        api::BitcoinLikeNetworkParameters LedgerApiBitcoinLikeBlockchainExplorer::getNetworkParameters() const {
+            return _parameters;
+        }
+
+        std::string LedgerApiBitcoinLikeBlockchainExplorer::getExplorerVersion() const {
+            return _explorerVersion;
+        }
+
+        Future<std::vector<std::shared_ptr<api::BigInt>>> LedgerApiBitcoinLikeBlockchainExplorer::getFees() {
+            bool parseNumbersAsString = true;
+            auto networkId = getNetworkParameters().Identifier;
+            return _http->GET(fmt::format("/blockchain/{}/{}/fees", getExplorerVersion(), networkId))
+                    .json(parseNumbersAsString).map<std::vector<std::shared_ptr<api::BigInt>>>(getExplorerContext(), [networkId] (const HttpRequest::JsonResult& result) {
+                        auto& json = *std::get<1>(result);
+                        if (!json.IsObject()) {
+                            throw make_exception(api::ErrorCode::HTTP_ERROR, "Failed to get fees for {}", networkId);
+                        }
+
+                        // Here we filter fields returned by this endpoint,
+                        // if the field's key is a number (number of confirmations) then it's an acceptable fee
+                        auto isValid = [] (const std::string &field) -> bool {
+                            return !field.empty() && std::find_if(field.begin(), field.end(), [](char c) { return !std::isdigit(c); }) == field.end();
+                        };
+                        std::vector<std::shared_ptr<api::BigInt>> fees;
+                        for (auto& item : json.GetObject()) {
+                            if (item.name.IsString() && item.value.IsString() && isValid(item.name.GetString())){
+                                fees.push_back(std::make_shared<BigInt>(BigInt::fromString(item.value.GetString())));
+                            }
+                        }
+                        return fees;
+                    });
+        }
+
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/factories/BitcoinLikeWalletFactory.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/factories/BitcoinLikeWalletFactory.cpp
@@ -1,0 +1,223 @@
+/*
+ *
+ * BitcoinLikeWalletFactory
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 31/01/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <leveldb/db.h>
+
+#include <core/Services.hpp>
+#include <core/api/BlockchainExplorerEngines.hpp>
+#include <core/api/ConfigurationDefaults.hpp>
+#include <core/api/KeychainEngines.hpp>
+#include <core/api/SynchronizationEngines.hpp>
+#include <core/api/BlockchainObserverEngines.hpp>
+
+#include <bitcoin/BitcoinNetworks.hpp>
+#include <bitcoin/BitcoinLikeCurrencies.hpp>
+#include <bitcoin/BitcoinLikeWallet.hpp>
+#include <bitcoin/explorers/LedgerApiBitcoinLikeBlockchainExplorer.hpp>
+#include <bitcoin/factories/BitcoinLikeCommonKeychainFactory.hpp>
+#include <bitcoin/factories/BitcoinLikeWalletFactory.hpp>
+#include <bitcoin/keychains/P2PKHBitcoinLikeKeychain.hpp>
+#include <bitcoin/keychains/P2SHBitcoinLikeKeychain.hpp>
+#include <bitcoin/keychains/P2WPKHBitcoinLikeKeychain.hpp>
+#include <bitcoin/keychains/P2WSHBitcoinLikeKeychain.hpp>
+#include <bitcoin/observers/LedgerApiBitcoinLikeBlockchainObserver.hpp>
+#include <bitcoin/synchronizers/BitcoinLikeBlockchainExplorerAccountSynchronizer.hpp>
+
+#define STRING(key, def) entry.configuration->getString(key).value_or(def)
+
+namespace ledger {
+    namespace core {
+        BitcoinLikeWalletFactory::BitcoinLikeWalletFactory(
+            const api::Currency &currency,
+            const std::shared_ptr<Services> &services
+        ): AbstractWalletFactory(currency, services) {
+            _keychainFactories = {
+                {api::KeychainEngines::BIP32_P2PKH, std::make_shared<BitcoinLikeCommonKeychainFactory<P2PKHBitcoinLikeKeychain>>()},
+                {api::KeychainEngines::BIP49_P2SH, std::make_shared<BitcoinLikeCommonKeychainFactory<P2SHBitcoinLikeKeychain>>()},
+                {api::KeychainEngines::BIP173_P2WPKH, std::make_shared<BitcoinLikeCommonKeychainFactory<P2WPKHBitcoinLikeKeychain>>()},
+                {api::KeychainEngines::BIP173_P2WSH, std::make_shared<BitcoinLikeCommonKeychainFactory<P2WSHBitcoinLikeKeychain>>()}
+            };
+        }
+
+        std::shared_ptr<AbstractWallet> BitcoinLikeWalletFactory::build(const WalletDatabaseEntry &entry) {
+            auto services = getServices();
+            services->logger()->info("Building wallet instance '{}' for {} with parameters: {}", entry.name, entry.currencyName, entry.configuration->dump());
+
+            // Get currency
+            try {
+                auto currency = networks::getBitcoinLikeNetworkParameters(entry.currencyName);
+            }
+            catch (Exception) {
+                throw make_exception(api::ErrorCode::UNSUPPORTED_CURRENCY, "Unsupported currency '{}'.", entry.currencyName);
+            }
+
+            // Configure keychain
+            auto keychainFactory = _keychainFactories.find(STRING(api::Configuration::KEYCHAIN_ENGINE, api::KeychainEngines::BIP32_P2PKH));
+            if (keychainFactory == _keychainFactories.end()) {
+                throw make_exception(api::ErrorCode::UNKNOWN_KEYCHAIN_ENGINE, "Engine '{}' is not a supported keychain engine.", STRING(api::Configuration::KEYCHAIN_ENGINE, "undefined"));
+            }
+
+            // Configure explorer
+            auto explorer = getExplorer(entry.currencyName, entry.configuration);
+            if (explorer == nullptr) {
+                throw make_exception(api::ErrorCode::UNKNOWN_BLOCKCHAIN_EXPLORER_ENGINE, "Engine '{}' is not a supported explorer engine.", STRING(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, "undefined"));
+            }
+
+            // Configure observer
+            auto observer = getObserver(entry.currencyName, entry.configuration);
+            if (observer == nullptr) {
+                services->logger()->warn("Observer engine '{}' is not supported. Wallet {} was created anyway. Real time events won't be handled by this instance.",  STRING(api::Configuration::BLOCKCHAIN_OBSERVER_ENGINE, "undefined"), entry.name);
+            }
+
+            // Configure synchronizer
+            using BitcoinLikeAccountSynchronizerFactory = std::function<std::shared_ptr<BitcoinLikeAccountSynchronizer> ()>;
+            Option<BitcoinLikeAccountSynchronizerFactory> synchronizerFactory;
+
+            {
+                auto engine = entry.configuration->getString(api::Configuration::SYNCHRONIZATION_ENGINE)
+                                           .value_or(api::SynchronizationEngines::BLOCKCHAIN_EXPLORER_SYNCHRONIZATION);
+                if (engine == api::SynchronizationEngines::BLOCKCHAIN_EXPLORER_SYNCHRONIZATION) {
+                    std::weak_ptr<Services> s = services;
+                    synchronizerFactory = Option<BitcoinLikeAccountSynchronizerFactory>([s, explorer]() {
+                        auto services = s.lock();
+                        if (!services) {
+                            throw make_exception(api::ErrorCode::NULL_POINTER, "WalletPool was released.");
+                        }
+                        return std::make_shared<BlockchainExplorerAccountSynchronizer>(services, explorer);
+                    });
+                }
+            }
+
+            if (synchronizerFactory.isEmpty()) {
+                throw make_exception(api::ErrorCode::UNKNOWN_SYNCHRONIZATION_ENGINE, "Engine '{}' is not a supported synchronization engine.", STRING(api::Configuration::SYNCHRONIZATION_ENGINE, "undefined"));
+            }
+
+            // Sets the derivation scheme
+            DerivationScheme scheme(STRING(api::Configuration::KEYCHAIN_DERIVATION_SCHEME, "44'/<coin_type>'/<account>'/<node>/<address>"));
+
+            return std::make_shared<BitcoinLikeWallet>(
+                    entry.name,
+                    explorer,
+                    observer,
+                    keychainFactory->second,
+                    synchronizerFactory.getValue(),
+                    services,
+                    getCurrency(),
+                    entry.configuration,
+                    scheme
+            );
+        }
+
+        std::shared_ptr<BitcoinLikeBlockchainExplorer>
+        BitcoinLikeWalletFactory::getExplorer(const std::string &currencyName,
+                                              const std::shared_ptr<api::DynamicObject> &configuration) {
+            auto it = _runningExplorers.begin();
+            while (it != _runningExplorers.end()) {
+                auto explorer = it->lock();
+                if (explorer != nullptr) {
+                    if (explorer->match(configuration)) {
+                        return explorer;
+                    }
+
+                    it++;
+                } else {
+                    it = _runningExplorers.erase(it);
+                }
+            }
+
+            auto services = getServices();
+            auto engine = configuration->getString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE)
+                                       .value_or(api::BlockchainExplorerEngines::LEDGER_API);
+            std::shared_ptr<BitcoinLikeBlockchainExplorer> explorer = nullptr;
+            if (engine == api::BlockchainExplorerEngines::LEDGER_API) {
+                auto http = services->getHttpClient(
+                        configuration->getString(
+                                api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT
+                        ).value_or(api::ConfigurationDefaults::BLOCKCHAIN_DEFAULT_API_ENDPOINT)
+                );
+
+                auto context = services->getDispatcher()->getSerialExecutionContext(api::BlockchainObserverEngines::LEDGER_API);
+                auto& networkParams = networks::getBitcoinLikeNetworkParameters(getCurrency().name);
+                explorer = std::make_shared<LedgerApiBitcoinLikeBlockchainExplorer>(context, http, networkParams, configuration);
+            }
+
+            if (explorer) {
+                _runningExplorers.push_back(explorer);
+            }
+
+            return explorer;
+        }
+
+        std::shared_ptr<BitcoinLikeBlockchainObserver>
+        BitcoinLikeWalletFactory::getObserver(const std::string &currencyName,
+                                              const std::shared_ptr<api::DynamicObject> &configuration) {
+            auto it = _runningObservers.begin();
+            while (it != _runningObservers.end()) {
+                auto observer = it->lock();
+                if (observer != nullptr) {
+                    if (observer->match(configuration)) {
+                        return observer;
+                    }
+
+                    it++;
+                } else {
+                    it = _runningObservers.erase(it);
+                }
+            }
+
+            auto services = getServices();
+            auto engine = configuration->getString(api::Configuration::BLOCKCHAIN_OBSERVER_ENGINE)
+                                        .value_or(api::BlockchainObserverEngines::LEDGER_API);
+            std::shared_ptr<BitcoinLikeBlockchainObserver> observer;
+
+            if (engine == api::BlockchainObserverEngines::LEDGER_API) {
+                auto ws = services->getWebSocketClient();
+                auto context = services->getDispatcher()->getSerialExecutionContext(api::BlockchainObserverEngines::LEDGER_API);
+                auto logger = services->logger();
+                const auto& currency = getCurrency();
+
+                observer = std::make_shared<LedgerApiBitcoinLikeBlockchainObserver>(
+                        context,
+                        ws,
+                        configuration,
+                        logger,
+                        currency
+                );
+            }
+
+            if (observer) {
+                _runningObservers.push_back(observer);
+            }
+
+            return observer;
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/io/BitcoinLikeInput.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/io/BitcoinLikeInput.cpp
@@ -1,0 +1,118 @@
+/*
+ *
+ * BitcoinLikeInput
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 12/07/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/wallet/Amount.hpp>
+#include <core/wallet/AbstractAccount.hpp>
+
+#include <bitcoin/io/BitcoinLikeInput.hpp>
+#include <bitcoin/transactions/BitcoinLikeTransaction.hpp>
+
+namespace ledger {
+    namespace core {
+
+        BitcoinLikeInput::BitcoinLikeInput(const std::shared_ptr<api::BitcoinLikeOperation> &operation, int32_t inputIndex) {
+            _operation = operation;
+            _inputIndex = inputIndex;
+        }
+
+        optional<std::string> BitcoinLikeInput::getAddress() {
+            return getInput().getAddress();
+        }
+
+        std::shared_ptr<api::Amount> BitcoinLikeInput::getValue() {
+            return getInput().getValue();
+        }
+
+        bool BitcoinLikeInput::isCoinbase() {
+            return static_cast<bool>(getInput().getCoinbase());
+        }
+
+        optional<std::string> BitcoinLikeInput::getCoinbase() {
+            return getInput().getCoinbase();
+        }
+
+        api::BitcoinLikeInput &BitcoinLikeInput::getInput() {
+            return *(_operation->getTransaction()->getInputs()[_inputIndex]);
+        }
+
+        optional<std::string> BitcoinLikeInput::getPreviousTxHash() {
+            return getInput().getPreviousTxHash();
+        }
+
+        optional<int32_t> BitcoinLikeInput::getPreviousOutputIndex() {
+            return getInput().getPreviousOutputIndex();
+        }
+
+        std::vector<std::vector<uint8_t>> BitcoinLikeInput::getPublicKeys() {
+            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "std::vector<std::vector<uint8_t>> BitcoinLikeInput::getPublicKeys()");
+        }
+
+        std::vector<std::shared_ptr<api::DerivationPath>> BitcoinLikeInput::getDerivationPath() {
+            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "std::vector<std::shared_ptr<DerivationPath>> BitcoinLikeInput::getDerivationPath()");
+        }
+
+        std::shared_ptr<api::BitcoinLikeOutput> BitcoinLikeInput::getPreviousOuput() {
+            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "std::shared_ptr<api::BitcoinLikeOutput> BitcoinLikeInput::getPreviousOuput()");
+        }
+
+        std::vector<uint8_t> BitcoinLikeInput::getScriptSig() {
+            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "std::vector<uint8_t> BitcoinLikeInput::getScriptSig()");
+        }
+
+        std::shared_ptr<api::BitcoinLikeScript> BitcoinLikeInput::parseScriptSig() {
+            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "std::shared_ptr<api::BitcoinLikeScript> BitcoinLikeInput::parseScriptSig()");
+        }
+
+        void BitcoinLikeInput::setScriptSig(const std::vector<uint8_t> &scriptSig) {
+            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "void BitcoinLikeInput::setScriptSig(const std::vector<uint8_t> &scriptSig)");
+        }
+
+        void BitcoinLikeInput::pushToScriptSig(const std::vector<uint8_t> &data) {
+            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "void BitcoinLikeInput::pushToScriptSig(const std::vector<uint8_t> &data)");
+        }
+
+        void BitcoinLikeInput::setSequence(int32_t sequence) {
+            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "void BitcoinLikeInput::setSequence(int32_t sequence)");
+        }
+
+        int64_t BitcoinLikeInput::getSequence() {
+            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "int32_t BitcoinLikeInput::getSequence()");
+        }
+
+        void BitcoinLikeInput::setP2PKHSigScript(const std::vector<uint8_t> &signature) {
+            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "void BitcoinLikeInput::setP2PKHSigScript(const std::vector<uint8_t> &signature)");
+        }
+
+        void BitcoinLikeInput::getPreviousTransaction(const std::function<void(std::experimental::optional<std::vector<uint8_t>>, std::experimental::optional<::ledger::core::api::Error>)> & callback) {
+            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "void BitcoinLikeInput::getPreviousTransaction(const std::shared_ptr<api::BinaryCallback> &callback)");
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/io/BitcoinLikeInputParser.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/io/BitcoinLikeInputParser.cpp
@@ -1,0 +1,117 @@
+/*
+ *
+ * BitcoinLikeInputParser
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 12/04/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/utils/DateUtils.hpp>
+
+#include <bitcoin/io/BitcoinLikeInputParser.hpp>
+
+namespace ledger {
+    namespace core {
+        bool BitcoinLikeInputParser::Null() {
+            return true;
+        }
+
+        bool BitcoinLikeInputParser::Bool(bool b) {
+            return true;
+        }
+
+        bool BitcoinLikeInputParser::Int(int i) {
+            return true;
+        }
+
+        bool BitcoinLikeInputParser::Uint(unsigned i) {
+            return true;
+        }
+
+        bool BitcoinLikeInputParser::Int64(int64_t i) {
+            return true;
+        }
+
+        bool BitcoinLikeInputParser::Uint64(uint64_t i) {
+            return true;
+        }
+
+        bool BitcoinLikeInputParser::Double(double d) {
+            return true;
+        }
+
+        bool BitcoinLikeInputParser::RawNumber(const rapidjson::Reader::Ch *str, rapidjson::SizeType length, bool copy) {
+            std::string number(str, length);
+            BigInt value = BigInt::fromString(number);
+            if (_lastKey == "input_index") {
+                _input->index = value.toUint64();
+            } else if (_lastKey == "value") {
+                _input->value = Option<BigInt>(value);
+            } else if (_lastKey == "output_index") {
+                _input->previousTxOutputIndex = value.toUint64();
+            }
+            return true;
+        }
+
+        bool BitcoinLikeInputParser::String(const rapidjson::Reader::Ch *str, rapidjson::SizeType length, bool copy) {
+            std::string value = std::string(str, length);
+            if (_lastKey == "output_hash") {
+                _input->previousTxHash = value;
+            } else if (_lastKey == "address") {
+                _input->address = Option<std::string>(value);
+            } else if (_lastKey == "script_signature") {
+                _input->signatureScript = Option<std::string>(value);
+            } else if (_lastKey == "coinbase") {
+                _input->coinbase = Option<std::string>(value);
+            }
+            return true;
+        }
+
+        bool BitcoinLikeInputParser::StartObject() {
+            return true;
+        }
+
+        bool BitcoinLikeInputParser::Key(const rapidjson::Reader::Ch *str, rapidjson::SizeType length, bool copy) {
+            return true;
+        }
+
+        bool BitcoinLikeInputParser::EndObject(rapidjson::SizeType memberCount) {
+            return true;
+        }
+
+        bool BitcoinLikeInputParser::StartArray() {
+            return true;
+        }
+
+        bool BitcoinLikeInputParser::EndArray(rapidjson::SizeType elementCount) {
+            return true;
+        }
+
+        void BitcoinLikeInputParser::init(BitcoinLikeBlockchainExplorerInput *input) {
+            _input = input;
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/io/BitcoinLikeOutput.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/io/BitcoinLikeOutput.cpp
@@ -1,0 +1,111 @@
+/*
+ *
+ * BitcoinLikeOutput
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 12/07/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/utils/Hex.hpp>
+#include <core/wallet/Amount.hpp>
+#include <core/wallet/AbstractAccount.hpp>
+#include <core/utils/Exception.hpp>
+
+#include <bitcoin/io/BitcoinLikeOutput.hpp>
+#include <bitcoin/scripts/BitcoinLikeScript.hpp>
+#include <bitcoin/scripts/BitcoinLikeInternalScript.hpp>
+#include <bitcoin/transactions/BitcoinLikeTransaction.hpp>
+
+namespace ledger {
+    namespace core {
+
+        BitcoinLikeOutput::BitcoinLikeOutput(const std::shared_ptr<::ledger::core::BitcoinLikeOperation> &operation,
+                                                   int32_t outputIndex) : _backend(operation) {
+            _outputIndex = outputIndex;
+            _currency = operation->getAccount()->getWallet()->getCurrency();
+        }
+
+        BitcoinLikeOutput::BitcoinLikeOutput(const BitcoinLikeBlockchainExplorerOutput &output, const api::Currency& currency) : _backend(output) {
+            _outputIndex = static_cast<int32_t>(output.index);
+            _currency = currency;
+        }
+
+        std::string BitcoinLikeOutput::getTransactionHash() {
+            if (_backend.isLeft())
+                return _backend.getLeft()->getTransaction()->getHash();
+            else
+                return _backend.getRight().transactionHash;
+        }
+
+        int32_t BitcoinLikeOutput::getOutputIndex() {
+            return _outputIndex;
+        }
+
+        std::shared_ptr<api::Amount> BitcoinLikeOutput::getValue() {
+            return std::make_shared<Amount>(_currency, 0, getOutput().value);
+        }
+
+        std::vector<uint8_t> BitcoinLikeOutput::getScript() {
+            return hex::toByteArray(getOutput().script);
+        }
+
+        optional<std::string> BitcoinLikeOutput::getAddress() {
+            return getOutput().address.toOptional();
+        }
+
+        BitcoinLikeBlockchainExplorerOutput &BitcoinLikeOutput::getOutput() {
+            if (_backend.isLeft())
+                return _backend.getLeft()->getExplorerTransaction().outputs[_outputIndex];
+            return _backend.getRight();
+        }
+
+        std::shared_ptr<api::BitcoinLikeScript> BitcoinLikeOutput::parseScript() {
+            auto result = BitcoinLikeScript::parse(getScript());
+            if (result.isFailure())
+                throw result.getFailure();
+            return std::make_shared<BitcoinLikeInternalScript>(result.getValue());
+        }
+
+        std::shared_ptr<api::DerivationPath> BitcoinLikeOutput::getDerivationPath() {
+            return _path;
+        }
+
+        std::experimental::optional<int64_t> BitcoinLikeOutput::getBlockHeight() {
+            return static_cast<int64_t>(getOutput().blockHeight.getValueOr(std::numeric_limits<uint64_t>::max()));
+        }
+
+        BitcoinLikeOutput::BitcoinLikeOutput(const BitcoinLikeBlockchainExplorerOutput &output,
+                                                   const api::Currency &currency,
+                                                   const std::shared_ptr<api::DerivationPath> &path)
+                : BitcoinLikeOutput(output, currency) {
+            _path = path;
+        }
+
+        const BigInt &BitcoinLikeOutput::value() {
+            return getOutput().value;
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/io/BitcoinLikeOutputParser.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/io/BitcoinLikeOutputParser.cpp
@@ -1,0 +1,111 @@
+/*
+ *
+ * BitcoinLikeOutputParser
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 13/04/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <bitcoin/io/BitcoinLikeOutputParser.hpp>
+
+namespace ledger {
+    namespace core {
+
+        bool BitcoinLikeOutputParser::Null() {
+            return true;
+        }
+
+        bool BitcoinLikeOutputParser::Bool(bool b) {
+            return true;
+        }
+
+        bool BitcoinLikeOutputParser::Int(int i) {
+            return true;
+        }
+
+        bool BitcoinLikeOutputParser::Uint(unsigned int i) {
+            return true;
+        }
+
+        bool BitcoinLikeOutputParser::Int64(int64_t i) {
+            return true;
+        }
+
+        bool BitcoinLikeOutputParser::Uint64(uint64_t i) {
+            return true;
+        }
+
+        bool BitcoinLikeOutputParser::Double(double d) {
+            return true;
+        }
+
+        bool BitcoinLikeOutputParser::RawNumber(const rapidjson::Reader::Ch *str, rapidjson::SizeType length, bool copy) {
+            std::string number(str, length);
+            BigInt value = BigInt::fromString(number);
+            if (_lastKey == "output_index") {
+                _output->index = value.toUnsignedInt();
+            } else if (_lastKey == "value") {
+                _output->value = value;
+            }
+            return true;
+        }
+
+        bool BitcoinLikeOutputParser::String(const rapidjson::Reader::Ch *str, rapidjson::SizeType length, bool copy) {
+            std::string value = std::string(str, length);
+            if (_lastKey == "address") {
+                _output->address = Option<std::string>(value);
+            } else if (_lastKey == "script_hex") {
+                _output->script = value;
+            }
+            return true;
+        }
+
+        bool BitcoinLikeOutputParser::StartObject() {
+            return true;
+        }
+
+        bool BitcoinLikeOutputParser::Key(const rapidjson::Reader::Ch *str, rapidjson::SizeType length, bool copy) {
+            return true;
+        }
+
+        bool BitcoinLikeOutputParser::EndObject(rapidjson::SizeType memberCount) {
+            return true;
+        }
+
+        bool BitcoinLikeOutputParser::StartArray() {
+            return true;
+        }
+
+        bool BitcoinLikeOutputParser::EndArray(rapidjson::SizeType elementCount) {
+            return true;
+        }
+
+        void BitcoinLikeOutputParser::init(BitcoinLikeBlockchainExplorerOutput *output) {
+            _output = output;
+        }
+
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/io/BitcoinLikeWritableInput.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/io/BitcoinLikeWritableInput.cpp
@@ -1,0 +1,141 @@
+/*
+ *
+ * BitcoinLikeWritableInput.cpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 10/04/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <bitcoin/io/BitcoinLikeWritableInput.hpp>
+#include <bitcoin/scripts/BitcoinLikeScript.hpp>
+#include <bitcoin/scripts/BitcoinLikeInternalScript.hpp>
+
+namespace ledger {
+    namespace core {
+
+        BitcoinLikeWritableInput::BitcoinLikeWritableInput(
+                const std::shared_ptr<ledger::core::BitcoinLikeBlockchainExplorer> &explorer,
+                const std::shared_ptr<api::ExecutionContext> &context, uint32_t sequence,
+                const std::vector<std::vector<uint8_t> > &pubKeys,
+                const std::vector<std::shared_ptr<api::DerivationPath>> &paths, const std::string &address,
+                const std::shared_ptr<api::Amount> &amount, const std::string &previousTxHash, int32_t index,
+                const std::vector<uint8_t> &scriptSig,
+                const std::shared_ptr<api::BitcoinLikeOutput> &previousOutput,
+                const std::string &keychainEngine) :
+                _explorer(explorer), _context(context), _sequence(sequence),
+                _pubKeys(pubKeys), _paths(paths), _address(address), _index(index),
+                _amount(amount), _previousHash(previousTxHash),
+                _previousScript(previousOutput) {
+            // TODO handle the case where explorer, context are missing properly
+            if (!scriptSig.empty()) {
+                auto isSigned = true;
+                auto strScriptSig = hex::toString(scriptSig);
+                auto parsedScript = BitcoinLikeScript::parse(scriptSig,
+                                                             BitcoinLikeScriptConfiguration(isSigned, keychainEngine));
+                if (parsedScript.isSuccess()) {
+                    _scriptSig = parsedScript.getValue();
+                }
+            }
+        }
+
+        optional<std::string> BitcoinLikeWritableInput::getAddress() {
+            return Option<std::string>(_address).toOptional();
+        }
+
+        std::vector<std::vector<uint8_t>> BitcoinLikeWritableInput::getPublicKeys() {
+            return _pubKeys;
+        }
+
+        std::vector<std::shared_ptr<api::DerivationPath> > BitcoinLikeWritableInput::getDerivationPath() {
+            return _paths;
+        }
+
+        std::shared_ptr<api::Amount> BitcoinLikeWritableInput::getValue() {
+            return _amount;
+        }
+
+        bool BitcoinLikeWritableInput::isCoinbase() {
+            return false;
+        }
+
+        optional<std::string> BitcoinLikeWritableInput::getCoinbase() {
+            return Option<std::string>().toOptional();
+        }
+
+        optional<std::string> BitcoinLikeWritableInput::getPreviousTxHash() {
+            return Option<std::string>(_previousHash).toOptional();
+        }
+
+        optional<int32_t> BitcoinLikeWritableInput::getPreviousOutputIndex() {
+            return Option<int32_t>(_index).toOptional();
+        }
+
+        std::shared_ptr<api::BitcoinLikeOutput> BitcoinLikeWritableInput::getPreviousOuput() {
+            return _previousScript;
+        }
+
+        std::vector<uint8_t> BitcoinLikeWritableInput::getScriptSig() {
+            return _scriptSig.serialize();
+        }
+
+        std::shared_ptr<api::BitcoinLikeScript> BitcoinLikeWritableInput::parseScriptSig() {
+            return std::make_shared<BitcoinLikeInternalScript>(_scriptSig);
+        }
+
+        void BitcoinLikeWritableInput::setScriptSig(const std::vector<uint8_t> &scriptSig) {
+            _scriptSig = BitcoinLikeScript::parse(scriptSig).getValue();
+        }
+
+        void BitcoinLikeWritableInput::pushToScriptSig(const std::vector<uint8_t> &data) {
+            _scriptSig << data;
+        }
+
+        void BitcoinLikeWritableInput::setSequence(int32_t sequence) {
+            _sequence = (uint32_t) sequence;
+        }
+
+        int64_t BitcoinLikeWritableInput::getSequence() {
+            return (int32_t) _sequence;
+        }
+
+        void BitcoinLikeWritableInput::setP2PKHSigScript(const std::vector<uint8_t> &signature) {
+            pushToScriptSig(signature);
+            pushToScriptSig(_pubKeys[0]);
+        }
+
+        void BitcoinLikeWritableInput::getPreviousTransaction(const std::function<void(std::experimental::optional<std::vector<uint8_t>>, std::experimental::optional<api::Error>)> & callback) {
+            getPreviousTransaction().callback(_context, callback);
+        }
+
+        Future<std::vector<uint8_t>> BitcoinLikeWritableInput::getPreviousTransaction() {
+            return _explorer->getRawTransaction(getPreviousTxHash().value()).map<std::vector<uint8_t> >(_context,
+                                                                                                        [](const Bytes &bytes) {
+                                                                                                            return bytes.getContainer();
+                                                                                                        });
+        }
+
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/keychains/BitcoinLikeKeychain.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/keychains/BitcoinLikeKeychain.cpp
@@ -1,0 +1,127 @@
+/*
+ *
+ * BitcoinLikeKeychain
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 17/01/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/api/Currency.hpp>
+#include <core/api/KeychainEngines.hpp>
+
+#include <bitcoin/keychains/BitcoinLikeKeychain.hpp>
+#include <bitcoin/BitcoinNetworks.hpp>
+
+namespace ledger {
+    namespace core {
+
+        int BitcoinLikeKeychain::getAccountIndex() const {
+            return _account;
+        }
+
+        const api::BitcoinLikeNetworkParameters BitcoinLikeKeychain::getNetworkParameters() const {
+            return networks::getBitcoinLikeNetworkParameters(_currency.name);
+        }
+
+        bool BitcoinLikeKeychain::markAsUsed(const std::vector<std::string> &addresses) {
+            bool result = false;
+            for (auto& address : addresses) {
+                result = markAsUsed(address) || result;
+            }
+            return result;
+        }
+
+        std::shared_ptr<Preferences> BitcoinLikeKeychain::getPreferences() const {
+            return _preferences;
+        }
+
+        std::shared_ptr<api::DynamicObject> BitcoinLikeKeychain::getConfiguration() const {
+            return _configuration;
+        }
+
+        BitcoinLikeKeychain::BitcoinLikeKeychain(const std::shared_ptr<api::DynamicObject>& configuration,
+                                                 const api::Currency &params, int account,
+                                                 const std::shared_ptr<Preferences>& preferences) :
+            _account(account), _preferences(preferences), _configuration(configuration), _currency(params),
+            _fullScheme(DerivationScheme(configuration
+                                                 ->getString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME)
+                                                 .value_or("44'/<coin_type>'/<account>'/<node>/<address>"))),
+            _scheme(DerivationScheme(configuration
+                    ->getString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME)
+                    .value_or("44'/<coin_type>'/<account>'/<node>/<address>")).getSchemeFrom(DerivationSchemeLevel::ACCOUNT_INDEX).shift())
+        {
+        }
+
+        const api::Currency& BitcoinLikeKeychain::getCurrency() const {
+            return _currency;
+        }
+
+        const DerivationScheme &BitcoinLikeKeychain::getDerivationScheme() const {
+            return _scheme;
+        }
+
+        DerivationScheme &BitcoinLikeKeychain::getDerivationScheme() {
+            return _scheme;
+        }
+
+        bool BitcoinLikeKeychain::markAsUsed(const std::string &address) {
+            auto path = getAddressDerivationPath(address);
+            if (path.nonEmpty()) {
+                return markPathAsUsed(DerivationPath(path.getValue()));
+            } else {
+                return false;
+            }
+        }
+
+        const DerivationScheme &BitcoinLikeKeychain::getFullDerivationScheme() const {
+            return _fullScheme;
+        }
+
+        std::string BitcoinLikeKeychain::getKeychainEngine() const {
+            return _configuration->getString(api::Configuration::KEYCHAIN_ENGINE).value_or(api::KeychainEngines::BIP32_P2PKH);
+        }
+
+        bool BitcoinLikeKeychain::isSegwit() const {
+            //TODO: find a better way to know whether it's segwit or not
+            return isSegwit(_configuration->getString(api::Configuration::KEYCHAIN_ENGINE).value_or(api::KeychainEngines::BIP32_P2PKH));
+        }
+
+        bool BitcoinLikeKeychain::isNativeSegwit() const {
+            return isNativeSegwit(_configuration->getString(api::Configuration::KEYCHAIN_ENGINE).value_or(api::KeychainEngines::BIP32_P2PKH));
+        }
+
+        bool BitcoinLikeKeychain::isSegwit(const std::string &keychainEngine) {
+            return keychainEngine == api::KeychainEngines::BIP49_P2SH ||
+                   keychainEngine == api::KeychainEngines::BIP173_P2WPKH ||
+                   keychainEngine == api::KeychainEngines::BIP173_P2WSH;
+        }
+
+        bool BitcoinLikeKeychain::isNativeSegwit(const std::string &keychainEngine) {
+            return keychainEngine == api::KeychainEngines::BIP173_P2WPKH ||
+                   keychainEngine == api::KeychainEngines::BIP173_P2WSH;
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/keychains/CommonBitcoinLikeKeychains.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/keychains/CommonBitcoinLikeKeychains.cpp
@@ -1,0 +1,272 @@
+/*
+ *
+ * CommonBitcoinLikeKeychain
+ * ledger-core
+ *
+ * Created by El Khalil Bellakrid on 05/05/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <iostream>
+
+#include <boost/iostreams/stream.hpp>
+#include <boost/iostreams/device/array.hpp>
+
+#include <cereal/cereal.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/set.hpp>
+
+#include <fmt/format.h>
+
+#include <core/api/Configuration.hpp>
+#include <core/api/ConfigurationDefaults.hpp>
+#include <core/api/DynamicObject.hpp>
+#include <core/api/KeychainEngines.hpp>
+#include <core/collections/Strings.hpp>
+#include <core/utils/DerivationPath.hpp>
+
+#include <bitcoin/BitcoinLikeAddress.hpp>
+#include <bitcoin/keychains/CommonBitcoinLikeKeychains.hpp>
+
+
+namespace ledger {
+    namespace core {
+
+        using namespace std;
+        
+        CommonBitcoinLikeKeychains::CommonBitcoinLikeKeychains(const std::shared_ptr<api::DynamicObject> &configuration,
+                                                               const api::Currency &params,
+                                                               int account,
+                                                               const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &xpub,
+                                                               const std::shared_ptr<Preferences> &preferences)
+                : BitcoinLikeKeychain(configuration, params, account, preferences) {
+            _xpub = xpub;
+
+            {
+                auto localPath = getDerivationScheme().getSchemeTo(DerivationSchemeLevel::NODE)
+                        .setAccountIndex(getAccountIndex())
+                        .setCoinType(getCurrency().bip44CoinType)
+                        .setNode(RECEIVE).getPath();
+                _publicNodeXpub = std::static_pointer_cast<BitcoinLikeExtendedPublicKey>(_xpub)->derive(localPath);
+            }
+            {
+                auto localPath = getDerivationScheme().getSchemeTo(DerivationSchemeLevel::NODE)
+                        .setAccountIndex(getAccountIndex())
+                        .setCoinType(getCurrency().bip44CoinType)
+                        .setNode(CHANGE).getPath();
+                _internalNodeXpub = std::static_pointer_cast<BitcoinLikeExtendedPublicKey>(_xpub)->derive(localPath);
+            }
+
+            // Try to restore the state from preferences
+            auto state = preferences->getData("state", {});
+            if (!state.empty()) {
+                boost::iostreams::array_source my_vec_source(reinterpret_cast<char*>(&state[0]), state.size());
+                boost::iostreams::stream<boost::iostreams::array_source> is(my_vec_source);
+                ::cereal::BinaryInputArchive archive(is);
+                archive(_state);
+            } else {
+                _state.maxConsecutiveReceiveIndex = 0;
+                _state.maxConsecutiveChangeIndex = 0;
+                _state.empty = true;
+            }
+            _observableRange = static_cast<uint32_t>(configuration->getInt(api::Configuration::KEYCHAIN_OBSERVABLE_RANGE)
+                    .value_or(api::ConfigurationDefaults::KEYCHAIN_DEFAULT_OBSERVABLE_RANGE));
+        }
+
+        bool CommonBitcoinLikeKeychains::markPathAsUsed(const DerivationPath &p) {
+            DerivationPath path(p);
+            if (path.getParent().getLastChildNum() == 0) {
+                if (path.getLastChildNum() < _state.maxConsecutiveReceiveIndex ||
+                    _state.nonConsecutiveReceiveIndexes.find(path.getLastChildNum()) != _state.nonConsecutiveReceiveIndexes.end()) {
+                    return false;
+                } else {
+                    if (path.getLastChildNum() == _state.maxConsecutiveReceiveIndex)
+                        _state.maxConsecutiveReceiveIndex += 1;
+                    else
+                        _state.nonConsecutiveReceiveIndexes.insert(path.getLastChildNum());
+                    _state.empty = false;
+                    saveState();
+                    getAllObservableAddresses(path.getLastChildNum(), path.getLastChildNum() + _observableRange);
+                    return true;
+                }
+            } else {
+                if (path.getLastChildNum() < _state.maxConsecutiveChangeIndex ||
+                    _state.nonConsecutiveChangeIndexes.find(path.getLastChildNum()) != _state.nonConsecutiveChangeIndexes.end()) {
+                    return false;
+                } else {
+                    if (path.getLastChildNum() == _state.maxConsecutiveChangeIndex)
+                        _state.maxConsecutiveChangeIndex += 1;
+                    else
+                        _state.nonConsecutiveChangeIndexes.insert(path.getLastChildNum());
+                    _state.empty = false;
+                    saveState();
+                    getAllObservableAddresses(path.getLastChildNum(), path.getLastChildNum() + _observableRange);
+                    return true;
+                }
+            }
+        }
+
+        BitcoinLikeKeychain::Address CommonBitcoinLikeKeychains::getFreshAddress(BitcoinLikeKeychain::KeyPurpose purpose) {
+            return derive(purpose, (purpose == KeyPurpose::RECEIVE ? _state.maxConsecutiveReceiveIndex : _state.maxConsecutiveChangeIndex));
+        }
+
+        bool CommonBitcoinLikeKeychains::isEmpty() const {
+            return _state.empty;
+        }
+
+        std::vector<BitcoinLikeKeychain::Address> CommonBitcoinLikeKeychains::getAllObservableAddresses(uint32_t from, uint32_t to) {
+            auto length = to - from;
+            std::vector<BitcoinLikeKeychain::Address> result;
+            result.reserve((length + 1) * 2);
+            for (auto i = 0; i <= length; i++) {
+                result.push_back(derive(KeyPurpose::RECEIVE, from + i));
+                result.push_back(derive(KeyPurpose::CHANGE, from + i));
+            }
+            return result;
+        }
+
+        std::vector<BitcoinLikeKeychain::Address>
+        CommonBitcoinLikeKeychains::getFreshAddresses(BitcoinLikeKeychain::KeyPurpose purpose, size_t n) {
+            auto startOffset = (purpose == KeyPurpose::RECEIVE) ? _state.maxConsecutiveReceiveIndex : _state.maxConsecutiveChangeIndex;
+            std::vector<BitcoinLikeKeychain::Address> result(n);
+            for (auto i = 0; i < n; i++) {
+                result[i] = derive(purpose, startOffset + i);
+            }
+            return result;
+        }
+
+        Option<BitcoinLikeKeychain::KeyPurpose>
+        CommonBitcoinLikeKeychains::getAddressPurpose(const std::string &address) const {
+            return getAddressDerivationPath(address).flatMap<KeyPurpose>([] (const std::string& p) {
+                DerivationPath derivation(p);
+                if (derivation.getDepth() > 1) {
+                    return Option<KeyPurpose>(derivation.getParent().getLastChildNum() == 0 ? KeyPurpose::RECEIVE : KeyPurpose::CHANGE);
+                } else {
+                    return Option<KeyPurpose>();
+                }
+            });
+        }
+
+        Option<std::string> CommonBitcoinLikeKeychains::getAddressDerivationPath(const std::string &address) const {
+            auto path = getPreferences()->getString(fmt::format("address:{}", address), "");
+            if (path.empty()) {
+                return Option<std::string>();
+            } else {
+                auto derivation = DerivationPath(getExtendedPublicKey()->getRootPath()) + DerivationPath(path);
+                return Option<std::string>(derivation.toString());
+            }
+        }
+
+        std::vector<BitcoinLikeKeychain::Address>
+        CommonBitcoinLikeKeychains::getAllObservableAddresses(BitcoinLikeKeychain::KeyPurpose purpose, uint32_t from,
+                                                            uint32_t to) {
+            auto maxObservableIndex = (purpose == KeyPurpose::CHANGE ? _state.maxConsecutiveChangeIndex + _state.nonConsecutiveChangeIndexes.size() : _state.maxConsecutiveReceiveIndex + _state.nonConsecutiveReceiveIndexes.size()) + _observableRange;
+            auto length = std::min<size_t >(to - from, maxObservableIndex - from);
+            std::vector<BitcoinLikeKeychain::Address> result(length +1);
+            for (auto i = 0; i <= length; i++) {
+                if (purpose == KeyPurpose::RECEIVE) {
+                    result.push_back(derive(KeyPurpose::RECEIVE, from + i));
+                } else {
+                    result.push_back(derive(KeyPurpose::CHANGE, from + i));
+                }
+            }
+            return result;
+        }
+
+        void CommonBitcoinLikeKeychains::saveState() {
+            while (_state.nonConsecutiveReceiveIndexes.find(_state.maxConsecutiveReceiveIndex) != _state.nonConsecutiveReceiveIndexes.end()) {
+                _state.nonConsecutiveReceiveIndexes.erase(_state.maxConsecutiveReceiveIndex);
+                _state.maxConsecutiveReceiveIndex += 1;
+            }
+            while (_state.nonConsecutiveChangeIndexes.find(_state.maxConsecutiveChangeIndex) != _state.nonConsecutiveChangeIndexes.end()) {
+                _state.nonConsecutiveChangeIndexes.erase(_state.maxConsecutiveChangeIndex);
+                _state.maxConsecutiveChangeIndex += 1;
+            }
+            std::stringstream is;
+            ::cereal::BinaryOutputArchive archive(is);
+            archive(_state);
+            auto savedState = is.str();
+            getPreferences()->edit()->putData("state", std::vector<uint8_t>((const uint8_t *)savedState.data(),(const uint8_t *)savedState.data() + savedState.size()))->commit();
+        }
+
+        std::shared_ptr<api::BitcoinLikeExtendedPublicKey> CommonBitcoinLikeKeychains::getExtendedPublicKey() const {
+            return _xpub;
+        }
+
+        std::string CommonBitcoinLikeKeychains::getRestoreKey() const {
+            return _xpub->toBase58();
+        }
+
+        int32_t CommonBitcoinLikeKeychains::getObservableRangeSize() const {
+            return _observableRange;
+        }
+
+        bool CommonBitcoinLikeKeychains::contains(const std::string &address) const {
+            return getAddressDerivationPath(address).nonEmpty();
+        }
+
+        Option<std::vector<uint8_t>> CommonBitcoinLikeKeychains::getPublicKey(const std::string &address) const {
+            auto path = getPreferences()->getString(fmt::format("address:{}", address), "");
+            if (path.empty()) {
+                Option<std::vector<uint8_t>>();
+            }
+            return Option<std::vector<uint8_t>>(_xpub->derivePublicKey(path));
+        }
+
+        BitcoinLikeKeychain::Address CommonBitcoinLikeKeychains::derive(KeyPurpose purpose, off_t index) {
+            auto currency = getCurrency();
+            auto iPurpose = (purpose == KeyPurpose::RECEIVE) ? 0 : 1;
+            auto localPath = getDerivationScheme()
+                    .setAccountIndex(getAccountIndex())
+                    .setCoinType(currency.bip44CoinType)
+                    .setNode(iPurpose)
+                    .setAddressIndex((int) index).getPath().toString();
+
+            auto cacheKey = fmt::format("path:{}", localPath);
+            auto address = getPreferences()->getString(cacheKey, "");
+
+            if (address.empty()) {
+
+                auto p = getDerivationScheme().getSchemeFrom(DerivationSchemeLevel::NODE).shift(1)
+                        .setAccountIndex(getAccountIndex())
+                        .setCoinType(currency.bip44CoinType)
+                        .setNode(iPurpose)
+                        .setAddressIndex((int) index).getPath().toString();
+                auto xpub = iPurpose == KeyPurpose::RECEIVE ? _publicNodeXpub : _internalNodeXpub;
+                address = BitcoinLikeAddress::fromPublicKey(xpub, currency, p, _keychainEngine);
+                // Feed path -> address cache
+                // Feed address -> path cache
+                getPreferences()
+                        ->edit()
+                        ->putString(cacheKey, address)
+                        ->putString(fmt::format("address:{}", address), localPath)
+                        ->commit();
+            }
+            return std::dynamic_pointer_cast<BitcoinLikeAddress>(BitcoinLikeAddress::parse(address, getCurrency(), Option<std::string>(localPath)));
+        }
+    }
+}
+
+CEREAL_CLASS_VERSION(ledger::core::KeychainPersistentState, 0);

--- a/ledger-core-bitcoin/src/bitcoin/keychains/P2PKHBitcoinLikeKeychain.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/keychains/P2PKHBitcoinLikeKeychain.cpp
@@ -1,0 +1,73 @@
+/*
+ *
+ * P2PKHBitcoinLikeKeychain
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 25/01/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/api/KeychainEngines.hpp>
+
+#include <bitcoin/keychains/P2PKHBitcoinLikeKeychain.hpp>
+
+namespace ledger {
+    namespace core {
+
+        P2PKHBitcoinLikeKeychain::P2PKHBitcoinLikeKeychain(const std::shared_ptr<api::DynamicObject> &configuration,
+                                                           const api::Currency &params,
+                                                           int account,
+                                                           const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &xpub,
+                                                           const std::shared_ptr<Preferences> &preferences)
+                : CommonBitcoinLikeKeychains(configuration, params, account, xpub, preferences)
+        {
+            _keychainEngine = api::KeychainEngines::BIP32_P2PKH;
+            getAllObservableAddresses(0, _observableRange);
+        }
+
+        int32_t P2PKHBitcoinLikeKeychain::getOutputSizeAsSignedTxInput() const {
+            int32_t result = 0;
+            //32 bytes of previous transaction hash
+            result += 32;
+            //4 bytes for output index (e.g. 0x000000)
+            result += 4;
+            //1 byte for scriptSig size (e.g. 0x8c)
+            result += 1;
+            //1 byte for length of (DER-encoded signature + hash code type) (e.g. 0x49)
+            result += 1;
+            //72 bytes of DER-signature
+            result += 72;
+            //1 byte for hash core type
+            result += 1;
+            //1 byte length of public key
+            result += 1;
+            //65 bytes for public key
+            result += 65;
+            //4 bytes for the sequence
+            result +=4;
+            return result;
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/keychains/P2SHBitcoinLikeKeychain.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/keychains/P2SHBitcoinLikeKeychain.cpp
@@ -1,0 +1,62 @@
+/*
+ *
+ * P2SHBitcoinLikeKeychain
+ * ledger-core
+ *
+ * Created by El Khalil Bellakrid on 30/04/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/api/KeychainEngines.hpp>
+
+#include <bitcoin/keychains/P2SHBitcoinLikeKeychain.hpp>
+
+namespace ledger {
+    namespace core {
+
+        P2SHBitcoinLikeKeychain::P2SHBitcoinLikeKeychain(const std::shared_ptr<api::DynamicObject> &configuration,
+                                                           const api::Currency &params,
+                                                           int account,
+                                                           const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &xpub,
+                                                           const std::shared_ptr<Preferences> &preferences)
+                : CommonBitcoinLikeKeychains(configuration, params, account, xpub, preferences)
+        {
+            _keychainEngine = api::KeychainEngines::BIP49_P2SH;
+            getAllObservableAddresses(0, _observableRange);
+        }
+
+        int32_t P2SHBitcoinLikeKeychain::getOutputSizeAsSignedTxInput() const {
+            int32_t result = 0;
+            //witness
+            //1 byte for number of stack elements
+            result += 1;
+            //72 byte for signature (length + signature)
+            result += 72;
+            //40 byte of hash script (length + script)
+            result += 40;
+            return result;
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/keychains/P2WPKHBitcoinLikeKeychain.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/keychains/P2WPKHBitcoinLikeKeychain.cpp
@@ -1,0 +1,60 @@
+/*
+ *
+ * P2WPKHBitcoinLikeKeychain
+ *
+ * Created by El Khalil Bellakrid on 19/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/api/KeychainEngines.hpp>
+
+#include <bitcoin/keychains/P2WPKHBitcoinLikeKeychain.hpp>
+
+namespace ledger {
+    namespace core {
+        P2WPKHBitcoinLikeKeychain::P2WPKHBitcoinLikeKeychain(const std::shared_ptr<api::DynamicObject> &configuration,
+                                                             const api::Currency &params,
+                                                             int account,
+                                                             const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &xpub,
+                                                             const std::shared_ptr<Preferences> &preferences)
+                : CommonBitcoinLikeKeychains(configuration, params, account, xpub, preferences)
+        {
+            _keychainEngine = api::KeychainEngines::BIP173_P2WPKH;
+            getAllObservableAddresses(0, _observableRange);
+        }
+
+        int32_t P2WPKHBitcoinLikeKeychain::getOutputSizeAsSignedTxInput() const {
+            int32_t result = 0;
+            //witness
+            //1 byte for number of stack elements
+            result += 1;
+            //72 byte for signature (length + signature)
+            result += 72;
+            //40 byte of hash script (length + script)
+            result += 40;
+            return result;
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/keychains/P2WSHBitcoinLikeKeychain.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/keychains/P2WSHBitcoinLikeKeychain.cpp
@@ -1,0 +1,61 @@
+/*
+ *
+ * P2WSHBitcoinLikeKeychain
+ *
+ * Created by El Khalil Bellakrid on 25/02/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/api/KeychainEngines.hpp>
+
+#include <bitcoin/keychains/P2WSHBitcoinLikeKeychain.hpp>
+#include <bitcoin/keychains/P2WSHBitcoinLikeKeychain.hpp>
+
+namespace ledger {
+    namespace core {
+        P2WSHBitcoinLikeKeychain::P2WSHBitcoinLikeKeychain(const std::shared_ptr<api::DynamicObject> &configuration,
+                                                           const api::Currency &params,
+                                                           int account,
+                                                           const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &xpub,
+                                                           const std::shared_ptr<Preferences> &preferences)
+                : CommonBitcoinLikeKeychains(configuration, params, account, xpub, preferences)
+        {
+            _keychainEngine = api::KeychainEngines::BIP173_P2WSH;
+            getAllObservableAddresses(0, _observableRange);
+        }
+
+        int32_t P2WSHBitcoinLikeKeychain::getOutputSizeAsSignedTxInput() const {
+            int32_t result = 0;
+            //witness
+            //1 byte for number of stack elements
+            result += 1;
+            //72 byte for signature (length + signature)
+            result += 72;
+            //40 byte of hash script (length + script)
+            result += 40;
+            return result;
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/observers/BitcoinLikeBlockchainObserver.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/observers/BitcoinLikeBlockchainObserver.cpp
@@ -1,0 +1,77 @@
+/*
+ *
+ * BitcoinLikeBlockchainObserver.cpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 05/10/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <bitcoin/observers/BitcoinLikeBlockchainObserver.hpp>
+#include <bitcoin/BitcoinLikeAccount.hpp>
+
+namespace ledger {
+    namespace core {
+
+        BitcoinLikeBlockchainObserver::BitcoinLikeBlockchainObserver(
+                const std::shared_ptr<api::ExecutionContext> &context,
+                const std::shared_ptr<api::DynamicObject>& configuration,
+                const std::shared_ptr<spdlog::logger>& logger,
+                const api::Currency &currency,
+                const std::vector<std::string>& matchableKeys) : DedicatedContext(context), ConfigurationMatchable(matchableKeys) {
+            _currency = currency;
+            _configuration = configuration;
+            setConfiguration(configuration);
+            setLogger(logger);
+        }
+
+        void BitcoinLikeBlockchainObserver::putTransaction(const BitcoinLikeBlockchainExplorerTransaction &tx) {
+            std::lock_guard<std::mutex> lock(_lock);
+            for (const auto& account : _accounts) {
+                account->run([account, tx] () {
+                    soci::session sql(account->getWallet()->getDatabase()->getPool());
+                    if (account->putTransaction(sql, tx) != BitcoinLikeAccount::FLAG_TRANSACTION_IGNORED)
+                        account->emitEventsNow();
+                });
+            }
+        }
+
+        void BitcoinLikeBlockchainObserver::putBlock(const BitcoinLikeBlockchainExplorer::Block& block) {
+            std::lock_guard<std::mutex> lock(_lock);
+            for (const auto& account : _accounts) {
+                account->run([account, block] () {
+                    bool shouldEmitNow = false;
+                    {
+                        soci::session sql(account->getWallet()->getDatabase()->getPool());
+                        shouldEmitNow = account->putBlock(sql, block);
+                    }
+                    if (shouldEmitNow)
+                        account->emitEventsNow();
+                });
+            }
+        }
+
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/observers/LedgerApiBitcoinLikeBlockchainObserver.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/observers/LedgerApiBitcoinLikeBlockchainObserver.cpp
@@ -1,0 +1,110 @@
+/*
+ *
+ * LedgerApiBitcoinLikeBlockchainObserver.cpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 05/10/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/api/ConfigurationDefaults.hpp>
+#include <core/api/Configuration.hpp>
+#include <core/math/Fibonacci.hpp>
+#include <core/utils/JSONUtils.hpp>
+
+#include <bitcoin/BitcoinNetworks.hpp>
+#include <bitcoin/observers/LedgerApiBitcoinLikeBlockchainObserver.hpp>
+#include <bitcoin/explorers/WebSocketNotificationParser.hpp>
+
+namespace ledger {
+    namespace core {
+
+        LedgerApiBitcoinLikeBlockchainObserver::LedgerApiBitcoinLikeBlockchainObserver(
+                const std::shared_ptr<api::ExecutionContext> &context,
+                const std::shared_ptr<WebSocketClient> &client,
+                const std::shared_ptr<api::DynamicObject>& configuration,
+                const std::shared_ptr<spdlog::logger>& logger,
+                const api::Currency &currency) :
+            BitcoinLikeBlockchainObserver(context, configuration, logger, currency, {api::Configuration::BLOCKCHAIN_OBSERVER_WS_ENDPOINT}) {
+            _client = client;
+            auto baseUrl = getConfiguration()->getString(api::Configuration::BLOCKCHAIN_OBSERVER_WS_ENDPOINT)
+                    .value_or(api::ConfigurationDefaults::BLOCKCHAIN_OBSERVER_WS_ENDPOINT);
+            _url = fmt::format(baseUrl, networks::getBitcoinLikeNetworkParameters(currency.name).Identifier);
+        }
+
+        void LedgerApiBitcoinLikeBlockchainObserver::onStart() {
+          connect();
+        }
+
+        void LedgerApiBitcoinLikeBlockchainObserver::onStop() {
+            auto self = shared_from_this();
+            run([self] () {
+                if (self->_socket != nullptr)
+                    self->_socket->close();
+                self->_handler = [self] (WebSocketEventType event,
+                               const std::shared_ptr<WebSocketConnection>& connection,
+                               const Option<std::string>& message, Option<api::ErrorCode> code) {
+
+                };
+            });
+        }
+
+        void LedgerApiBitcoinLikeBlockchainObserver::connect() {
+            logger()->info("Connect {} observer", getCurrency().name);
+            auto self = shared_from_this();
+            _handler = [self] (WebSocketEventType event,
+                               const std::shared_ptr<WebSocketConnection>& connection,
+                               const Option<std::string>& message, Option<api::ErrorCode> code) {
+                self->onSocketEvent(event, connection, message, code);
+            };
+            _client->connect(_url, _handler);
+        }
+
+        void LedgerApiBitcoinLikeBlockchainObserver::reconnect() {
+            auto self = shared_from_this();
+            auto delay = std::min(std::max(Fibonacci::compute(_attempt) * 500, 30000), 500);
+            logger()->info("Attempt reconnection in {}ms for {} observer", delay, getCurrency().name);
+            getContext()->delay(LambdaRunnable::make([self] () {
+                self->connect();
+            }), delay);
+        }
+
+
+
+        void LedgerApiBitcoinLikeBlockchainObserver::onMessage(const std::string &message) {
+            auto self = shared_from_this();
+            run([message, self] () {
+                auto result = JSONUtils::parse<WebSocketNotificationParser>(message);
+                result->block.currencyName = self->getCurrency().name;
+                if (result->type == "new-transaction") {
+                    self->putTransaction(result->transaction);
+                } else if (result->type == "new-block") {
+                    self->putBlock(result->block);
+                }
+            });
+        }
+
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/operations/BitcoinLikeOperation.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/operations/BitcoinLikeOperation.cpp
@@ -1,0 +1,74 @@
+/*
+ *
+ * BitcoinLikeOperation
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 12/07/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/operation/OperationDatabaseHelper.hpp>
+
+#include <bitcoin/operations/BitcoinLikeOperation.hpp>
+#include <bitcoin/transactions/BitcoinLikeTransaction.hpp>
+
+namespace ledger {
+    namespace core {
+
+        BitcoinLikeOperation::BitcoinLikeOperation(
+            const std::shared_ptr<const AbstractWallet>& wallet,
+            BitcoinLikeBlockchainExplorerTransaction const& tx)
+                : _tx(std::make_shared<BitcoinLikeTransaction>(wallet->getCurrency())),
+                  _explorerTx(tx)
+        {}
+
+        BitcoinLikeOperation::BitcoinLikeOperation(
+            const std::shared_ptr<BitcoinLikeOperation> &operation,
+            BitcoinLikeBlockchainExplorerTransaction const& tx) 
+                : _tx(std::make_shared<BitcoinLikeTransaction>(operation, operation->getCurrency())),
+                  _explorerTx(tx)
+        {}
+        
+        std::shared_ptr<api::BitcoinLikeTransaction> BitcoinLikeOperation::getTransaction() {
+            return _tx;
+        }
+
+        BitcoinLikeBlockchainExplorerTransaction& BitcoinLikeOperation::getExplorerTransaction() {
+            return _explorerTx;
+        }
+
+        void BitcoinLikeOperation::setExplorerTransaction(BitcoinLikeBlockchainExplorerTransaction const& tx) {
+            _explorerTx = tx;
+        }
+
+        void BitcoinLikeOperation::refreshUid(std::string const&) {
+            uid = OperationDatabaseHelper::createUid(accountUid, _tx->getHash(), type);
+        }
+
+        bool BitcoinLikeOperation::isComplete() {
+            return static_cast<bool>(_tx);
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/operations/BitcoinLikeOperationQuery.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/operations/BitcoinLikeOperationQuery.cpp
@@ -1,0 +1,61 @@
+/*
+ *
+ * BitcoinLikeOperationQuery
+ *
+ * Created by Alexis Le Provost 08/10/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <bitcoin/database/BitcoinLikeTransactionDatabaseHelper.hpp>
+#include <bitcoin/operations/BitcoinLikeOperationQuery.hpp>
+
+namespace ledger {
+    namespace core {
+
+        BitcoinLikeOperationQuery::BitcoinLikeOperationQuery(
+            const std::shared_ptr<api::QueryFilter>& headFilter,
+            const std::shared_ptr<DatabaseSessionPool>& pool,
+            const std::shared_ptr<api::ExecutionContext>& context,
+            const std::shared_ptr<api::ExecutionContext>& mainContext) 
+            : OperationQuery(headFilter, pool, context, mainContext) {
+
+            }
+
+        void BitcoinLikeOperationQuery::inflateCompleteTransaction(
+                soci::session &sql, const std::string &accountUid, BitcoinLikeOperation& operation) {
+            BitcoinLikeBlockchainExplorerTransaction tx;
+            operation.setExplorerTransaction(tx);
+            std::string transactionHash;
+            sql << "SELECT transaction_hash FROM bitcoin_operations WHERE uid = :uid", soci::use(operation.getUid()), soci::into(transactionHash);
+            BitcoinLikeTransactionDatabaseHelper::getTransactionByHash(sql, transactionHash, accountUid, operation.getExplorerTransaction());
+        }
+
+        std::shared_ptr<BitcoinLikeOperation> BitcoinLikeOperationQuery::createOperation(std::shared_ptr<AbstractAccount> &account) {
+             BitcoinLikeBlockchainExplorerTransaction tx;
+
+            return std::make_shared<BitcoinLikeOperation>(account->getWallet(), tx);
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/scripts/BitcoinLikeInternalScript.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/scripts/BitcoinLikeInternalScript.cpp
@@ -1,0 +1,112 @@
+/*
+ *
+ * BitcoinLikeInternalScript.cpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 09/04/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <bitcoin/scripts/BitcoinLikeInternalScript.hpp>
+
+namespace ledger {
+    namespace core {
+
+        static inline const ledger::core::BitcoinLikeScriptChunk& chunkOf(const std::shared_ptr<BitcoinLikeInternalScript> &script,
+                              int index) {
+            auto it = script->getScript().toList().begin();
+            while (index > 0) {
+                index--;
+                it++;
+            }
+            return *it;
+        }
+
+        std::shared_ptr<api::BitcoinLikeScriptChunk> BitcoinLikeInternalScript::head() {
+            return std::make_shared<BitcoinLikeInternalScriptChunk>(shared_from_this(), 0);
+        }
+
+        std::string BitcoinLikeInternalScript::toString() {
+            return _script.toString();
+        }
+
+        BitcoinLikeInternalScript::BitcoinLikeInternalScript(const ledger::core::BitcoinLikeScript &script) : _script(script) {
+
+        }
+
+        const ledger::core::BitcoinLikeScript &BitcoinLikeInternalScript::getScript() const {
+            return _script;
+        }
+
+        bool BitcoinLikeInternalScriptChunk::isOperator() {
+            return getChunk().isOpCode();
+        }
+
+        bool BitcoinLikeInternalScriptChunk::isPushedData() {
+            return getChunk().isBytes();
+        }
+
+        BitcoinLikeInternalScriptChunk::BitcoinLikeInternalScriptChunk(const std::shared_ptr<BitcoinLikeInternalScript> &script,
+                                                             int index) : _chunk(chunkOf(script, index)) {
+            _script = script;
+            _index = index;
+        }
+
+        optional<api::BitcoinLikeScriptOperator> BitcoinLikeInternalScriptChunk::getOperator() {
+            auto &chunk = getChunk();
+            if (chunk.isBytes()) {
+                api::BitcoinLikeScriptOperator op(btccore::GetOpName(chunk.getOpCode()), (uint8_t) chunk.getOpCode());
+                return Option<api::BitcoinLikeScriptOperator>(op).toOptional();
+            }
+            return Option<api::BitcoinLikeScriptOperator>().toOptional();
+        }
+
+        optional<std::vector<uint8_t>> BitcoinLikeInternalScriptChunk::getPushedData() {
+            auto &chunk = getChunk();
+            if (chunk.isBytes()) return Option<std::vector<uint8_t> >(chunk.getBytes()).toOptional();
+            return Option<std::vector<uint8_t> >().toOptional();
+        }
+
+        std::shared_ptr<api::BitcoinLikeScriptChunk> BitcoinLikeInternalScriptChunk::next() {
+            return std::make_shared<BitcoinLikeInternalScriptChunk>(_script, _index + 1);
+        }
+
+        bool BitcoinLikeInternalScriptChunk::hasNext() {
+            return _index + 1 < _script->getScript().toList().size();
+        }
+
+        const ledger::core::BitcoinLikeScriptChunk &BitcoinLikeInternalScriptChunk::getChunk() const {
+            return _chunk;
+        }
+
+        std::shared_ptr<api::BitcoinLikeScript> api::BitcoinLikeScript::parse(const std::vector<uint8_t> &data) {
+            auto result = ledger::core::BitcoinLikeScript::parse(data);
+            if (result.isFailure())
+                throw make_exception(api::ErrorCode::RUNTIME_ERROR, result.getFailure().getMessage());
+            return std::make_shared<BitcoinLikeInternalScript>(result.getValue());
+        }
+
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/scripts/BitcoinLikeScript.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/scripts/BitcoinLikeScript.cpp
@@ -1,0 +1,263 @@
+/*
+ *
+ * BitcoinLikeScript.cpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 03/04/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/api/Currency.hpp>
+#include <core/api/KeychainEngines.hpp>
+#include <core/bytes/BytesReader.hpp>
+#include <core/bytes/BytesWriter.hpp>
+#include <core/crypto/HASH160.hpp>
+#include <core/utils/Hex.hpp>
+
+#include <bitcoin/BitcoinNetworks.hpp>
+#include <bitcoin/bech32/Bech32Factory.hpp>
+#include <bitcoin/scripts/BitcoinLikeScript.hpp>
+
+namespace ledger {
+    namespace core {
+
+        Try<BitcoinLikeScript> BitcoinLikeScript::parse(const std::vector<uint8_t> &script,
+                                                        const BitcoinLikeScriptConfiguration &configuration) {
+            return Try<BitcoinLikeScript>::from([&]() -> BitcoinLikeScript {
+                BytesReader reader(script);
+                BitcoinLikeScript s(configuration);
+                while (reader.hasNext()) {
+                    auto byte = reader.readNextByte();
+                    if (byte >= 0x01 && byte <= 0x4b) {
+                        s << reader.read(byte);
+                    } else if (byte == btccore::OP_PUSHDATA1) {
+                        s << reader.read(reader.readNextByte());
+                    } else if (byte == btccore::OP_PUSHDATA2) {
+                        s << reader.read(reader.readNextBeBigInt(2).toUnsignedInt());
+                    } else if (byte == btccore::OP_PUSHDATA4) {
+                        s << reader.read(reader.readNextBeBigInt(4).toUnsignedInt());
+                    } else {
+                        s << (btccore::opcodetype) byte;
+                    }
+                }
+                return s;
+            });
+        }
+
+        BitcoinLikeScript &BitcoinLikeScript::operator<<(btccore::opcodetype op_code) {
+            _chunks.push_back(BitcoinLikeScriptChunk(op_code));
+            return *this;
+        }
+
+        BitcoinLikeScript &BitcoinLikeScript::operator<<(const std::vector<uint8_t> &bytes) {
+            _chunks.push_back(BitcoinLikeScriptChunk(bytes));
+            return *this;
+        }
+
+        std::string BitcoinLikeScript::toString() const {
+            std::stringstream ss;
+            bool first = true;
+            for (auto &chunk : _chunks) {
+                if (!first) {
+                    ss << " ";
+                } else {
+                    first = false;
+                }
+                if (chunk.isBytes()) {
+                    const auto &bytes = chunk.getBytes();
+                    ss << "PUSHDATA(" << bytes.size() << ")[" << hex::toString(bytes) << "]";
+                } else {
+                    ss << btccore::GetOpName(chunk.getOpCode());
+                }
+            }
+            return ss.str();
+        }
+
+        std::vector<uint8_t> BitcoinLikeScript::serialize() const {
+            BytesWriter writer;
+            for (auto &chunk : _chunks) {
+                if (chunk.isBytes()) {
+                    auto &bytes = chunk.getBytes();
+                    auto size = bytes.size();
+                    if (size <= 0x75) {
+                        writer.writeByte((uint8_t) size).writeByteArray(bytes);
+                    } else if (size <= 0xFF) {
+                        writer.writeByte((uint8_t) size).writeByteArray(bytes);
+                    } else if (size <= 0xFFFF) {
+                        writer.writeLeValue<uint16_t>((uint16_t) size).writeByteArray(bytes);
+                    } else {
+                        writer.writeLeValue<uint32_t>((uint32_t) size).writeByteArray(bytes);
+                    }
+                } else {
+                    writer.writeByte(chunk.getOpCode());
+                }
+            }
+            return writer.toByteArray();
+        }
+
+        const std::list<BitcoinLikeScriptChunk> &BitcoinLikeScript::toList() const {
+            return _chunks;
+        }
+
+        BitcoinLikeScript
+        BitcoinLikeScript::fromAddress(const std::string &address, const api::Currency &currency) {
+            auto a = std::dynamic_pointer_cast<BitcoinLikeAddress>(BitcoinLikeAddress::parse(address, currency));
+            BitcoinLikeScript script;
+            if (a->isP2WPKH() || a->isP2WSH()) {
+                script << btccore::OP_0 << a->getHash160();
+            } else if (a->isP2PKH()) {
+                script << btccore::OP_DUP << btccore::OP_HASH160 << a->getHash160() << btccore::OP_EQUALVERIFY
+                       << btccore::OP_CHECKSIG;
+            } else if (a->isP2SH()) {
+                script << btccore::OP_HASH160 << a->getHash160() << btccore::OP_EQUAL;
+            } else {
+                throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Cannot create output script from {}.", address);
+            }
+
+            auto &additionalBIPS = networks::getBitcoinLikeNetworkParameters(currency.name).AdditionalBIPs;
+            auto it = std::find(additionalBIPS.begin(), additionalBIPS.end(), "BIP115");
+            if (it != additionalBIPS.end()) {
+                script << hex::toByteArray(networks::BIP115_PARAMETERS.blockHash)
+                       << networks::BIP115_PARAMETERS.blockHeight
+                       << btccore::OP_CHECKBLOCKATHEIGHT;
+            }
+
+            return script;
+        }
+
+        bool BitcoinLikeScript::isP2PKH() const {
+            if (_configuration.isSigned) {
+                return _configuration.keychainEngine == api::KeychainEngines::BIP32_P2PKH;
+            }
+            return size() >= 5 && (*this)[0].isEqualTo(btccore::OP_DUP) && (*this)[1].isEqualTo(btccore::OP_HASH160)
+                   && (*this)[2].sizeEqualsTo(20) && (*this)[3].isEqualTo(btccore::OP_EQUALVERIFY)
+                   && (*this)[4].isEqualTo(btccore::OP_CHECKSIG);
+        }
+
+        bool BitcoinLikeScript::isP2SH() const {
+            if (_configuration.isSigned) {
+                return _configuration.keychainEngine == api::KeychainEngines::BIP49_P2SH;
+            }
+            return (size() >= 3 && (*this)[0].isEqualTo(btccore::OP_HASH160) && (*this)[1].sizeEqualsTo(20)
+                    && (*this)[22].isEqualTo(btccore::OP_EQUAL));
+        }
+
+        bool BitcoinLikeScript::isP2WPKH() const {
+            if (_configuration.isSigned) {
+                return _configuration.keychainEngine == api::KeychainEngines::BIP173_P2WPKH;
+            }
+            return (size() == 2 && (*this)[0].isEqualTo(btccore::OP_0) && (*this)[1].sizeEqualsTo(20));
+        }
+
+        bool BitcoinLikeScript::isP2WSH() const {
+            if (_configuration.isSigned) {
+                return _configuration.keychainEngine == api::KeychainEngines::BIP173_P2WSH;
+            }
+            return (size() == 2 && (*this)[0].isEqualTo(btccore::OP_0) && (*this)[1].sizeEqualsTo(32));
+        }
+
+        std::size_t BitcoinLikeScript::size() const {
+            return _chunks.size();
+        }
+
+        const BitcoinLikeScriptChunk &BitcoinLikeScript::operator[](int index) const {
+            auto size = this->size();
+            auto it = _chunks.begin();
+            for (auto i = 0; i < index; i++)
+                it++;
+            return *it; // Make it breakable on purpose if you are trying to fetch something which doesn't exist the list will throw an exception
+        }
+
+        Option<BitcoinLikeAddress>
+        BitcoinLikeScript::parseAddress(const api::Currency &currency) const {
+            const auto &params = networks::getBitcoinLikeNetworkParameters(currency.name);
+            HashAlgorithm hashAlgorithm(params.Identifier);
+            if (isP2SH()) {
+                //Signed : <ScriptSig> <PubKey>
+                if (_configuration.isSigned) {
+                    std::vector<uint8_t> script = {0x00, 0x14};
+                    //Hash160 of public key
+                    auto publicKeyHash160 = HASH160::hash((*this)[1].getBytes(), hashAlgorithm);
+                    script.insert(script.end(), publicKeyHash160.begin(), publicKeyHash160.end());
+                    return Option<BitcoinLikeAddress>(
+                            BitcoinLikeAddress(currency,
+                                               HASH160::hash(script, hashAlgorithm),
+                                               api::KeychainEngines::BIP49_P2SH));
+                }
+                //Unsigned : OP_HASH160 <PubKeyHash> OP_EQUAL
+                return Option<BitcoinLikeAddress>(
+                        BitcoinLikeAddress(currency, (*this)[1].getBytes(), api::KeychainEngines::BIP49_P2SH));
+            } else if (isP2PKH()) {
+                // Signed : <ScriptSig> <PubKey>
+                auto index = _configuration.isSigned ? 1 : 2;
+                // Unsigned : OP_DUP OP_HASH160 <PubKeyHash> OP_EQUALVERIFY OP_CHECKSIG
+                return Option<BitcoinLikeAddress>(
+                        BitcoinLikeAddress(currency, (*this)[index].getBytes(), api::KeychainEngines::BIP32_P2PKH));
+            } else if (isP2WPKH()) {
+                // <OP_0> <PubKeyHash>
+                return Option<BitcoinLikeAddress>(
+                        BitcoinLikeAddress(currency, (*this)[1].getBytes(), api::KeychainEngines::BIP173_P2WPKH));
+            } else if (isP2WSH()) {
+                // <OP_0> <WitnessScript>
+                return Option<BitcoinLikeAddress>(
+                        BitcoinLikeAddress(currency, (*this)[1].getBytes(), api::KeychainEngines::BIP173_P2WSH));
+            }
+            return Option<BitcoinLikeAddress>();
+        }
+
+
+        BitcoinLikeScriptChunk::BitcoinLikeScriptChunk(BitcoinLikeScriptOpCode op) : _value(op) {
+
+        }
+
+        BitcoinLikeScriptChunk::BitcoinLikeScriptChunk(const std::vector<uint8_t> &bytes) : _value(bytes) {
+
+        }
+
+        const std::vector<uint8_t> &BitcoinLikeScriptChunk::getBytes() const {
+            return _value.getLeft();
+        }
+
+        bool BitcoinLikeScriptChunk::isBytes() const {
+            return _value.isLeft();
+        }
+
+        BitcoinLikeScriptOpCode BitcoinLikeScriptChunk::getOpCode() const {
+            return _value.getRight();
+        }
+
+        bool BitcoinLikeScriptChunk::isOpCode() const {
+            return _value.isRight();
+        }
+
+        bool BitcoinLikeScriptChunk::isEqualTo(btccore::opcodetype code) const {
+            return isOpCode() && getOpCode() == code;
+        }
+
+        bool BitcoinLikeScriptChunk::sizeEqualsTo(std::size_t size) const {
+            return isBytes() && getBytes().size() == size;
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/scripts/BitcoinLikeScriptOperators.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/scripts/BitcoinLikeScriptOperators.cpp
@@ -1,0 +1,291 @@
+/*
+ *
+ * operators.cpp.cpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 03/04/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <bitcoin/scripts/BitcoinLikeScriptOperators.hpp>
+
+namespace ledger {
+    namespace core {
+        namespace btccore {
+            const char *GetOpName(opcodetype opcode) {
+                switch (opcode) {
+                    // push value
+                    case OP_0                      :
+                        return "OP_0";
+                    case OP_PUSHDATA1              :
+                        return "OP_PUSHDATA1";
+                    case OP_PUSHDATA2              :
+                        return "OP_PUSHDATA2";
+                    case OP_PUSHDATA4              :
+                        return "OP_PUSHDATA4";
+                    case OP_1NEGATE                :
+                        return "-1";
+                    case OP_RESERVED               :
+                        return "OP_RESERVED";
+                    case OP_1                      :
+                        return "1";
+                    case OP_2                      :
+                        return "2";
+                    case OP_3                      :
+                        return "3";
+                    case OP_4                      :
+                        return "4";
+                    case OP_5                      :
+                        return "5";
+                    case OP_6                      :
+                        return "6";
+                    case OP_7                      :
+                        return "7";
+                    case OP_8                      :
+                        return "8";
+                    case OP_9                      :
+                        return "9";
+                    case OP_10                     :
+                        return "10";
+                    case OP_11                     :
+                        return "11";
+                    case OP_12                     :
+                        return "12";
+                    case OP_13                     :
+                        return "13";
+                    case OP_14                     :
+                        return "14";
+                    case OP_15                     :
+                        return "15";
+                    case OP_16                     :
+                        return "16";
+
+                        // control
+                    case OP_NOP                    :
+                        return "OP_NOP";
+                    case OP_VER                    :
+                        return "OP_VER";
+                    case OP_IF                     :
+                        return "OP_IF";
+                    case OP_NOTIF                  :
+                        return "OP_NOTIF";
+                    case OP_VERIF                  :
+                        return "OP_VERIF";
+                    case OP_VERNOTIF               :
+                        return "OP_VERNOTIF";
+                    case OP_ELSE                   :
+                        return "OP_ELSE";
+                    case OP_ENDIF                  :
+                        return "OP_ENDIF";
+                    case OP_VERIFY                 :
+                        return "OP_VERIFY";
+                    case OP_RETURN                 :
+                        return "OP_RETURN";
+
+                        // stack ops
+                    case OP_TOALTSTACK             :
+                        return "OP_TOALTSTACK";
+                    case OP_FROMALTSTACK           :
+                        return "OP_FROMALTSTACK";
+                    case OP_2DROP                  :
+                        return "OP_2DROP";
+                    case OP_2DUP                   :
+                        return "OP_2DUP";
+                    case OP_3DUP                   :
+                        return "OP_3DUP";
+                    case OP_2OVER                  :
+                        return "OP_2OVER";
+                    case OP_2ROT                   :
+                        return "OP_2ROT";
+                    case OP_2SWAP                  :
+                        return "OP_2SWAP";
+                    case OP_IFDUP                  :
+                        return "OP_IFDUP";
+                    case OP_DEPTH                  :
+                        return "OP_DEPTH";
+                    case OP_DROP                   :
+                        return "OP_DROP";
+                    case OP_DUP                    :
+                        return "OP_DUP";
+                    case OP_NIP                    :
+                        return "OP_NIP";
+                    case OP_OVER                   :
+                        return "OP_OVER";
+                    case OP_PICK                   :
+                        return "OP_PICK";
+                    case OP_ROLL                   :
+                        return "OP_ROLL";
+                    case OP_ROT                    :
+                        return "OP_ROT";
+                    case OP_SWAP                   :
+                        return "OP_SWAP";
+                    case OP_TUCK                   :
+                        return "OP_TUCK";
+
+                        // splice ops
+                    case OP_CAT                    :
+                        return "OP_CAT";
+                    case OP_SUBSTR                 :
+                        return "OP_SUBSTR";
+                    case OP_LEFT                   :
+                        return "OP_LEFT";
+                    case OP_RIGHT                  :
+                        return "OP_RIGHT";
+                    case OP_SIZE                   :
+                        return "OP_SIZE";
+
+                        // bit logic
+                    case OP_INVERT                 :
+                        return "OP_INVERT";
+                    case OP_AND                    :
+                        return "OP_AND";
+                    case OP_OR                     :
+                        return "OP_OR";
+                    case OP_XOR                    :
+                        return "OP_XOR";
+                    case OP_EQUAL                  :
+                        return "OP_EQUAL";
+                    case OP_EQUALVERIFY            :
+                        return "OP_EQUALVERIFY";
+                    case OP_RESERVED1              :
+                        return "OP_RESERVED1";
+                    case OP_RESERVED2              :
+                        return "OP_RESERVED2";
+
+                        // numeric
+                    case OP_1ADD                   :
+                        return "OP_1ADD";
+                    case OP_1SUB                   :
+                        return "OP_1SUB";
+                    case OP_2MUL                   :
+                        return "OP_2MUL";
+                    case OP_2DIV                   :
+                        return "OP_2DIV";
+                    case OP_NEGATE                 :
+                        return "OP_NEGATE";
+                    case OP_ABS                    :
+                        return "OP_ABS";
+                    case OP_NOT                    :
+                        return "OP_NOT";
+                    case OP_0NOTEQUAL              :
+                        return "OP_0NOTEQUAL";
+                    case OP_ADD                    :
+                        return "OP_ADD";
+                    case OP_SUB                    :
+                        return "OP_SUB";
+                    case OP_MUL                    :
+                        return "OP_MUL";
+                    case OP_DIV                    :
+                        return "OP_DIV";
+                    case OP_MOD                    :
+                        return "OP_MOD";
+                    case OP_LSHIFT                 :
+                        return "OP_LSHIFT";
+                    case OP_RSHIFT                 :
+                        return "OP_RSHIFT";
+                    case OP_BOOLAND                :
+                        return "OP_BOOLAND";
+                    case OP_BOOLOR                 :
+                        return "OP_BOOLOR";
+                    case OP_NUMEQUAL               :
+                        return "OP_NUMEQUAL";
+                    case OP_NUMEQUALVERIFY         :
+                        return "OP_NUMEQUALVERIFY";
+                    case OP_NUMNOTEQUAL            :
+                        return "OP_NUMNOTEQUAL";
+                    case OP_LESSTHAN               :
+                        return "OP_LESSTHAN";
+                    case OP_GREATERTHAN            :
+                        return "OP_GREATERTHAN";
+                    case OP_LESSTHANOREQUAL        :
+                        return "OP_LESSTHANOREQUAL";
+                    case OP_GREATERTHANOREQUAL     :
+                        return "OP_GREATERTHANOREQUAL";
+                    case OP_MIN                    :
+                        return "OP_MIN";
+                    case OP_MAX                    :
+                        return "OP_MAX";
+                    case OP_WITHIN                 :
+                        return "OP_WITHIN";
+
+                        // crypto
+                    case OP_RIPEMD160              :
+                        return "OP_RIPEMD160";
+                    case OP_SHA1                   :
+                        return "OP_SHA1";
+                    case OP_SHA256                 :
+                        return "OP_SHA256";
+                    case OP_HASH160                :
+                        return "OP_HASH160";
+                    case OP_HASH256                :
+                        return "OP_HASH256";
+                    case OP_CODESEPARATOR          :
+                        return "OP_CODESEPARATOR";
+                    case OP_CHECKSIG               :
+                        return "OP_CHECKSIG";
+                    case OP_CHECKSIGVERIFY         :
+                        return "OP_CHECKSIGVERIFY";
+                    case OP_CHECKMULTISIG          :
+                        return "OP_CHECKMULTISIG";
+                    case OP_CHECKMULTISIGVERIFY    :
+                        return "OP_CHECKMULTISIGVERIFY";
+
+                        // expansion
+                    case OP_NOP1                   :
+                        return "OP_NOP1";
+                    case OP_CHECKLOCKTIMEVERIFY    :
+                        return "OP_CHECKLOCKTIMEVERIFY";
+                    case OP_CHECKSEQUENCEVERIFY    :
+                        return "OP_CHECKSEQUENCEVERIFY";
+                    case OP_NOP4                   :
+                        return "OP_NOP4";
+                    case OP_CHECKBLOCKATHEIGHT                   :
+                        return "OP_CHECKBLOCKATHEIGHT";
+                    case OP_NOP6                   :
+                        return "OP_NOP6";
+                    case OP_NOP7                   :
+                        return "OP_NOP7";
+                    case OP_NOP8                   :
+                        return "OP_NOP8";
+                    case OP_NOP9                   :
+                        return "OP_NOP9";
+                    case OP_NOP10                  :
+                        return "OP_NOP10";
+
+                    case OP_INVALIDOPCODE          :
+                        return "OP_INVALIDOPCODE";
+
+                        // Note:
+                        //  The template matching params OP_SMALLINTEGER/etc are defined in opcodetype enum
+                        //  as kind of implementation hack, they are *NOT* real opcodes.  If found in real
+                        //  Script, just let the default: case deal with them.
+
+                    default:
+                        return "OP_UNKNOWN";
+                }
+            }
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/synchronizers/BitcoinLikeBlockchainExplorerAccountSynchronizer.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/synchronizers/BitcoinLikeBlockchainExplorerAccountSynchronizer.cpp
@@ -1,0 +1,94 @@
+/*
+ *
+ * BlockchainExplorerAccountSynchronizer
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 26/05/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <bitcoin/BitcoinLikeAccount.hpp>
+#include <bitcoin/synchronizers/BitcoinLikeBlockchainExplorerAccountSynchronizer.hpp>
+
+namespace ledger {
+    namespace core {
+
+        BlockchainExplorerAccountSynchronizer::BlockchainExplorerAccountSynchronizer(
+                const std::shared_ptr<Services> &services,
+                const std::shared_ptr<BitcoinLikeBlockchainExplorer> &explorer) :
+                DedicatedContext(services->getDispatcher()
+                                         ->getThreadPoolExecutionContext("synchronizers")) {
+            _explorer = explorer;
+        }
+
+        void BlockchainExplorerAccountSynchronizer::updateCurrentBlock(std::shared_ptr<AbstractBlockchainExplorerAccountSynchronizer::SynchronizationBuddy> &buddy,
+                                                                       const std::shared_ptr<api::ExecutionContext> &context) {
+            _explorer->getCurrentBlock().onComplete(context, [buddy] (const TryPtr<BitcoinLikeBlockchainExplorer::Block>& block) {
+                if (block.isSuccess()) {
+                    soci::session sql(buddy->account->getWallet()->getDatabase()->getPool());
+                    buddy->account->putBlock(sql, *block.getValue());
+                }
+            });
+        }
+
+        void BlockchainExplorerAccountSynchronizer::updateTransactionsToDrop(soci::session &sql,
+                                                                             std::shared_ptr<SynchronizationBuddy> &buddy,
+                                                                             const std::string &accountUid) {
+            //Get all transactions in DB that may be dropped (txs without block_uid)
+            soci::rowset<soci::row> rows = (sql.prepare << "SELECT op.uid, btc_op.transaction_hash FROM operations AS op "
+                                                            "LEFT OUTER JOIN bitcoin_operations AS btc_op ON btc_op.uid = op.uid "
+                                                            "WHERE op.block_uid IS NULL AND op.account_uid = :uid ", soci::use(accountUid));
+
+            for (auto &row : rows) {
+                if (row.get_indicator(0) != soci::i_null && row.get_indicator(1) != soci::i_null) {
+                    buddy->transactionsToDrop.insert(std::pair<std::string, std::string>(row.get<std::string>(1), row.get<std::string>(0)));
+                }
+            }
+
+        }
+
+
+        void BlockchainExplorerAccountSynchronizer::reset(const std::shared_ptr<BitcoinLikeAccount>& account,
+                                                          const std::chrono::system_clock::time_point& toDate) {
+
+        }
+
+        std::shared_ptr<ProgressNotifier<Unit>> BlockchainExplorerAccountSynchronizer::synchronize(const std::shared_ptr<BitcoinLikeAccount>& account) {
+            return synchronizeAccount(account);
+        }
+
+        bool BlockchainExplorerAccountSynchronizer::isSynchronizing() const {
+            return _notifier != nullptr;
+        }
+
+        std::shared_ptr<BlockchainAccountSynchronizer> BlockchainExplorerAccountSynchronizer::getSharedFromThis() {
+            return shared_from_this();
+        }
+
+        std::shared_ptr<api::ExecutionContext> BlockchainExplorerAccountSynchronizer::getSynchronizerContext() {
+            return getContext();
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/transactions/BitcoinLikeStrategyUTXOPicker.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/transactions/BitcoinLikeStrategyUTXOPicker.cpp
@@ -1,0 +1,596 @@
+/*
+ *
+ * BitcoinLikeStrategyUTXOPicker.cpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 29/03/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <random>
+
+#include <bitcoin/api/BitcoinLikeScript.hpp>
+#include <bitcoin/api/BitcoinLikeScriptChunk.hpp>
+#include <bitcoin/scripts/BitcoinLikeInternalScript.hpp>
+#include <bitcoin/transactions/BitcoinLikeStrategyUTXOPicker.hpp>
+#include <bitcoin/transactions/BitcoinLikeTransaction.hpp>
+
+namespace ledger {
+    namespace core {
+
+        BitcoinLikeStrategyUTXOPicker::BitcoinLikeStrategyUTXOPicker(const std::shared_ptr<api::ExecutionContext> &context,
+                                                                     const api::Currency &currency) : BitcoinLikeUTXOPicker(context, currency) {
+
+        }
+
+        Future<BitcoinLikeUTXOPicker::UTXODescriptorList>
+        BitcoinLikeStrategyUTXOPicker::filterInputs(const std::shared_ptr<BitcoinLikeUTXOPicker::Buddy> &buddy) {
+            return computeAggregatedAmount(buddy).flatMap<UTXODescriptorList>(getContext(), [=] (const BigInt& a) -> Future<UTXODescriptorList> {
+                buddy->logger->info("GET UTXO");
+                return buddy->getUTXO().map<UTXODescriptorList>(getContext(), [=] (const std::vector<std::shared_ptr<api::BitcoinLikeOutput>>& UTXO) -> UTXODescriptorList {
+                    buddy->logger->info("GOT UTXO");
+                    if (UTXO.size() == 0)
+                        throw make_exception(api::ErrorCode::NOT_ENOUGH_FUNDS, "There is no UTXO on this account.");
+                    //If wipe mode no matter which strategy we use, let's use filterWithDeepFirst (for the moment)
+                    if (buddy->request.wipe) {
+                        return filterWithDeepFirst(buddy, UTXO, a);
+                    }
+                    auto picker = buddy->request.UTXOPicker.getValue();
+                    const api::BitcoinLikePickingStrategy strategy = std::get<0>(picker);
+                    switch (strategy) {
+                        case api::BitcoinLikePickingStrategy::DEEP_OUTPUTS_FIRST:
+                            return filterWithDeepFirst(buddy, UTXO, a);
+                        case api::BitcoinLikePickingStrategy::OPTIMIZE_SIZE:
+                            return filterWithOptimizeSize(buddy, UTXO, a);
+                        case api::BitcoinLikePickingStrategy::MERGE_OUTPUTS:
+                            return filterWithMergeOutputs(buddy, UTXO, a);
+                    }
+                });
+            });
+        }
+
+        Future<BigInt> BitcoinLikeStrategyUTXOPicker::computeAggregatedAmount(
+                const std::shared_ptr<BitcoinLikeUTXOPicker::Buddy> &buddy) {
+            using UDList = std::list<BitcoinLikeUTXOPicker::UTXODescriptor>;
+            static std::function<Future<BigInt> (std::shared_ptr<api::ExecutionContext>, UDList::const_iterator, BigInt, const std::shared_ptr<Buddy>& buddy)> go
+                    = [] (std::shared_ptr<api::ExecutionContext> context, const UDList::const_iterator it, BigInt v, const std::shared_ptr<Buddy>& buddy) mutable -> Future<BigInt> {
+                        if (it == buddy->request.inputs.end())
+                            return Future<BigInt>::successful(v);
+                        const auto& i = *it;
+                        const auto outputIndex = std::get<1>(i);
+                        buddy->logger->info("GET TX 1");
+                        return buddy->getTransaction(String(std::get<0>(i))).flatMap<BigInt>(context, [=] (const std::shared_ptr<BitcoinLikeBlockchainExplorerTransaction>& tx) -> Future<BigInt> {
+                            buddy->logger->info("GOT TX 1");
+                            auto newIt = it;
+                            return go(context, newIt++, v + tx->outputs[outputIndex].value, buddy);
+                        });
+            };
+            return go(getContext(), buddy->request.inputs.begin(), BigInt(), buddy);
+        }
+
+        BitcoinLikeUTXOPicker::UTXODescriptorList
+        BitcoinLikeStrategyUTXOPicker::filterWithDeepFirst(const std::shared_ptr<BitcoinLikeUTXOPicker::Buddy> &buddy,
+                                                           const std::vector<std::shared_ptr<api::BitcoinLikeOutput>> &UTXO,
+                                                           const BigInt &aggregatedAmount) {
+            // First add block height and time information to the list of UTXO
+            using RichUTXO = std::tuple<uint64_t, std::shared_ptr<api::BitcoinLikeOutput>>;
+            using RichUTXOList = std::vector<RichUTXO>;
+            std::shared_ptr<RichUTXOList> richUTXO = std::make_shared<RichUTXOList>();
+
+            for (auto &u : UTXO) {
+                uint64_t block_height = u->getBlockHeight().value_or(std::numeric_limits<uint64_t>::max());
+                RichUTXO curr_richUTXO{block_height, u};
+                richUTXO->emplace_back(std::move(curr_richUTXO));
+            }
+
+            // Sort the list by deep
+            std::sort(richUTXO->begin(), richUTXO->end(), [] (const RichUTXO& a, const RichUTXO& b) -> bool {
+                return std::get<0>(a) < std::get<0>(b);
+            });
+
+            // Aggregate the amount needed by the transaction
+            BigInt amount = aggregatedAmount;
+            auto pickedInputs = 0;
+            for (const RichUTXO & ru : (*richUTXO)) {
+                const std::shared_ptr<BitcoinLikeOutput>& output = std::dynamic_pointer_cast<BitcoinLikeOutput>(std::get<1>(ru));
+                amount = amount + output->value();
+                buddy->logger->debug("Collected: {} Needed: {}", amount.toString(), buddy->outputAmount.toString());
+                pickedInputs += 1;
+                bool computeOutputAmount = pickedInputs == UTXO.size();
+                if (hasEnough(buddy, amount, pickedInputs, computeOutputAmount)) {
+                    break;
+                }
+                if (pickedInputs >= richUTXO->size() && !buddy->request.wipe) {
+                    throw make_exception(api::ErrorCode::NOT_ENOUGH_FUNDS, "Cannot gather enough funds.");
+                }
+            }
+
+            buddy->logger->debug("Require {} inputs to complete the transaction with {} for {}", pickedInputs, amount.toString(), buddy->outputAmount.toString());
+
+            // Build UTXODescriptorList from our RichUTXOList
+            UTXODescriptorList out;
+
+            for (auto index = 0; index < pickedInputs; index++) {
+                const std::shared_ptr<BitcoinLikeOutput>& output =
+                        std::dynamic_pointer_cast<BitcoinLikeOutput>(std::get<1>((*richUTXO)[index]));
+                //Fix: use uniform initialization
+                UTXODescriptor UTXODescriptor{output->getTransactionHash(), output->getOutputIndex(), std::get<1>(buddy->request.UTXOPicker.getValue())};
+                out.emplace_back(std::move(UTXODescriptor));
+            }
+
+            return out;
+        }
+
+        bool BitcoinLikeStrategyUTXOPicker::hasEnough(const std::shared_ptr<BitcoinLikeUTXOPicker::Buddy> &buddy,
+                                                      const BigInt &aggregatedAmount,
+                                                      int inputCount,
+                                                      bool computeOutputAmount) {
+            if (buddy->outputAmount > aggregatedAmount) return false;
+            // TODO Handle multiple outputs
+
+            auto computeAmountWithFees = [&] (int addedOutputCount) -> BigInt {
+                auto outputCount = buddy->request.outputs.size() + addedOutputCount;
+                auto size = BitcoinLikeTransaction::estimateSize(inputCount,
+                                                                    outputCount,
+                                                                    getCurrency(),
+                                                                    buddy->keychain->getKeychainEngine());
+                buddy->logger->debug("Estimate for {} inputs with {} outputs", inputCount,  buddy->request.outputs.size() + addedOutputCount);
+                buddy->logger->debug("Estimated size {} <> {}", size.Min, size.Max);
+                return buddy->outputAmount + (*buddy->request.feePerByte * BigInt(size.Max));
+            };
+
+            // Check the amount of fees needed when we don't need to add a change output to the transaction
+            auto minimumNeededAmount = computeAmountWithFees(0);
+            buddy->logger->debug("Minimum required with fees {} got {}", minimumNeededAmount.toString(), aggregatedAmount.toString());
+            if (buddy->outputAmount > minimumNeededAmount || aggregatedAmount < minimumNeededAmount) return false;
+
+            //No need for change if we're wiping
+            if(!buddy->request.wipe) {
+                BigInt changeAmount = aggregatedAmount - minimumNeededAmount;
+                buddy->changeAmount = changeAmount;
+                buddy->logger->debug(
+                    "Change amount {}, dust {}",
+                    changeAmount.toString(),
+                    BigInt(networks::getBitcoinLikeNetworkParameters(getCurrency().name).DustAmount).toString());
+                if (changeAmount > BigInt(networks::getBitcoinLikeNetworkParameters(getCurrency().name).DustAmount)) {
+                    // The change amount is bigger than the dust so we need to create a change output,
+                    // let's see if we have enough fees to handle this output
+                    auto minimumNeededAmountWithChange = computeAmountWithFees(1);
+                    buddy->changeAmount = aggregatedAmount - minimumNeededAmountWithChange;
+                    buddy->logger->debug("Minimum required with change {} got {}", minimumNeededAmountWithChange.toString(), aggregatedAmount.toString());
+                    if (buddy->outputAmount > minimumNeededAmountWithChange) return false;
+                }
+            } else if(computeOutputAmount) {
+                buddy->outputAmount = aggregatedAmount - minimumNeededAmount;
+            }
+            return !buddy->request.wipe;
+        }
+
+        BitcoinLikeUTXOPicker::UTXODescriptorList
+        BitcoinLikeStrategyUTXOPicker::filterWithOptimizeSize(const std::shared_ptr<BitcoinLikeUTXOPicker::Buddy> &buddy,
+                                                              const std::vector<std::shared_ptr<api::BitcoinLikeOutput>> &UTXOs,
+                                                              const BigInt &aggregatedAmount) {
+
+            //Don't use this strategy for wipe mode (we have more performent strategies for this use case)
+            if (buddy->request.wipe) {
+                throw make_exception(api::ErrorCode::ILLEGAL_ARGUMENT, "Strategy filterWithLowestFees can't be called when wiping funds to address, please use another strategy");
+            }
+            /*
+             * This coin selection is inspired from the one used in Bitcoin Core
+             * for more details please refer to SelectCoinsBnB
+             * https://github.com/bitcoin/bitcoin/blob/0c5f67b8e5d9a502c6d321c5e0696bc3e9b4690d/src/wallet/coinselection.cpp
+             * A coin selection is considered valid if its total value is within the range : [targetAmount, targetAmount + costOfChange]
+            */
+
+            //Compute long term fees
+            uint32_t confirmTarget = 1008;
+            //TODO: we will have a call to estimateSmartFees (bitcoin core/ explorer side) to estimate long term fees
+            //int64_t longTermFees = estimateSmartFees(confirmTarget);
+            int64_t longTermFees = DEFAULT_FALLBACK_FEE;
+
+            //Compute cost of change
+            auto fixedSize = BitcoinLikeTransaction::estimateSize(0,
+                                                                     0,
+                                                                     getCurrency(),
+                                                                     buddy->keychain->getKeychainEngine());
+            //Size of only 1 output (without fixed size)
+            auto oneOutputSize = BitcoinLikeTransaction::estimateSize(0,
+                                                                         1,
+                                                                         getCurrency(),
+                                                                         buddy->keychain->getKeychainEngine()).Max - fixedSize.Max;
+            //Size 1 signed UTXO (signed input)
+            auto signedUTXOSize = BitcoinLikeTransaction::estimateSize(1,
+                                                                          0,
+                                                                          getCurrency(),
+                                                                          buddy->keychain->getKeychainEngine()).Max - fixedSize.Max;
+
+            //Size of unsigned change
+            auto changeSize = oneOutputSize;
+            //Size of signed change
+            auto signedChangeSize = signedUTXOSize;
+
+            auto effectiveFees = buddy->request.feePerByte;
+            //TODO: compute default discard fees
+            //int64_t costOfChange = DEFAULT_DISCARD_FEE * signedChangeSize +  effectiveFees->toInt64() * changeSize;
+            int64_t costOfChange = effectiveFees->toInt64() * changeSize;
+            buddy->logger->debug("Cost of change {}, signedChangeSize {}, changeSize {}", costOfChange, signedChangeSize, changeSize);
+
+            //Calculate effective value of outputs
+            using EffectiveUTXOList = std::vector<EffectiveUTXO>;
+            EffectiveUTXOList listEffectiveUTXOs;
+            //Get size of UTXOs as a signed input in a transaction
+            for (auto& UTXO : UTXOs) {
+                auto outEffectiveValue = UTXO->getValue()->toLong() - effectiveFees->toInt64() * signedUTXOSize;
+                if (outEffectiveValue > 0) {
+                    auto outEffectiveFees = effectiveFees->toInt64() * signedUTXOSize;
+                    auto outLongTermFees = longTermFees * signedUTXOSize;
+                    EffectiveUTXO effectiveUTXO{UTXO, outEffectiveValue, outEffectiveFees, outLongTermFees};
+                    listEffectiveUTXOs.emplace_back(std::move(effectiveUTXO));
+                }
+            }
+
+            //Get no inputs fees
+            // At beginning, there are no outputs in tx, so noInputFees are fixed fees
+            int64_t notInputFees = effectiveFees->toInt64() * (fixedSize.Max + (int64_t)(oneOutputSize * buddy->request.outputs.size()));//at least fixed size and outputs(version...)
+
+            //Start coin selection algorithm (according to SelectCoinBnb from Bitcoin Core)
+            int64_t currentValue = 0;
+            std::vector<bool> currentSelection;
+            currentSelection.reserve(UTXOs.size());
+
+            //Actual amount we are targetting
+            int64_t actualTarget = notInputFees + buddy->outputAmount.toInt64();
+
+            //Calculate current available amount
+            int64_t currentAvailableValue = 0;
+            for (auto& effectiveUTXO : listEffectiveUTXOs) {
+                currentAvailableValue += effectiveUTXO.effectiveValue;
+            }
+
+            //Insufficient funds
+            if (currentAvailableValue < actualTarget) {
+                throw make_exception(api::ErrorCode::NOT_ENOUGH_FUNDS, "Cannot gather enough funds.");
+            }
+
+            auto descendingEffectiveValue = [] (const EffectiveUTXO &lhs, const EffectiveUTXO &rhs) -> bool {
+                return  lhs.effectiveValue > rhs.effectiveValue ;
+            };
+
+            //Sort UTXOs by effectiveValue
+            std::sort(listEffectiveUTXOs.begin(), listEffectiveUTXOs.end(), descendingEffectiveValue);
+
+            int64_t currentWaste = 0, currentActualTarget = actualTarget;
+            int64_t bestWaste = MAX_MONEY;
+            std::vector<bool> bestSelection;
+            buddy->logger->debug("Start filterWithLowestFees, target range is {} to {}, available funds {}", actualTarget, actualTarget + costOfChange, currentAvailableValue);
+            //Deep first search loop to choose UTXOs
+            for (size_t i = 0; i < TOTAL_TRIES; i++) {
+
+                //Condition for starting a backtrack
+                bool backtrack = false;
+                if(currentValue + currentAvailableValue < currentActualTarget || //Cannot reach target with the amount remaining in currentAvailableValue
+                   currentValue > currentActualTarget + costOfChange || // Selected value is out of range, go back and try other branch
+                   (currentWaste > bestWaste && listEffectiveUTXOs.at(0).effectiveFees - listEffectiveUTXOs.at(0).longTermFees > 0) ) { //avoid selecting UTXOs producing more waste
+                    buddy->logger->debug("Should backtrack");
+                    backtrack = true;
+                } else if (currentValue >= currentActualTarget) { //Selected valued is within range
+                    currentWaste += (currentValue - currentActualTarget);
+                    buddy->logger->debug("Selected Value is within range, current waste {}, best waste {}", currentWaste, bestWaste);
+                    if (currentWaste <= bestWaste) {
+                        bestSelection = currentSelection;
+                        bestSelection.resize(listEffectiveUTXOs.size());
+                        bestWaste = currentWaste;
+                    }
+                    // remove the excess value as we will be selecting different coins now
+                    currentWaste -= (currentValue - currentActualTarget);
+                    backtrack = true;
+                }
+
+                //Move backwards
+                if (backtrack) {
+                    // Walk backwards to find the last included UTXO that still needs to have its omission branch traversed.
+                    while (!currentSelection.empty() && !currentSelection.back()) {
+                        currentSelection.pop_back();
+                        currentAvailableValue += listEffectiveUTXOs.at(currentSelection.size()).effectiveValue;
+                    }
+
+                    //Case we walked back to the first UTXO and all solutions searched.
+                    if (currentSelection.empty()) {
+                        buddy->logger->debug("Current selection is empty, break !");
+                        break;
+                    }
+
+                    //Output was included on previous iterations, try excluding now
+                    currentSelection.back() = false;
+                    auto& effectiveUTXO = listEffectiveUTXOs.at(currentSelection.size() - 1);
+                    currentValue -= effectiveUTXO.effectiveValue;
+                    currentWaste -= (effectiveUTXO.effectiveFees - effectiveUTXO.longTermFees);
+                    currentActualTarget -= effectiveUTXO.effectiveFees;
+                    buddy->logger->debug("Backtrack, remove {}, current values is {} and current waste is {}", effectiveUTXO.effectiveValue, currentValue, currentWaste);
+                } else { //Moving forwards, continuing down this branch
+                    buddy->logger->debug("Moving forward with currentSelection size {}", currentSelection.size());
+                    auto& effectiveUTXO = listEffectiveUTXOs.at(currentSelection.size());
+
+                    //Remove this UTXO from currentAvailableValue
+                    currentAvailableValue -= effectiveUTXO.effectiveValue;
+
+                    // Avoid searching a branch if the previous UTXO has the same value and same waste and was excluded. Since the ratio of fee to
+                    // long term fee is the same, we only need to check if one of those values match in order to know that the waste is the same.
+                    if (!currentSelection.empty() && !currentSelection.back() &&
+                        effectiveUTXO.effectiveValue == listEffectiveUTXOs.at(currentSelection.size() - 1).effectiveValue &&
+                        effectiveUTXO.effectiveFees == listEffectiveUTXOs.at(currentSelection.size() - 1).effectiveFees) {
+                        currentSelection.push_back(false);
+                    } else {
+                        //Inclusion branch first
+                        currentSelection.push_back(true);
+                        currentValue += effectiveUTXO.effectiveValue;
+                        currentWaste += (effectiveUTXO.effectiveFees - effectiveUTXO.longTermFees);
+                        currentActualTarget += effectiveUTXO.effectiveFees;
+                        buddy->logger->debug("Select UTXO with effective value {}, current waste is {}", effectiveUTXO.effectiveValue, currentWaste);
+                    }
+                }
+            }
+
+            //If no selection found fallback on filterWithDeepFirst
+            if (bestSelection.empty()) {
+                buddy->logger->debug("No best selection found, fallback on filterWithKnapsackSolver coin selection");
+                return filterWithKnapsackSolver(buddy, UTXOs, aggregatedAmount);
+            }
+
+            //Prepare result
+            buddy->logger->debug("Found best selection of size: {}", bestSelection.size());
+            UTXODescriptorList out;
+            BigInt bestValue = BigInt::ZERO;
+            for (size_t i = 0; i < bestSelection.size(); i++) {
+                if (bestSelection.at(i)) {
+                    buddy->logger->debug("Choose UTXO with value: {}", listEffectiveUTXOs.at(i).output->getValue()->toLong());
+                    bestValue = bestValue + BigInt(listEffectiveUTXOs.at(i).output->getValue()->toLong());
+                    UTXODescriptor UTXODescriptor{listEffectiveUTXOs.at(i).output->getTransactionHash(), listEffectiveUTXOs.at(i).output->getOutputIndex(), std::get<1>(buddy->request.UTXOPicker.getValue())};
+                    out.emplace_back(std::move(UTXODescriptor));
+                }
+            }
+
+            //Set change amount
+            buddy->changeAmount = bestValue - BigInt(currentActualTarget + costOfChange);
+
+            return out;
+        }
+
+        static void approximateBestSubset(const std::vector<std::shared_ptr<api::BitcoinLikeOutput>> &vUTXOs, const int64_t totalLower, const BigInt &targetValue,
+                                          std::vector<bool>& bestValues, int64_t &bestValue, int iterations = 1000) {
+            std::vector<bool> includedUTXOs;
+
+            bestValues.assign(vUTXOs.size(), true);
+            bestValue = totalLower;
+
+            auto insecureRand = [] () -> bool {
+                auto seed = std::chrono::system_clock::now().time_since_epoch().count();
+                return std::default_random_engine(seed)() % 2 == 0;
+            };
+
+            for (int nRep = 0; nRep < iterations && bestValue != targetValue.toInt64(); nRep++)
+            {
+                includedUTXOs.assign(vUTXOs.size(), false);
+                int64_t total = 0;
+                bool fReachedTarget = false;
+                for (int nPass = 0; nPass < 2 && !fReachedTarget; nPass++)
+                {
+                    for (unsigned int i = 0; i < vUTXOs.size(); i++)
+                    {
+                        //The solver here uses a randomized algorithm,
+                        //the randomness serves no real security purpose but is just
+                        //needed to prevent degenerate behavior and it is important
+                        //that the rng is fast. We do not use a constant random sequence,
+                        //because there may be some privacy improvement by making
+                        //the selection random.
+                        if (nPass == 0 ? insecureRand() : !includedUTXOs[i])
+                        {
+                            total += vUTXOs[i]->getValue()->toLong();
+                            includedUTXOs[i] = true;
+                            if (total >= targetValue.toInt64())
+                            {
+                                fReachedTarget = true;
+                                if (total < bestValue)
+                                {
+                                    bestValue = total;
+                                    bestValues = includedUTXOs;
+                                }
+                                total -= vUTXOs[i]->getValue()->toLong();
+                                includedUTXOs[i] = false;
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+
+        BitcoinLikeUTXOPicker::UTXODescriptorList BitcoinLikeStrategyUTXOPicker::filterWithKnapsackSolver(const std::shared_ptr<BitcoinLikeUTXOPicker::Buddy> &buddy,
+                                                                                                                  const std::vector<std::shared_ptr<api::BitcoinLikeOutput>> &UTXOs,
+                                                                                                                  const BigInt &aggregatedAmount) {
+            //Tx fixed size
+            auto fixedSize = BitcoinLikeTransaction::estimateSize(0,
+                                                                     0,
+                                                                     getCurrency(),
+                                                                     buddy->keychain->getKeychainEngine());
+            //Size of one output (without fixed size)
+            auto oneOutputSize = BitcoinLikeTransaction::estimateSize(0,
+                                                                         1,
+                                                                         getCurrency(),
+                                                                         buddy->keychain->getKeychainEngine()).Max - fixedSize.Max;
+            //Size of UTXO as signed input in tx
+            auto signedUTXOSize = buddy->keychain->getOutputSizeAsSignedTxInput();
+
+            //Amount + fixed size fees + outputs fees
+            auto amountWithFixedFees = buddy->request.feePerByte->toInt64() * (fixedSize.Max + (buddy->request.outputs.size() * oneOutputSize)) + buddy->outputAmount.toInt64();
+            auto amountWithFees = amountWithFixedFees;
+
+            buddy->logger->debug("Start filterWithKnapsackSolver, target range is {} to {}", amountWithFees, amountWithFees + MIN_CHANGE);
+            //List of values less than target
+            int64_t totalLower = 0;
+            Option<std::shared_ptr<api::BitcoinLikeOutput>> coinLowestLarger;
+            std::vector<std::shared_ptr<api::BitcoinLikeOutput>> vUTXOs;
+            UTXODescriptorList out;
+
+            //Random shuffle UTXOs
+            std::vector<size_t> indexes;
+            for (size_t index = 0; index < UTXOs.size(); index++) {
+                indexes.push_back(index);
+            }
+            auto seed = std::chrono::system_clock::now().time_since_epoch().count();
+            std::shuffle(indexes.begin(), indexes.end(),std::default_random_engine(seed));
+
+            for (auto index : indexes) {
+                auto& UTXO = UTXOs[index];
+                //Add fees for a signed input to amount
+                amountWithFees = amountWithFixedFees + signedUTXOSize * buddy->request.feePerByte->toInt64();
+                //If UTXO has exact amount return it
+                if (UTXO->getValue()->toLong() == amountWithFees) {
+                    buddy->logger->debug("Found UTXO with right amount: {}",UTXO->getValue()->toLong());
+                    UTXODescriptor UTXODescriptor{UTXO->getTransactionHash(), UTXO->getOutputIndex(), std::get<1>(buddy->request.UTXOPicker.getValue())};
+                    out.emplace_back(UTXODescriptor);
+                    return out;
+                } else if (UTXO->getValue()->toLong() < amountWithFees + MIN_CHANGE) { //If UTXO in range keep it
+                    buddy->logger->debug("Found UTXO in range : {} to {}",amountWithFees, amountWithFees + MIN_CHANGE);
+                    vUTXOs.push_back(UTXO);
+                    totalLower += UTXO->getValue()->toLong();
+                } else if (!coinLowestLarger.nonEmpty() || UTXO->getValue()->toLong() < coinLowestLarger.getValue()->getValue()->toLong()) { //Keep track of lowest UTXO out of range
+                    buddy->logger->debug("Set lowest out of range UTXO : {} ",UTXO->getValue()->toLong());
+                    coinLowestLarger = UTXO;
+                }
+            }
+
+            //Compute amount if all vUTXOs used as signed inputs
+            amountWithFees = amountWithFixedFees + (int64_t) vUTXOs.size() * signedUTXOSize * buddy->request.feePerByte->toInt64();
+
+            //If exact amount, return vUTXOs
+            if (totalLower == amountWithFees) {
+                buddy->logger->debug("Total of lower UTXOs and amount equal");
+                for (auto& selectedUTXO : vUTXOs) {
+                    UTXODescriptor UTXODescriptor{selectedUTXO->getTransactionHash(), selectedUTXO->getOutputIndex(), std::get<1>(buddy->request.UTXOPicker.getValue())};
+                    out.emplace_back(UTXODescriptor);
+                }
+                return out;
+            } else if (totalLower < amountWithFees) {
+                buddy->logger->debug("Total of lower UTXOs lower than amount equal");
+                //If total lower then and no coinLowestLarger then use filterWithDeepFirst
+                if (!coinLowestLarger.nonEmpty()) {
+                    buddy->logger->debug("No best selection found, fallback on filterWithDeepFirst coin selection");
+                    return filterWithDeepFirst(buddy, UTXOs, buddy->outputAmount);
+                }
+            }
+
+            //Sort vUTXOs descending
+            auto descending = [] (const std::shared_ptr<api::BitcoinLikeOutput> &lhs,
+                                  const std::shared_ptr<api::BitcoinLikeOutput> &rhs) -> bool {
+                return  lhs->getValue()->toLong() > rhs->getValue()->toLong() ;
+            };
+            std::sort(vUTXOs.begin(), vUTXOs.end(), descending);
+
+            //Approximate best tries
+            std::vector<bool> bestValues;
+            int64_t bestValue = 0;
+            buddy->logger->debug("Approximate Best Subset 1st try");
+            approximateBestSubset(vUTXOs, totalLower, BigInt((int64_t)amountWithFees), bestValues, bestValue);
+            if (bestValue != amountWithFees && totalLower >= amountWithFees + MIN_CHANGE) {
+                buddy->logger->debug("First approximation, bestValue {} with {} bestValues", bestValue, bestValues.size());
+                buddy->logger->debug("Approximate Best Subset 2nd try");
+                approximateBestSubset(vUTXOs, totalLower, BigInt((int64_t)amountWithFees + MIN_CHANGE), bestValues, bestValue);
+                buddy->logger->debug("Second approximation, bestValue {} with {} bestValues", bestValue, bestValues.size());
+            }
+
+            //If bestValue is different from amountWithFees and coinLowestLarger is lower than bestVaule, then choose coinLowestLarger
+            if (coinLowestLarger.nonEmpty() &&
+                ((bestValue != amountWithFees && bestValue < amountWithFees + MIN_CHANGE) ||
+                 coinLowestLarger.getValue()->getValue()->toLong() <= bestValue))
+            {
+                buddy->logger->debug("Add coinLowestLarger to coin selection");
+                UTXODescriptor UTXODescriptor{coinLowestLarger.getValue()->getTransactionHash(), coinLowestLarger.getValue()->getOutputIndex(), std::get<1>(buddy->request.UTXOPicker.getValue())};
+                out.emplace_back(UTXODescriptor);
+
+                //Compute change if needed
+                amountWithFees = amountWithFixedFees + signedUTXOSize * buddy->request.feePerByte->toInt64();
+                if (amountWithFees < coinLowestLarger.getValue()->getValue()->toLong()) {
+                    //Add cost of change
+                    amountWithFees += oneOutputSize * buddy->request.feePerByte->toInt64();
+                    buddy->changeAmount =  BigInt((int64_t)(coinLowestLarger.getValue()->getValue()->toLong() - amountWithFees));
+                }
+            }
+            else { //Pick bestValues
+                buddy->logger->debug("Push all vUTXOs");
+                int64_t totalBest = 0;
+                for (unsigned int i = 0; i < vUTXOs.size(); i++) {
+                    if (bestValues[i])
+                    {
+                        UTXODescriptor UTXODescriptor{vUTXOs[i]->getTransactionHash(), vUTXOs[i]->getOutputIndex(), std::get<1>(buddy->request.UTXOPicker.getValue())};
+                        out.emplace_back(UTXODescriptor);
+                        totalBest += vUTXOs[i]->getValue()->toLong();
+                    }
+
+                }
+                //Set amount of change
+                buddy->changeAmount =  BigInt(totalBest - (int64_t)(amountWithFees + oneOutputSize * buddy->request.feePerByte->toInt64()));
+            }
+
+            return out;
+        }
+
+        BitcoinLikeUTXOPicker::UTXODescriptorList BitcoinLikeStrategyUTXOPicker::filterWithMergeOutputs(const std::shared_ptr<BitcoinLikeUTXOPicker::Buddy> &buddy,
+                                                                                                                const std::vector<std::shared_ptr<api::BitcoinLikeOutput>> &UTXOs,
+                                                                                                                const BigInt &aggregatedAmount) {
+            buddy->logger->debug("Start filterWithMergeOutputs");
+            auto sortedUTXOs = UTXOs;
+            auto ascending = [] (const std::shared_ptr<api::BitcoinLikeOutput> &lhs,
+                                 const std::shared_ptr<api::BitcoinLikeOutput> &rhs) -> bool {
+                return  lhs->getValue()->toLong() < rhs->getValue()->toLong() ;
+            };
+
+            std::sort(sortedUTXOs.begin(), sortedUTXOs.end(), ascending);
+
+            UTXODescriptorList out;
+            BigInt amount = aggregatedAmount;
+            int pickedInputs = 0;
+            for (auto& UTXO : sortedUTXOs) {
+
+                pickedInputs += 1;
+                amount = amount + BigInt(UTXO->getValue()->toLong());
+                UTXODescriptor UTXODescriptor{UTXO->getTransactionHash(), UTXO->getOutputIndex(), std::get<1>(buddy->request.UTXOPicker.getValue())};
+                out.emplace_back(std::move(UTXODescriptor));
+                bool computeOutputAmount = pickedInputs == sortedUTXOs.size();
+                if (hasEnough(buddy, amount, pickedInputs, computeOutputAmount)) {
+                    break;
+                }
+
+                if (pickedInputs >= sortedUTXOs.size() && !buddy->request.wipe) {
+                    throw make_exception(api::ErrorCode::NOT_ENOUGH_FUNDS, "Cannot gather enough funds.");
+                }
+            }
+
+            return out;
+        }
+
+    }
+}
+

--- a/ledger-core-bitcoin/src/bitcoin/transactions/BitcoinLikeTransaction.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/transactions/BitcoinLikeTransaction.cpp
@@ -1,0 +1,778 @@
+/*
+ *
+ * BitcoinLikeTransaction
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 12/07/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/api/KeychainEngines.hpp>
+#include <core/bytes/BytesWriter.hpp>
+#include <core/bytes/BytesReader.hpp>
+#include <core/crypto/HASH160.hpp>
+#include <core/crypto/SHA512.hpp>
+#include <core/math/Base58.hpp>
+#include <core/wallet/Amount.hpp>
+
+#include <bitcoin/BitcoinNetworks.hpp>
+#include <bitcoin/scripts/BitcoinLikeScript.hpp>
+#include <bitcoin/transactions/BitcoinLikeTransaction.hpp>
+
+namespace ledger {
+    namespace core {
+
+
+        BitcoinLikeTransaction::BitcoinLikeTransaction(const api::Currency &currency,
+                                                       const std::string &keychainEngine,
+                                                       uint64_t currentBlockHeight) :
+                _currency(currency), _keychainEngine(keychainEngine), _currentBlockHeight(currentBlockHeight) {
+            _version = 1;
+            _params = networks::getBitcoinLikeNetworkParameters(currency.name);
+            _writable = true;
+        }
+
+        BitcoinLikeTransaction::BitcoinLikeTransaction(
+                const std::shared_ptr<BitcoinLikeOperation>& operation,
+                const api::Currency &currency,
+                const std::string &keychainEngine,
+                uint64_t currentBlockHeight)
+                : BitcoinLikeTransaction(currency, keychainEngine, currentBlockHeight) {
+
+            auto& tx = operation->getExplorerTransaction();
+
+            _time = tx.receivedAt;
+            _lockTime = tx.lockTime;
+            _writable = false;
+
+            if (tx.fees.nonEmpty())
+                _fees = std::make_shared<Amount>(currency, 0, tx.fees.getValue());
+            else
+                _fees = nullptr;
+
+            auto inputCount = tx.inputs.size();
+            for (auto index = 0; index < inputCount; index++) {
+                _inputs.push_back(std::make_shared<BitcoinLikeInput>(operation, index));
+            }
+
+            auto outputCount = tx.outputs.size();
+            for (auto index = 0; index < outputCount; index++) {
+                _outputs.push_back(std::make_shared<BitcoinLikeOutput>(operation, index));
+            }
+
+            if (tx.block.nonEmpty()) {
+                _block = std::make_shared<BitcoinLikeBlock>(tx.block.getValue());
+            } else {
+                _block = nullptr;
+            }
+            _hash = tx.hash;
+        }
+
+        std::vector<std::shared_ptr<api::BitcoinLikeInput>> BitcoinLikeTransaction::getInputs() {
+            return _inputs;
+        }
+
+        std::vector<std::shared_ptr<api::BitcoinLikeOutput>> BitcoinLikeTransaction::getOutputs() {
+            return _outputs;
+        }
+
+        std::shared_ptr<api::BitcoinLikeBlock> BitcoinLikeTransaction::getBlock() {
+            return _block;
+        }
+
+        int64_t BitcoinLikeTransaction::getLockTime() {
+            return _lockTime;
+        }
+
+        std::shared_ptr<api::Amount> BitcoinLikeTransaction::getFees() {
+            ledger::core::BigInt value(0);
+            for (auto &input : getInputs()) {
+                auto v = std::dynamic_pointer_cast<ledger::core::Amount>(input->getValue());
+                if (v == nullptr)
+                    return nullptr;
+                value = value + *(v->value());
+            }
+            for (auto &output : getOutputs()) {
+                auto v = std::dynamic_pointer_cast<ledger::core::Amount>(output->getValue())->value();
+                value = value - *v;
+            }
+            return std::make_shared<ledger::core::Amount>(_currency, 0, value);
+        }
+
+        std::chrono::system_clock::time_point BitcoinLikeTransaction::getTime() {
+            return _time;
+        }
+
+        std::string BitcoinLikeTransaction::getHash() {
+            return _hash;
+        }
+
+        optional<int32_t> BitcoinLikeTransaction::getTimestamp() {
+            return _timestamp.map<int32_t>([](const uint32_t &v) {
+                return (int32_t) v;
+            }).toOptional();
+        }
+
+        std::vector<uint8_t> BitcoinLikeTransaction::serialize() {
+            BytesWriter writer;
+            serializeProlog(writer);
+            serializeInputs(writer);
+            serializeOutputs(writer);
+            serializeEpilogue(writer);
+            return writer.toByteArray();
+        }
+
+        optional<std::vector<uint8_t>> BitcoinLikeTransaction::getWitness() {
+            bool isDecred =  _params.Identifier == "dcr";
+            BytesWriter witness;
+
+            //Decred has a special witness with nb of witnesses and no stack size,
+            //and additional fields: amount, block height, block index
+            if (BitcoinLikeKeychain::isSegwit(_keychainEngine) && !isDecred) {
+                for (auto &input : _inputs) {
+                    auto scriptSig = input->getScriptSig();
+                    if (!scriptSig.empty()) {
+                        //Stack size
+                        witness.writeVarInt(2);
+                        witness.writeByteArray(scriptSig);
+                    }
+                }
+            } else if (isDecred){
+                witness.writeVarInt(_inputs.size());
+                for (auto &input : _inputs) {
+                    //TODO: Amount (not used can be anything)
+                    witness.writeByteArray({0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+                    witness.writeByteArray({0x00, 0x00, 0x00, 0x00});
+                    witness.writeByteArray({0xff, 0xff, 0xff, 0xff});
+                    auto scriptSig = input->getScriptSig();
+                    witness.writeVarInt(scriptSig.size());
+                    if (!scriptSig.empty()) {
+                        witness.writeByteArray(scriptSig);
+                    }
+                    auto pubKeys = input->getPublicKeys();
+                    if (!pubKeys.empty()) {
+                        witness.writeVarInt(pubKeys[0].size());
+                        witness.writeByteArray(pubKeys[0]);
+                    }
+                }
+            }
+            return Option<std::vector<uint8_t>>(witness.toByteArray()).toOptional();
+        }
+
+        api::EstimatedSize BitcoinLikeTransaction::getEstimatedSize() {
+            return estimateSize(getInputs().size(),
+                                getOutputs().size(),
+                                _currency,
+                                _keychainEngine);
+        }
+
+        bool BitcoinLikeTransaction::isWriteable() const {
+            return _writable;
+        }
+
+        bool BitcoinLikeTransaction::isReadOnly() const {
+            return !isWriteable();
+        }
+
+        BitcoinLikeTransaction &
+        BitcoinLikeTransaction::addInput(const std::shared_ptr<BitcoinLikeWritableInput> &input) {
+            _inputs.push_back(input);
+            return *this;
+        }
+
+        BitcoinLikeTransaction &BitcoinLikeTransaction::setLockTime(uint32_t lockTime) {
+            _lockTime = lockTime;
+            return *this;
+        }
+
+        BitcoinLikeTransaction &
+        BitcoinLikeTransaction::addOutput(const std::shared_ptr<api::BitcoinLikeOutput> &output) {
+            _outputs.push_back(output);
+            return *this;
+        }
+
+        api::EstimatedSize
+        BitcoinLikeTransaction::estimateSize(std::size_t inputCount,
+                                                std::size_t outputCount,
+                                                const api::Currency &currency,
+                                                const std::string &keychainEngine) {
+            // TODO Handle outputs and input for multisig P2SH
+            size_t maxSize, minSize, fixedSize = 0;
+
+            // Fixed size computation
+            fixedSize = 4; // Transaction version
+            // TODO: Why we don't use _params here ?
+            if (networks::getBitcoinLikeNetworkParameters(currency.name).UsesTimestampedTransaction)
+                fixedSize += 4; // Timestamp
+            fixedSize += BytesWriter().writeVarInt(inputCount).toByteArray().size(); // Number of inputs
+            fixedSize += BytesWriter().writeVarInt(outputCount).toByteArray().size(); // Number of outputs
+            fixedSize += 4; // Timelock
+
+            auto isSegwit = BitcoinLikeKeychain::isSegwit(keychainEngine);
+            if (isSegwit) {
+                // Native Segwit: 32 PrevTxHash + 4 Index + 1 null byte + 4 sequence
+                // P2SH: 32 PrevTxHash + 4 Index + 23 scriptPubKey + 4 sequence
+                auto isNativeSegwit = BitcoinLikeKeychain::isNativeSegwit(keychainEngine);
+                size_t inputSize = isNativeSegwit ? 41 : 63;
+                size_t noWitness = fixedSize + inputSize * inputCount + 34 * outputCount;
+                
+                // Include flag and marker size (one byte each)
+                size_t minWitness = noWitness + (106 * inputCount) + 2;
+                size_t maxWitness = noWitness + (108 * inputCount) + 2;
+                
+                minSize = (noWitness * 3 + minWitness) / 4;
+                maxSize = (noWitness * 3 + maxWitness) / 4;
+            } else {
+                minSize = fixedSize + 146 * inputCount + 32 * outputCount;
+                maxSize = fixedSize + 148 * inputCount + 34 * outputCount;
+            }
+            return api::EstimatedSize(static_cast<int32_t>(minSize), static_cast<int32_t>(maxSize));
+        }
+
+        BitcoinLikeTransaction &BitcoinLikeTransaction::setVersion(uint32_t version) {
+            _version = version;
+            // Update params
+            _params = networks::getBitcoinLikeNetworkParameters(_currency.name, _version);
+            return *this;
+        }
+
+        BitcoinLikeTransaction &BitcoinLikeTransaction::setTimestamp(uint32_t ts) {
+            _timestamp = Option<uint32_t>(ts);
+            return *this;
+        }
+
+        BitcoinLikeTransaction &BitcoinLikeTransaction::setHash(const std::string &hash) {
+            _hash = hash;
+            return *this;
+        }
+
+        std::vector<uint8_t> BitcoinLikeTransaction::serializeOutputs() {
+            BytesWriter writer;
+            serializeOutputs(writer);
+            return writer.toByteArray();
+        }
+
+        api::BitcoinLikeSignatureState BitcoinLikeTransaction::setSignatures(const std::vector<api::BitcoinLikeSignature> & signatures, bool overrid) {
+            if (signatures.size() != _inputs.size()) {
+                return api::BitcoinLikeSignatureState::MISSING_DATA;
+            }
+            for (std::size_t i = 0; i < signatures.size(); ++i) {
+                if (overrid == true ) {
+                    _inputs[i]->setScriptSig(std::vector<uint8_t>{});
+                }
+                else if (_inputs[i]->getScriptSig().size() > 0) {
+                    return api::BitcoinLikeSignatureState::ALREADY_SIGNED;
+                }
+                BytesWriter writer;
+                //Get length representing length of R and S
+                //4 value representing both stack size and length of R and S - sighash is excluded
+                auto const sAndRLengthInt = 4 + signatures[i].r.size() + signatures[i].s.size();
+                //DER Signature = Total Size | DER prefix | Size(S+R) | R StackSize | R Length | R | S StackSize | S Length | S | SIGHASH
+                auto const totalSigInt = 2 + sAndRLengthInt;
+                writer.writeByte(totalSigInt);
+                //DER prefix
+                writer.writeByte(0x30);
+                //Size of DER signature minus DER prefix | Size(S+R)
+                writer.writeByte(sAndRLengthInt);
+                //R field
+                writer.writeByte(0x02); //Nb of stack elements
+                writer.writeByte(signatures[i].r.size());
+                writer.writeByteArray(signatures[i].r);
+                //S field
+                writer.writeByte(0x02); //Nb of stack elements
+                writer.writeByte(signatures[i].s.size());
+                writer.writeByteArray(signatures[i].s);
+                writer.writeByte(networks::sigHashType::SIGHASH_ALL);
+                _inputs[i]->setP2PKHSigScript(writer.toByteArray());
+            }
+            return api::BitcoinLikeSignatureState::SIGNING_SUCCEED;
+        }
+
+        api::BitcoinLikeSignatureState BitcoinLikeTransaction::setDERSignatures(const std::vector<std::vector<uint8_t>> & signatures, bool override) {
+            if (signatures.size() != _inputs.size()) {
+                return api::BitcoinLikeSignatureState::MISSING_DATA;
+            }
+            for (std::size_t i = 0; i < signatures.size(); ++i) {
+                if (override == true) {
+                    _inputs[i]->setScriptSig(std::vector<uint8_t>{});
+                }
+                else if (_inputs[i]->getScriptSig().size() > 0) {
+                    return api::BitcoinLikeSignatureState::ALREADY_SIGNED;
+                }
+                _inputs[i]->setP2PKHSigScript(signatures[i]);
+            }
+            return api::BitcoinLikeSignatureState::SIGNING_SUCCEED;
+        }
+
+        int32_t BitcoinLikeTransaction::getVersion() {
+            return _version;
+        }
+
+        void BitcoinLikeTransaction::serializeProlog(BytesWriter &writer) {
+            auto &additionalBIPs = _params.AdditionalBIPs;
+            auto it = std::find(additionalBIPs.begin(), additionalBIPs.end(), "ZIP");
+            auto zipParameters = _currentBlockHeight > networks::ZIP_SAPLING_PARAMETERS.blockHeight ?
+                                 networks::ZIP_SAPLING_PARAMETERS : networks::ZIP143_PARAMETERS;
+
+            if (it != additionalBIPs.end() && _currentBlockHeight > networks::ZIP143_PARAMETERS.blockHeight) {
+                setVersion(zipParameters.version);
+
+                //New version and overwinter flag
+                auto header = zipParameters.overwinterFlag;
+                header.push_back(0x00);
+                header.push_back(0x00);
+                header.push_back(zipParameters.version);
+                //Push header (0x80000003 in LE)
+                writer.writeLeByteArray(header);
+
+                //Version group Id (0x03C48270 in LE)
+                writer.writeLeByteArray(zipParameters.versionGroupId);
+
+            } else {
+                writer.writeLeValue<int32_t>(_version);
+            }
+
+            if (_params.UsesTimestampedTransaction) {
+                auto ts = getTimestamp();
+                if (!ts)
+                    throw make_exception(api::ErrorCode::INCOMPLETE_TRANSACTION, "Missing transaction timestamp");
+                writer.writeLeValue<uint32_t>(ts.value());
+            }
+
+            if (BitcoinLikeKeychain::isSegwit(_keychainEngine)) {
+                //write marker
+                writer.writeByte(0x00);
+                //write flag
+                writer.writeByte(0x01);
+            }
+        }
+
+        void BitcoinLikeTransaction::serializeInputs(BytesWriter &writer) {
+            // If all inputs are empty we need to create an unsigned transaction
+            writer.writeVarInt(_inputs.size());
+            for (auto &input : _inputs) {
+                auto hash = input->getPreviousTxHash();
+                if (!hash)
+                    throw make_exception(api::ErrorCode::INCOMPLETE_TRANSACTION, "Missing previous transaction hash");
+                writer.writeLeByteArray(hex::toByteArray(hash.value()));
+                if (!input->getPreviousOutputIndex())
+                    throw make_exception(api::ErrorCode::INCOMPLETE_TRANSACTION, "Missing previous transaction index");
+                writer.writeLeValue<int32_t>(input->getPreviousOutputIndex().value());
+
+                //Decred has only a tree field
+                if (_params.Identifier == "dcr") {
+                    writer.writeByteArray({0x00});
+                    writer.writeLeValue<uint32_t>(static_cast<const uint32_t>(input->getSequence()));
+                    return;
+                }
+
+                auto scriptSig = input->getScriptSig();
+                auto isSegwit = BitcoinLikeKeychain::isSegwit(_keychainEngine);
+                if (!isSegwit && scriptSig.size() > 0) {
+                    writer.writeVarInt(scriptSig.size());
+                    writer.writeByteArray(scriptSig);
+                } else if (isSegwit && scriptSig.size() > 1) {
+                    auto pubKeys = input->getPublicKeys();
+                    if (!pubKeys.empty()) {
+                        //TODO: handle multi-sig
+                        std::vector<uint8_t> redeemScript = {0x00, 0x14};
+                        redeemScript.insert(redeemScript.end(), pubKeys[0].begin(), pubKeys[0].end());
+                        writer.writeVarInt(redeemScript.size() + 1);
+                        writer.writeVarInt(redeemScript.size());
+                        writer.writeByteArray(redeemScript);
+                    } else {
+                        writer.writeVarInt(0);
+                    }
+                } else {
+                    auto prevOut = input->getPreviousOuput()->getScript();
+                    writer.writeVarInt(prevOut.size());
+                    writer.writeByteArray(prevOut);
+                }
+
+                writer.writeLeValue<uint32_t>(static_cast<const uint32_t>(input->getSequence()));
+            }
+        }
+
+        void BitcoinLikeTransaction::serializeOutputs(BytesWriter &writer) {
+            writer.writeVarInt(_outputs.size());
+
+            for (auto &output : _outputs) {
+                writer.writeLeValue<uint64_t>(static_cast<const uint64_t>(output->getValue()->toLong()));
+
+                //Decred has a version of script
+                if (_params.Identifier == "dcr") {
+                    writer.writeByteArray({0x00, 0x00});
+                }
+
+                auto script = output->getScript();
+                writer.writeVarInt(script.size());
+                writer.writeByteArray(script);
+            }
+        }
+
+        void BitcoinLikeTransaction::serializeEpilogue(BytesWriter &writer) {
+            auto witness = getWitness();
+            auto isDecred =  _params.Identifier == "dcr";
+
+            //Decred has witness after lockTime
+            if (!isDecred) {
+                writer.writeByteArray(witness.value_or(std::vector<uint8_t>()));
+            }
+
+            writer.writeLeValue<int32_t>(_lockTime);
+
+            //TODO: activate when LedgerJS not adding expiryHeight and extraData to transaction
+            /*
+            auto &additionalBIPs = _params.AdditionalBIPs;
+            auto it = std::find(additionalBIPs.begin(), additionalBIPs.end(), "ZIP");
+            if (it != additionalBIPs.end() && _currentBlockHeight > networks::ZIP143_PARAMETERS.blockHeight) {
+                //TODO: Feature request: set Expiry height
+                writer.writeByteArray({0x00, 0x00, 0x00, 0x00});
+                //Extra Data
+                if (_currentBlockHeight > networks::ZIP_SAPLING_PARAMETERS.blockHeight) {
+                    writer.writeByteArray({0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+                } else {
+                    writer.writeByteArray({0x00});
+                }
+            }
+            */
+
+            //Decred has a witness and an expiry height
+            if (isDecred) {
+                writer.writeByteArray({0xff, 0xff, 0xff, 0xff});
+                writer.writeByteArray(witness.value_or(std::vector<uint8_t>()));
+            }
+        }
+
+
+        std::shared_ptr<api::BitcoinLikeTransaction>
+        api::BitcoinLikeTransactionBuilder::parseRawUnsignedTransaction(const api::Currency &currency,
+                                                                        const std::vector<uint8_t> &rawTransaction,
+                                                                        std::experimental::optional<int32_t> currentBlockHeight) {
+            return ::ledger::core::BitcoinLikeTransaction::parseRawTransaction(currency, rawTransaction, currentBlockHeight, false);
+        }
+
+        std::shared_ptr<api::BitcoinLikeTransaction>
+        BitcoinLikeTransaction::parseRawSignedTransaction(const api::Currency &currency,
+                                                             const std::vector<uint8_t> &rawTransaction,
+                                                             std::experimental::optional<int32_t> currentBlockHeight) {
+            return ::ledger::core::BitcoinLikeTransaction::parseRawTransaction(currency, rawTransaction, currentBlockHeight, true);
+        }
+
+        std::shared_ptr<api::BitcoinLikeTransaction>
+        BitcoinLikeTransaction::parseRawTransaction(const api::Currency &currency,
+                                                       const std::vector<uint8_t> &rawTransaction,
+                                                       std::experimental::optional<int32_t> currentBlockHeight,
+                                                       bool isSigned) {
+            BytesReader reader(rawTransaction);
+            // Parse version
+            auto version = reader.readNextLeUint();
+            auto params = networks::getBitcoinLikeNetworkParameters(currency.name, version);
+            auto isDecred = params.Identifier == "dcr";
+            HashAlgorithm hashAlgorithm(params.Identifier);
+            //Parse additionalBIPs if there are any
+            auto &additionalBIPs = params.AdditionalBIPs;
+            auto it = std::find(additionalBIPs.begin(), additionalBIPs.end(), "ZIP");
+            auto zipParameters = currentBlockHeight.value_or(0) > networks::ZIP_SAPLING_PARAMETERS.blockHeight ?
+                                 networks::ZIP_SAPLING_PARAMETERS : networks::ZIP143_PARAMETERS;
+            if (it != additionalBIPs.end() &&
+                currentBlockHeight.value_or(0) > networks::ZIP143_PARAMETERS.blockHeight) {
+                //Substract overwinterFlag
+                auto overwinterFlag = zipParameters.overwinterFlag[0];
+                version -= (~(overwinterFlag << 24) + 1);
+
+                //Read version group Id
+                reader.read(zipParameters.versionGroupId.size());
+            }
+
+            // Parse timestamp
+            auto usesTimeStamp = params.UsesTimestampedTransaction;
+            uint32_t timeStamp = 0;
+            if (usesTimeStamp) {
+                timeStamp = reader.readNextLeUint();
+            }
+
+            // Parse segwit marker and flag
+            bool isSegwit = false;
+            auto marker = reader.peek();
+            auto offsetToMarker = reader.getCursor();
+            if (marker == 0x00) {
+                isSegwit = true;
+                marker = reader.readNextByte();
+                auto flag = reader.readNextByte();
+            }
+
+            auto keychainEngine = isSegwit ? api::KeychainEngines::BIP49_P2SH : api::KeychainEngines::BIP32_P2PKH;
+            auto tx = std::make_shared<BitcoinLikeTransaction>(currency, keychainEngine, currentBlockHeight.value_or(0));
+            tx->setVersion(version);
+            if (usesTimeStamp) {
+                tx->setTimestamp(timeStamp);
+            }
+
+            // Parse inputs
+            std::vector<BitcoinLikePreparedInput> preparedInputs;
+            std::vector<std::vector<uint8_t>> scriptSigs;
+            auto inputsCount = reader.readNextVarInt();
+            for (auto index = 0; index < inputsCount; index++) {
+                //Previous Tx Hash in LE
+                auto prevTxHashBytes = reader.read(32);
+                std::reverse(prevTxHashBytes.begin(), prevTxHashBytes.end());
+                auto previousTxHash = hex::toString(prevTxHashBytes);
+                auto outputIndex = reader.readNextLeUint();
+
+                ledger::core::BitcoinLikeBlockchainExplorerOutput output;
+                std::string address;
+                std::vector<std::vector<uint8_t>> pubKeys;
+
+                //Decred has a tree field (1 bytes) and nothing else
+                if (isDecred) {
+                    reader.readNextByte();
+                } else {
+                    auto scriptSize = reader.readNextVarInt();
+                    auto scriptSig = reader.read(scriptSize);
+                    auto parsedScript = ledger::core::BitcoinLikeScript::parse(scriptSig);
+                    if (parsedScript.isSuccess()) {
+
+                        // Useful to remove script sigs from rawTx to compute txHash (e.g. XST)
+                        {
+                            BytesWriter localWriter;
+                            localWriter.writeVarInt(scriptSize);
+                            localWriter.writeByteArray(scriptSig);
+                            scriptSigs.emplace_back(localWriter.toByteArray());
+                        }
+
+                        BytesReader localReader(scriptSig);
+                        if (isSigned && !isSegwit) {
+                            //Get address from signed script
+                            auto sigSize = localReader.readNextVarInt();
+                            auto sig = localReader.read(sigSize);
+                            // For example XST, sometimes does not have pubKey in signature ... (e.g. 6a1e7109ce7cae649c2f79200c946622f97ea6c86b2366cbbb7a512acdb3c1c2)
+                            if (scriptSize - sigSize > 1) {
+                                auto pubKeySize = localReader.readNextVarInt();
+                                auto pubKey = localReader.read(pubKeySize);
+                                pubKeys.push_back(pubKey);
+                                BitcoinLikeAddress localAddress(currency,
+                                                                HASH160::hash(pubKey, hashAlgorithm),
+                                                                api::KeychainEngines::BIP32_P2PKH);
+                                address = localAddress.toBase58();
+                            }
+                            output.script = hex::toString(scriptSig);
+                        } else if (isSigned && isSegwit && !scriptSig.empty()) {
+                            //Get address from redeem script
+                            auto redeemScriptSize = localReader.readNextVarInt();
+                            auto redeemScript = localReader.read(redeemScriptSize);
+                            //Get pubKeys from Redeem script : 0x00 0x14 <pubKey>
+                            std::vector<uint8_t> pubKey(redeemScript.begin() + 2, redeemScript.end());
+                            pubKeys.push_back(pubKey);
+                            BitcoinLikeAddress localAddress(currency,
+                                                            HASH160::hash(redeemScript, hashAlgorithm),
+                                                            api::KeychainEngines::BIP49_P2SH);
+                            address = localAddress.toBase58();
+
+                        } else {
+                            auto parsedAddress = parsedScript.getValue().parseAddress(currency);
+                            if (parsedAddress.hasValue()) {
+                                address = parsedAddress.getValue().toString();
+                            }
+                            output.script = hex::toString(parsedScript.getValue().serialize());
+                        }
+                    }
+                }
+                auto sequence = reader.readNextLeUint();
+                output.address = address;
+                output.transactionHash = previousTxHash;
+                output.index = outputIndex;
+                preparedInputs.emplace_back(BitcoinLikePreparedInput(sequence, address, previousTxHash, outputIndex, pubKeys, output));
+            }
+
+            // Parse outputs
+            auto outputsCount = reader.readNextVarInt();
+            for (auto index = 0; index < outputsCount; index++) {
+                ledger::core::BitcoinLikeBlockchainExplorerOutput output;
+                output.index = static_cast<uint64_t>(index);
+                output.value = reader.readNextLeBigInt(8);
+                //Decred has an additional version script (2 byte)
+                if (isDecred) {
+                    reader.read(2);
+                }
+                auto scriptSize = reader.readNextVarInt();
+                auto lockScript = reader.read(scriptSize);
+                auto parsedScript = ledger::core::BitcoinLikeScript::parse(lockScript);
+                if (parsedScript.isSuccess()) {
+                    auto parsedAddress = parsedScript.getValue().parseAddress(currency);
+                    if (parsedAddress.hasValue())
+                        output.address = Option<std::string>(parsedAddress.getValue().toString());
+                }
+                output.script = hex::toString(lockScript);
+                tx->addOutput(std::shared_ptr<BitcoinLikeOutput>(new BitcoinLikeOutput(
+                        output, currency
+                )));
+            }
+
+            //Decred has lockTime, expiry height and nb of witnesses before witness
+            if (isDecred) {
+                //LockTime
+                tx->setLockTime(reader.readNextLeUint());
+                //Expiry Height
+                reader.read(4);
+                //Number of inputs
+                reader.readNextVarInt();
+            }
+
+            //This will usefull to computes tx hash (txID)
+            std::vector<uint8_t> modifTx(rawTransaction.begin(), rawTransaction.begin() + reader.getCursor());
+
+            // For XST we should remove the script sigs
+            // Reference: https://github.com/StealthSend/Stealth/commit/5be35d6c2c500b32ed82e5d6913d66d18a4b0a7f#diff-e8db9b851adc2422aadfffca88f14c91R566
+            if (params.Identifier == "xst" && !usesTimeStamp) {
+                auto strRawTx = hex::toString(modifTx);
+                auto removeScriptSig = [] (std::string &rawTx, const std::string &scriptSig) {
+                    size_t pos = rawTx.find(scriptSig);
+                    if (pos != std::string::npos) {
+                        rawTx.erase(pos, scriptSig.length());
+                        rawTx.insert(pos, "00");
+                    }
+                };
+                for (auto &scriptSig : scriptSigs) {
+                    removeScriptSig(strRawTx, hex::toString(scriptSig));
+                }
+                modifTx = hex::toByteArray(strRawTx);
+            }
+
+            // Remove marker and flag if segwit
+            if (isSegwit) {
+                modifTx.erase(modifTx.begin() + offsetToMarker, modifTx.begin() + offsetToMarker + 2);
+            }
+
+            //Get witness if needed
+            if (isSigned && (isSegwit || isDecred)) {
+                for (auto index = 0; index < inputsCount; index++) {
+                    //Decred has no stack size on witness
+                    auto stackSize = isDecred ? 2 : reader.readNextVarInt();
+                    if (stackSize != 0 && stackSize != 2) {
+                        throw make_exception(api::ErrorCode::INVALID_ARGUMENT,
+                                             "Stack size not valid in signed segwit transaction");
+                    }
+
+                    if (stackSize == 2) {
+
+                        if (isDecred) {
+                            //Amount
+                            reader.read(8);
+                            //Block height
+                            reader.read(4);
+                            //Block Index
+                            reader.read(4);
+                            //Whole script size
+                            reader.readNextVarInt();
+                        }
+
+                        auto scriptSigSize = reader.readNextVarInt();
+                        auto scriptSig = reader.read(scriptSigSize);
+                        auto pubKeySize = reader.readNextVarInt();
+                        auto pubKey = reader.read(pubKeySize);
+
+                        //Get script sig
+                        BytesWriter writer;
+                        writer.writeVarInt(scriptSigSize);
+                        writer.writeByteArray(scriptSig);
+                        writer.writeVarInt(pubKeySize);
+                        writer.writeByteArray(pubKey);
+                        preparedInputs[index].output.script = hex::toString(writer.toByteArray());
+
+                        // Get address, if not recovered yet
+                        // This is only possible in case of BIP173_P2WPKH or BIP173_P2WSH
+                        // For BIP32_P2PKH it is recovered from scriptPubKey (see above)
+                        // For BIP49_P2SH it is recovered from redeemScript (see above)
+                        // Note: Decred does not support segwit
+                        auto outAddress = preparedInputs[index].address;
+                        if (isSegwit && preparedInputs[index].address.empty()) {
+                            // Get keychain engine
+                            // BIP173_P2WPKH script : <sig> <pubKey> (with <pubKey>.size() == 33)
+                            // BIP173_P2WSH script : <sig> <witness>
+                            auto keychain = pubKey.size() == 33 ? api::KeychainEngines::BIP173_P2WPKH : api::KeychainEngines::BIP173_P2WSH;
+                            // Get hash160 to construct address
+                            auto hash160 = BitcoinLikeAddress::fromPublicKeyToHash160(pubKey, currency, keychain);
+                            preparedInputs[index].address = BitcoinLikeAddress(currency, hash160, keychain).toString();
+                        }
+                    }
+                }
+            }
+
+
+            //Decred has lockTime before witness
+            if (!isDecred) {
+                auto timelock = reader.read(4);
+                modifTx = vector::concat(modifTx, timelock);
+
+                BytesReader timelockReader(timelock);
+                tx->setLockTime(timelockReader.readNextLeUint());
+            }
+
+            if (isSigned) {
+                auto modifTxStr = hex::toString(modifTx);
+                // Double hash
+                auto doubleHash = SHA256::bytesToBytesHash(SHA256::bytesToBytesHash(modifTx));
+                // To little endian
+                std::reverse(doubleHash.begin(), doubleHash.end());
+                tx->setHash(hex::toString(doubleHash));
+            }
+
+
+            //Finally append inputs to tx
+            for (auto i = 0; i < inputsCount; i++) {
+                auto keychainEngine = isSegwit ? api::KeychainEngines::BIP49_P2SH : api::KeychainEngines::BIP32_P2PKH;
+                std::vector<uint8_t> scriptSig;
+                std::vector<std::vector<uint8_t>> pubKeys;
+                if (isSigned) {
+                    scriptSig = hex::toByteArray(preparedInputs[i].output.script);
+                    pubKeys = preparedInputs[i].pubKeys;
+                }
+                tx->addInput(
+                        std::shared_ptr<BitcoinLikeWritableInput>(
+                                new BitcoinLikeWritableInput(nullptr,
+                                                            nullptr,
+                                                            preparedInputs[i].sequence,
+                                                            pubKeys,
+                                                            {},
+                                                            preparedInputs[i].address,
+                                                            nullptr,
+                                                            preparedInputs[i].previousTxHash,
+                                                            preparedInputs[i].outputIndex,
+                                                            scriptSig,
+                                                            std::shared_ptr<BitcoinLikeOutput>(
+                                                                    new BitcoinLikeOutput(
+                                                                            preparedInputs[i].output, currency)),
+                                                            keychainEngine
+                                )
+                        )
+                );
+            }
+
+            return tx;
+        }
+
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/transactions/BitcoinLikeTransactionBuilder.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/transactions/BitcoinLikeTransactionBuilder.cpp
@@ -1,0 +1,208 @@
+/*
+ *
+ * BitcoinLikeTransactionBuilder.cpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 27/03/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/utils/Hex.hpp>
+#include <core/wallet/Amount.hpp>
+
+#include <bitcoin/BitcoinNetworks.hpp>
+#include <bitcoin/api/BitcoinLikeAddress.hpp>
+#include <bitcoin/scripts/BitcoinLikeScript.hpp>
+#include <bitcoin/scripts/BitcoinLikeInternalScript.hpp>
+#include <bitcoin/transactions/BitcoinLikeTransactionBuilder.hpp>
+
+namespace ledger {
+    namespace core {
+
+        static const std::shared_ptr<BigInt> DEFAULT_MAX_AMOUNT = std::make_shared<BigInt>(BigInt::fromHex(
+                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        )); // Max ui512
+
+        BitcoinLikeTransactionBuilder::BitcoinLikeTransactionBuilder(const BitcoinLikeTransactionBuilder &cpy)
+                : _request(std::make_shared<BigInt>(networks::getBitcoinLikeNetworkParameters(cpy._currency.name).DustAmount)) {
+            _currency = cpy._currency;
+            _build = cpy._build;
+            _request = cpy._request;
+            _context = cpy._context;
+            _logger = cpy._logger;
+        }
+
+        BitcoinLikeTransactionBuilder::BitcoinLikeTransactionBuilder(
+                const std::shared_ptr<api::ExecutionContext> &context, const api::Currency &currency,
+                const std::shared_ptr<spdlog::logger> &logger,
+                const BitcoinLikeTransactionBuildFunction &buildFunction) :
+                _request(std::make_shared<BigInt>(networks::getBitcoinLikeNetworkParameters(currency.name).DustAmount)) {
+            _currency = currency;
+            _build = buildFunction;
+            _context = context;
+            _logger = logger;
+            _request.wipe = false;
+        }
+
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+        BitcoinLikeTransactionBuilder::addInput(const std::string &transactionHash, int32_t index, int32_t sequence) {
+            //Fix: use uniform initialization
+            using InputType = std::tuple<std::string, int32_t, uint32_t>;
+            InputType new_input{transactionHash, index, sequence};
+            _request.inputs.emplace_back(std::move(new_input));
+            return shared_from_this();
+        }
+
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+        BitcoinLikeTransactionBuilder::addOutput(const std::shared_ptr<api::Amount> &amount,
+                                                 const std::shared_ptr<api::BitcoinLikeScript> &script) {
+            auto a = std::dynamic_pointer_cast<Amount>(std::dynamic_pointer_cast<Amount>(amount))->value();
+            _request.outputs.push_back(std::tuple<std::shared_ptr<BigInt>, std::shared_ptr<api::BitcoinLikeScript>>(a, script));
+            return shared_from_this();
+        }
+
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+        BitcoinLikeTransactionBuilder::addChangePath(const std::string &path) {
+            _request.changePaths.push_back(path);
+            return shared_from_this();
+        }
+
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+        BitcoinLikeTransactionBuilder::excludeUTXO(const std::string &transactionHash, int32_t outputIndex) {
+            //Fix: use uniform initialization
+            using UTXOType = std::tuple<std::string, int32_t>;
+            UTXOType excluded_UTXO{transactionHash, outputIndex};
+            _request.excludedUTXO.push_back(excluded_UTXO);
+            return shared_from_this();
+        }
+
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+        BitcoinLikeTransactionBuilder::setNumberOfChangeAddresses(int32_t count) {
+            _request.changeCount = count;
+            return shared_from_this();
+        }
+
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+        BitcoinLikeTransactionBuilder::pickInputs(api::BitcoinLikePickingStrategy strategy, int32_t sequence) {
+            //Fix: use uniform initialization
+            using UTXOPickerType = std::tuple<api::BitcoinLikePickingStrategy, uint32_t>;
+            UTXOPickerType new_UTXO_picker{strategy, sequence};
+            _request.UTXOPicker = Option<UTXOPickerType>(std::move(new_UTXO_picker));
+            return shared_from_this();
+        }
+
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+        BitcoinLikeTransactionBuilder::sendToAddress(const std::shared_ptr<api::Amount> &amount,
+                                                     const std::string &address) {
+            addOutput(amount, createSendScript(address));
+            return shared_from_this();
+        }
+
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+        BitcoinLikeTransactionBuilder::wipeToAddress(const std::string &address) {
+            //First reset request
+            reset();
+            //Wipe mode
+            _request.wipe = true;
+            //We don't have the amount yet, will be set when we fill outputs in BitcoinLikeUTXOPicker
+            auto a = std::shared_ptr<BigInt>();
+            auto script = createSendScript(address);
+            _request.outputs.push_back(std::tuple<std::shared_ptr<BigInt>, std::shared_ptr<api::BitcoinLikeScript>>(a, script));
+            return shared_from_this();
+        }
+
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+        BitcoinLikeTransactionBuilder::setFeesPerByte(const std::shared_ptr<api::Amount> &fees) {
+            _request.feePerByte = std::dynamic_pointer_cast<Amount>(fees)->value();
+            return shared_from_this();
+        }
+
+        void
+        BitcoinLikeTransactionBuilder::build(const std::function<void(std::shared_ptr<api::BitcoinLikeTransaction>, std::experimental::optional<api::Error>)> & callback) {
+            build().callback(_context, callback);
+        }
+
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+        BitcoinLikeTransactionBuilder::setMaxAmountOnChange(const std::shared_ptr<api::Amount> &amount) {
+            _request.maxChange = std::dynamic_pointer_cast<Amount>(amount)->value();
+            return shared_from_this();
+        }
+
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder>
+        BitcoinLikeTransactionBuilder::setMinAmountOnChange(const std::shared_ptr<api::Amount> &amount) {
+            _request.minChange = std::dynamic_pointer_cast<Amount>(amount)->value();
+            return shared_from_this();
+        }
+
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder> BitcoinLikeTransactionBuilder::clone() {
+            return std::make_shared<BitcoinLikeTransactionBuilder>(*this);
+        }
+
+        void BitcoinLikeTransactionBuilder::reset() {
+            _request = BitcoinLikeTransactionBuildRequest(std::make_shared<BigInt>(
+                    networks::getBitcoinLikeNetworkParameters(_currency.name).DustAmount)
+            );
+        }
+
+        Future<std::shared_ptr<api::BitcoinLikeTransaction>> BitcoinLikeTransactionBuilder::build() {
+            return _build(_request);
+        }
+
+        std::shared_ptr<api::BitcoinLikeScript>
+        BitcoinLikeTransactionBuilder::createSendScript(const std::string &address) {
+            auto a = std::dynamic_pointer_cast<BitcoinLikeAddress>(BitcoinLikeAddress::parse(address, _currency));
+            if (a == nullptr) {
+                throw make_exception(api::ErrorCode::RUNTIME_ERROR, "Invalid address {}", address);
+            }
+            BitcoinLikeScript script;
+            if (a->isP2PKH()) {
+                script << btccore::OP_DUP << btccore::OP_HASH160 << a->getHash160() << btccore::OP_EQUALVERIFY
+                       << btccore::OP_CHECKSIG;
+            } else if (a->isP2SH()) {
+                script << btccore::OP_HASH160 << a->getHash160() << btccore::OP_EQUAL;
+            } else if (a->isP2WPKH() || a->isP2WSH()) {
+                script << btccore::OP_0 << a->getHash160();
+            } else {
+                throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Cannot create output script from {}.", address);
+            }
+
+            auto &additionalBIPS = networks::getBitcoinLikeNetworkParameters(_currency.name).AdditionalBIPs;
+            auto it = std::find(additionalBIPS.begin(), additionalBIPS.end(), "BIP115");
+            if (it != additionalBIPS.end()) {
+                script << hex::toByteArray(networks::BIP115_PARAMETERS.blockHash)
+                       << networks::BIP115_PARAMETERS.blockHeight
+                       << btccore::OP_CHECKBLOCKATHEIGHT;
+            }
+            return std::make_shared<BitcoinLikeInternalScript>(script);
+        }
+
+        BitcoinLikeTransactionBuildRequest::BitcoinLikeTransactionBuildRequest(
+                const std::shared_ptr<BigInt> &minChange) {
+            this->minChange = minChange;
+            this->maxChange = DEFAULT_MAX_AMOUNT;
+        }
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/transactions/BitcoinLikeTransactionParser.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/transactions/BitcoinLikeTransactionParser.cpp
@@ -1,0 +1,183 @@
+/*
+ *
+ * BitcoinLikeTransactionParser
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 27/03/2017.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/utils/DateUtils.hpp>
+
+#include <bitcoin/transactions/BitcoinLikeTransactionParser.hpp>
+
+#define PROXY_PARSE(method, ...)                                    \
+ auto& currentObject = _hierarchy.top();                            \
+ if (currentObject == "block") {                                    \
+    return _blockParser.method(__VA_ARGS__);                        \
+ } else if (currentObject == "inputs") {                            \
+    return _inputParser.method(__VA_ARGS__);                        \
+ } else if (currentObject == "outputs") {                           \
+    return _outputParser.method(__VA_ARGS__);                        \
+ } else                                                             \
+
+namespace ledger {
+    namespace core {
+
+        bool BitcoinLikeTransactionParser::Key(const rapidjson::Reader::Ch *str, rapidjson::SizeType length, bool copy) {
+            _lastKey = std::string(str, length);
+            PROXY_PARSE(Key, str, length, copy) {
+                return true;
+            }
+        }
+
+        bool BitcoinLikeTransactionParser::StartObject() {
+            if (_arrayDepth == 0) {
+                _hierarchy.push(_lastKey);
+            }
+
+            auto& currentObject = _hierarchy.top();
+
+            if (currentObject == "inputs") {
+                BitcoinLikeBlockchainExplorerInput input;
+                _transaction->inputs.push_back(input);
+                _inputParser.init(&_transaction->inputs.back());
+            } else if (currentObject == "outputs") {
+                BitcoinLikeBlockchainExplorerOutput output;
+                _transaction->outputs.push_back(output);
+                _outputParser.init(&_transaction->outputs.back());
+                // Set block height
+                if (_transaction->block.hasValue()) {
+                    _transaction->outputs.back().blockHeight = _transaction->block.getValue().height;
+                }
+            } else if (currentObject == "block") {
+                BitcoinLikeBlockchainExplorer::Block block;
+                _transaction->block = Option<BitcoinLikeBlockchainExplorer::Block>(block);
+                _blockParser.init(&_transaction->block.getValue());
+            }
+
+            return true;
+        }
+
+        bool BitcoinLikeTransactionParser::EndObject(rapidjson::SizeType memberCount) {
+            auto& currentObject = _hierarchy.top();
+
+            if (_arrayDepth == 0) {
+                _hierarchy.pop();
+            }
+            return true;
+        }
+
+        bool BitcoinLikeTransactionParser::StartArray() {
+            if (_arrayDepth == 0) {
+                _hierarchy.push(_lastKey);
+            }
+            _arrayDepth += 1;
+            return true;
+        }
+
+        bool BitcoinLikeTransactionParser::EndArray(rapidjson::SizeType elementCount) {
+            _arrayDepth -= 1;
+            if (_arrayDepth == 0) {
+                _hierarchy.pop();
+            }
+            return true;
+        }
+
+        bool BitcoinLikeTransactionParser::Null() {
+            PROXY_PARSE(Null) {
+                return true;
+            }
+        }
+
+        bool BitcoinLikeTransactionParser::Bool(bool b) {
+            PROXY_PARSE(Bool, b) {
+                return true;
+            }
+        }
+
+        bool BitcoinLikeTransactionParser::Int(int i) {
+            return Uint64(i);
+        }
+
+        bool BitcoinLikeTransactionParser::Uint(unsigned i) {
+            return Uint64(i);
+        }
+
+        bool BitcoinLikeTransactionParser::Int64(int64_t i) {
+            return Uint64(i);
+        }
+
+        bool BitcoinLikeTransactionParser::Uint64(uint64_t i) {
+            PROXY_PARSE(Uint64, i) {
+                return true;
+            }
+        }
+
+        bool BitcoinLikeTransactionParser::Double(double d) {
+            PROXY_PARSE(Double, d) {
+                return true;
+            }
+        }
+
+        bool BitcoinLikeTransactionParser::RawNumber(const rapidjson::Reader::Ch *str, rapidjson::SizeType length, bool copy) {
+            PROXY_PARSE(RawNumber, str, length, copy) {
+                std::string number(str, length);
+                BigInt value = BigInt::fromString(number);
+                if (_lastKey == "lock_time") {
+                    _transaction->lockTime = value.toUint64();
+                } else if (_lastKey == "fees") {
+                    _transaction->fees = Option<BigInt>(value);
+                } else if (_lastKey == "confirmations") {
+                    _transaction->confirmations = value.toUint64();
+                }
+                return true;
+            }
+        }
+
+        bool BitcoinLikeTransactionParser::String(const rapidjson::Reader::Ch *str, rapidjson::SizeType length, bool copy) {
+            PROXY_PARSE(String, str, length, copy) {
+                std::string value(str, length);
+                if (_lastKey == "hash") {
+                    _transaction->hash = value;
+                } else if (_lastKey == "received_at") {
+                    _transaction->receivedAt = DateUtils::fromJSON(value);
+                }
+                return true;
+            }
+        }
+
+        BitcoinLikeTransactionParser::BitcoinLikeTransactionParser(std::string& lastKey) :
+            _lastKey(lastKey), _blockParser(lastKey), _inputParser(lastKey), _outputParser(lastKey)
+        {
+            _arrayDepth = 0;
+        }
+
+        void BitcoinLikeTransactionParser::init(BitcoinLikeBlockchainExplorerTransaction *transaction) {
+            _transaction = transaction;
+        }
+
+    }
+}

--- a/ledger-core-bitcoin/src/bitcoin/transactions/BitcoinLikeUTXOPicker.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/transactions/BitcoinLikeUTXOPicker.cpp
@@ -1,0 +1,251 @@
+/*
+ *
+ * BitcoinLikeUTXOPicker.cpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 28/03/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/async/Promise.hpp>
+#include <core/utils/ImmediateExecutionContext.hpp>
+
+#include <bitcoin/api/BitcoinLikeScript.hpp>
+#include <bitcoin/api/BitcoinLikeScriptChunk.hpp>
+#include <bitcoin/scripts/BitcoinLikeInternalScript.hpp>
+#include <bitcoin/transactions/BitcoinLikeTransaction.hpp>
+#include <bitcoin/transactions/BitcoinLikeUTXOPicker.hpp>
+
+namespace ledger {
+    namespace core {
+
+
+        BitcoinLikeUTXOPicker::BitcoinLikeUTXOPicker(const std::shared_ptr<api::ExecutionContext> &context,
+                                                     const api::Currency &currency) : DedicatedContext(context),
+                                                                                      _currency(currency)
+        {}
+
+        BitcoinLikeTransactionBuildFunction
+        BitcoinLikeUTXOPicker::getBuildFunction(const BitcoinLikeGetUTXOFunction &getUTXO,
+                                                const BitcoinLikeGetTxFunction& getTransaction,
+                                                const std::shared_ptr<BitcoinLikeBlockchainExplorer> &explorer,
+                                                const std::shared_ptr<BitcoinLikeKeychain> &keychain,
+                                                const uint64_t currentBlockHeight,
+                                                const std::shared_ptr<spdlog::logger>& logger,
+                                                bool partial)
+        {
+            auto self = shared_from_this();
+            logger->info("Get build function");
+            return [=] (const BitcoinLikeTransactionBuildRequest& r) -> Future<std::shared_ptr<api::BitcoinLikeTransaction>> {
+                return self->async<std::shared_ptr<Buddy>>([=] () {
+                    logger->info("Constructing BitcoinLikeTransactionBuildFunction with blockHeight: {}", currentBlockHeight);
+                    auto tx = std::make_shared<BitcoinLikeTransaction>(self->_currency, keychain->getKeychainEngine(), currentBlockHeight);
+                    auto filteredGetUTXO = createFilteredUTXOFunction(r, getUTXO);
+                    return std::make_shared<Buddy>(r, filteredGetUTXO, getTransaction, explorer, keychain, logger, tx, partial);
+                }).flatMap<std::shared_ptr<api::BitcoinLikeTransaction>>(ImmediateExecutionContext::INSTANCE, [=] (const std::shared_ptr<Buddy>& buddy) -> Future<std::shared_ptr<api::BitcoinLikeTransaction>> {
+                    buddy->logger->info("Buddy created");
+                    return self->fillInputs(buddy).flatMap<Unit>(ImmediateExecutionContext::INSTANCE, [=] (const Unit&) -> Future<Unit> {
+                        return self->fillOutputs(buddy);
+                    }).flatMap<Unit>(ImmediateExecutionContext::INSTANCE, [=] (const Unit&) -> Future<Unit> {
+                        return self->fillTransactionInfo(buddy);
+                    }).mapPtr<api::BitcoinLikeTransaction>(ImmediateExecutionContext::INSTANCE, [=] (const Unit&) -> std::shared_ptr<api::BitcoinLikeTransaction> {
+                        buddy->logger->info("Empty transaction built");
+                        return buddy->transaction;
+                    });;
+                });
+            };;
+        }
+
+        const api::Currency &BitcoinLikeUTXOPicker::getCurrency() const {
+            return _currency;
+        }
+
+        Future<Unit> BitcoinLikeUTXOPicker::fillOutputs(const std::shared_ptr<Buddy>& buddy) {
+            // Fill reception outputs
+            auto params = networks::getBitcoinLikeNetworkParameters(getCurrency().name);
+            auto outputIndex = 0;
+            for (auto &output : buddy->request.outputs) {
+                auto amount = std::get<0>(output);
+                //Set right amount if we are in wipe mode
+                if(buddy->request.wipe) {
+                    amount = std::make_shared<ledger::core::BigInt>(buddy->outputAmount);
+                }
+                auto script = std::dynamic_pointer_cast<BitcoinLikeInternalScript>(std::get<1>(output))->getScript();
+                auto address = script.parseAddress(getCurrency()).map<std::string>([] (const BitcoinLikeAddress& addr) {
+                    return addr.getStringAddress();
+                });
+                BitcoinLikeBlockchainExplorerOutput out;
+                out.index = static_cast<uint64_t>(outputIndex);
+                out.value = *amount;
+                out.address = address;
+                out.script = hex::toString(script.serialize());
+                std::shared_ptr<api::DerivationPath> derivationPath = nullptr;
+                if (address.nonEmpty()) {
+                    auto path = buddy->keychain->getAddressDerivationPath(out.address.getValue());
+                    if (path.nonEmpty()) {
+                        derivationPath = std::make_shared<DerivationPath>(DerivationPath(path.getValue()));
+                    }
+                } else {
+                    auto addressFromScript = script.parseAddress(getCurrency());
+                    if (addressFromScript.nonEmpty())
+                        out.address = addressFromScript.getValue().toString();
+                }
+                outputIndex += 1;
+                buddy->transaction->addOutput(std::make_shared<BitcoinLikeOutput>(out, getCurrency(), derivationPath));
+            }
+
+            // Fill change outputs
+
+            if (buddy->changeAmount > BigInt(networks::getBitcoinLikeNetworkParameters(_currency.name).DustAmount)) {
+                // TODO implement multi change
+                // TODO implement use specific change address
+                auto changeAddress = buddy->keychain->getFreshAddress(BitcoinLikeKeychain::CHANGE)->toString();
+
+                auto amount = buddy->changeAmount;
+                auto script = BitcoinLikeScript::fromAddress(changeAddress, _currency);
+                BitcoinLikeBlockchainExplorerOutput out;
+                out.index = static_cast<uint64_t>(buddy->transaction->getOutputs().size());
+                out.value = amount;
+                out.address = Option<std::string>(changeAddress).toOptional();
+                out.script = hex::toString(script.serialize());
+                std::shared_ptr<DerivationPath> derivationPath = nullptr;
+                auto path = buddy->keychain->getAddressDerivationPath(changeAddress);
+                if (path.nonEmpty()) {
+                    derivationPath = std::make_shared<DerivationPath>(DerivationPath(path.getValue()));
+                }
+                buddy->transaction->addOutput(std::make_shared<BitcoinLikeOutput>(out, getCurrency(), derivationPath));
+            }
+
+            return Future<Unit>::successful(unit);
+        }
+
+        Future<Unit> BitcoinLikeUTXOPicker::fillTransactionInfo(const std::shared_ptr<Buddy>& buddy) {
+            if (buddy->isPartial) {
+                return Future<Unit>::successful(unit);
+            }
+            //Set timestamp
+            buddy->explorer->getTimestamp().onComplete(ImmediateExecutionContext::INSTANCE, [=] (const Try<int64_t> &timestamp){
+                if (timestamp.isSuccess()) {
+                    buddy->transaction->setTimestamp(timestamp.getValue());
+                }
+            });
+
+            return buddy->explorer->getCurrentBlock().map<Unit>(ImmediateExecutionContext::INSTANCE, [=] (const std::shared_ptr<BitcoinLikeBlockchainExplorer::Block>& block) -> Unit{
+                buddy->transaction->setLockTime(static_cast<uint32_t>(block->height));
+                return unit;
+            });
+        }
+
+        Future<Unit> BitcoinLikeUTXOPicker::fillInputs(const std::shared_ptr<Buddy>& buddy) {
+            buddy->logger->info("Filling inputs");
+            auto self = shared_from_this();
+            auto pickUTXO = [=] () -> Future<UTXODescriptorList> {
+                if (buddy->request.UTXOPicker.nonEmpty()) {
+                   return self->filterInputs(buddy);
+                }
+                return Future<UTXODescriptorList>::successful(std::move(UTXODescriptorList()));
+            };
+
+            auto inputs = std::make_shared<UTXODescriptorList>();
+            static std::function<Future<Unit> (int, const std::shared_ptr<UTXODescriptorList>&, const std::shared_ptr<Buddy>&, const std::shared_ptr<BitcoinLikeUTXOPicker>&)> performFill
+            = [] (int index, const std::shared_ptr<UTXODescriptorList>& inputs, const std::shared_ptr<Buddy>& buddy, const std::shared_ptr<BitcoinLikeUTXOPicker>& self) mutable -> Future<Unit> {
+                if (index >= inputs->size())
+                    return Future<Unit>::successful(unit);
+                return self->fillInput(buddy, (*inputs)[index]).flatMap<Unit>(ImmediateExecutionContext::INSTANCE, [=] (const Unit&) {
+                    return performFill(index + 1, inputs, buddy, self);
+                });
+            };
+            inputs->insert(inputs->end(), buddy->request.inputs.begin(), buddy->request.inputs.end());
+            return performFill(0, inputs, buddy, self).flatMap<UTXODescriptorList>(ImmediateExecutionContext::INSTANCE, [=] (const Unit&) mutable -> Future<UTXODescriptorList> {
+                return pickUTXO();
+            }).flatMap<Unit>(ImmediateExecutionContext::INSTANCE, [=] (const UTXODescriptorList& UTXO) mutable -> Future<Unit> {
+                auto offset = static_cast<int>(inputs->size());
+                inputs->insert(inputs->end(), UTXO.begin(), UTXO.end());
+                return performFill(offset, inputs, buddy, self);
+            });
+        }
+
+        Future<Unit> BitcoinLikeUTXOPicker::fillInput(const std::shared_ptr<BitcoinLikeUTXOPicker::Buddy> &buddy,
+                                                      const BitcoinLikeUTXOPicker::UTXODescriptor &desc) {
+            const std::string& hash = std::get<0>(desc);
+            auto txGetter = [=] (const std::string &hash) -> FuturePtr<BitcoinLikeBlockchainExplorerTransaction> {
+                if (buddy->isPartial) {
+                    return buddy->getTransaction(hash);
+                }
+                return buddy->explorer->getTransactionByHash(hash);
+            };
+            return txGetter(hash).map<Unit>(ImmediateExecutionContext::INSTANCE, [=] (const std::shared_ptr<BitcoinLikeBlockchainExplorerTransaction>& tx) {
+                buddy->logger->debug("Get output {} on {}", std::get<1>(desc), tx->outputs.size());
+                auto output = tx->outputs[std::get<1>(desc)];
+                std::vector<std::vector<uint8_t>> pub_keys;
+                std::vector<std::shared_ptr<api::DerivationPath>> paths;
+
+                // Get derivations and public keys
+                if (output.address.nonEmpty()) {
+                    auto derivationPath = buddy->keychain->getAddressDerivationPath(output.address.getValue());
+                    if (derivationPath.nonEmpty()) {
+                        paths.push_back(std::make_shared<DerivationPath>(DerivationPath(derivationPath.getValue())));
+                        pub_keys.push_back(buddy->keychain->getPublicKey(output.address.getValue()).getValue());
+                    }
+                }
+                auto input = std::shared_ptr<BitcoinLikeWritableInput>(
+                        new BitcoinLikeWritableInput(
+                                buddy->explorer, getContext(), std::get<2>(desc), pub_keys, paths,
+                                output.address.getValueOr(""),
+                                std::make_shared<Amount>(buddy->keychain->getCurrency(), 0, output.value),
+                                hash, std::get<1>(desc), {}, std::make_shared<BitcoinLikeOutput>(output, _currency)
+                        )
+                );
+                buddy->transaction->addInput(input);
+                return unit;
+            });
+        }
+
+        BitcoinLikeGetUTXOFunction
+        BitcoinLikeUTXOPicker::createFilteredUTXOFunction(const BitcoinLikeTransactionBuildRequest &request,
+                                                          const BitcoinLikeGetUTXOFunction &getUTXO) {
+            return [=] () -> Future<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>> {
+                return getUTXO().map<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>>(getContext(), [=] (const std::vector<std::shared_ptr<api::BitcoinLikeOutput>>& UTXO) {
+                    std::vector<std::shared_ptr<api::BitcoinLikeOutput>> filtered;
+                    auto isExcluded = [&] (const std::shared_ptr<api::BitcoinLikeOutput>& output) -> bool {
+                        for (auto& o : request.excludedUTXO) {
+                            auto hash = std::get<0>(o);
+                            auto index = std::get<1>(o);
+                            if (output->getTransactionHash() == hash && output->getOutputIndex() == index)
+                                return true;
+                        }
+                        return false;
+                    };
+                    for (auto& output : UTXO) {
+                        if (!isExcluded(output)) {
+                            filtered.push_back(output);
+                        }
+                    }
+                    return filtered;
+                });
+            };
+        }
+    }
+}


### PR DESCRIPTION
This PR contains the segregation of BTC without the latest fixes on `develop`and without any tests.

Some classes had been renamed to be consistent with the rest of our codebase. For instance `BitcoinLikeUtxoPicker` and `BlockParser` become respectively `BitcoinLikeUTXOPicker` and `BitcoinLikeBlockParser`.

## Mandatory picture of a cat
![tong_cat](https://user-images.githubusercontent.com/6042495/72819965-72e68300-3c6e-11ea-885b-de7a806a8ce8.gif)
