### PR TITLE
PostgreSQL support: build libcore with PG support only for JNI builds

### DIFF
--- a/.circleci/build_lib.sh
+++ b/.circleci/build_lib.sh
@@ -16,12 +16,12 @@ export PATH=$PATH:~/cmake_folder/bin
 ###
 
 function command_target_jni {
-  add_to_cmake_params -DTARGET_JNI=ON
+  add_to_cmake_params -DTARGET_JNI=ON -DPG_SUPPORT=ON -DPostgreSQL_INCLUDE_DIR=/usr/include/postgresql
 }
 
 function command_Release {
   BUILD_CONFIG="Release"
-  add_to_cmake_params -DBUILD_TESTS=OFF -DPG_SUPPORT=ON -DPostgreSQL_INCLUDE_DIR=/usr/include/postgresql
+  add_to_cmake_params -DBUILD_TESTS=OFF
 }
 
 function command_Debug {


### PR DESCRIPTION
We activate PG support only for JNI builds (for the Vault) not to introduce any issues on Live's side.
Activating it for Live would require building PG in libcore and link against it: https://ledgerhq.atlassian.net/browse/LLC-517