### PR TITLE
Fix Ethereum ReorgLastBlock test segfault.

### DIFF
--- a/core/test/integration/synchronization/ethereum_synchronization.cpp
+++ b/core/test/integration/synchronization/ethereum_synchronization.cpp
@@ -31,6 +31,7 @@
 #include <gtest/gtest.h>
 #include "../BaseFixture.h"
 #include <set>
+#include <api/ConfigurationDefaults.hpp>
 #include <api/KeychainEngines.hpp>
 #include <api/EthereumLikeTransaction.hpp>
 #include <api/OperationOrderKey.hpp>
@@ -108,7 +109,7 @@ TEST_F(EthereumLikeWalletSynchronization, MediumXpubSynchronization) {
                     auto amountToSend = std::make_shared<api::BigIntImpl>(BigInt::fromString("10"));
                     auto transferData = wait(std::dynamic_pointer_cast<ERC20LikeAccount>(erc20Accounts[0])->getTransferToAddressData(amountToSend, "0xabf06640f8ca8fC5e0Ed471b10BeFCDf65A33e43"));
                     EXPECT_GT(transferData.size(), 0);
-                    
+
                     auto operations = wait(std::dynamic_pointer_cast<OperationQuery>(erc20Accounts[0]
                                                                                              ->queryOperations()
                                                                                              ->addOrder(api::OperationOrderKey::DATE, true)
@@ -347,6 +348,9 @@ TEST_F(EthereumLikeWalletSynchronization, ReorgLastBlock) {
     auto walletName = "e847815f-488a-4301-b67c-378a5e9c8a61";
     {
         auto fakeHttp = std::make_shared<test::FakeHttpClient>();
+
+        backend = std::static_pointer_cast<DatabaseBackend>(DatabaseBackend::getSqlite3Backend());
+
         auto pool = WalletPool::newInstance(
             "my_ppol",
             "",
@@ -373,8 +377,8 @@ TEST_F(EthereumLikeWalletSynchronization, ReorgLastBlock) {
                 test::UrlConnectionData blockNotFound;
                 blockNotFound.statusCode = 404;
                 blockNotFound.body = "Block 0xaef3a92f1017445c98139b7ab3ddd6e8abfe75588652338ca6f537cf47ab620d not found";
-                
-                fakeHttp->setBehavior({ 
+
+                fakeHttp->setBehavior({
                     {
                         "http://test.test/blockchain/v3/eth/blocks/current" ,
                         test::FakeUrlConnection::fromString("{\"hash\":\"0xdd73566cf4913cba5060377397283cf411e03bdbe1b83d4695699d9e6ac1c941\",\"height\":8175344,\"time\":\"2019-07-18T14:54:00Z\",\"txs\":[]}")


### PR DESCRIPTION
# Content

The problem was due to the fact most of the time, we use newDefaultPool,
which wraps the backend construction. In the case of ReorgLastBlock, the
WalletPool is hand-crafted and backend is not initialized (it’s a null
shared pointer).

Fixes LLC-514.

# Mandatory picture of animal

![](https://phaazon.net/media/uploads/shibacumber.gif)