### PR TITLE
Fix integer overflow on DerivationPath

### DIFF
--- a/ledger-core/idl/derivation.djinni
+++ b/ledger-core/idl/derivation.djinni
@@ -1,16 +1,16 @@
 DerivationPath = interface +c {
     # Get the number of element in this path.
-    const getDepth(): i32;
+    const getDepth(): i64;
 
     # Get the child num at the given index in the path.
-    const getChildNum(index: i32): i32;
+    const getChildNum(index: i64): i64;
 
     # Get the child num at the given index in the path. If the child num is hardened, returns it
     # without the hardened marker bit.
-    const getUnhardenedChildNum(index: i32): i32;
+    const getUnhardenedChildNum(index: i64): i64;
 
     # Return true if the given index in the path is an hardened child num.
-    const isHardened(index: i32): bool;
+    const isHardened(index: i64): bool;
 
     # Serialize the given path to a human readable string like "44'/0'/0'/0/0".
     const toString(addLeadingM: bool): string;
@@ -20,7 +20,7 @@ DerivationPath = interface +c {
     const getAbstractParent(): DerivationPath;
 
     # Return an array where which item is a child num of the path.
-    const toVector(): list<i32>;
+    const toVector(): list<i64>;
 
     static parse(path: string): DerivationPath;
 }

--- a/ledger-core/inc/core/key/ExtendedPublicKey.hpp
+++ b/ledger-core/inc/core/key/ExtendedPublicKey.hpp
@@ -48,7 +48,7 @@ namespace ledger {
         template <class NetworkParameters>
         class ExtendedPublicKey {
         public:
-            static inline DeterministicPublicKey _derive(int index, const std::vector<int32_t>& childNums, const DeterministicPublicKey& key) {
+            static inline DeterministicPublicKey _derive(int index, const std::vector<int64_t>& childNums, const DeterministicPublicKey& key) {
                 if (index >= childNums.size()) {
                     return key;
                 }

--- a/ledger-core/inc/core/utils/DerivationPath.hpp
+++ b/ledger-core/inc/core/utils/DerivationPath.hpp
@@ -42,34 +42,34 @@ namespace ledger {
         class DerivationPath : public api::DerivationPath {
         public:
             explicit DerivationPath(const std::string& path);
-            explicit DerivationPath(const std::vector<int32_t>& path);
+            explicit DerivationPath(const std::vector<int64_t>& path);
             DerivationPath(const DerivationPath& path);
             DerivationPath(DerivationPath&& path);
             DerivationPath& operator=(DerivationPath&& path);
             DerivationPath& operator=(const DerivationPath& path);
 
-            int32_t getDepth() const override;
-            int32_t getChildNum(int32_t index) const override;
-            int32_t getUnhardenedChildNum(int32_t index) const override;
-            bool isHardened(int32_t index) const override;
+            int64_t getDepth() const override;
+            int64_t getChildNum(int64_t index) const override;
+            int64_t getUnhardenedChildNum(int64_t index) const override;
+            bool isHardened(int64_t index) const override;
             std::string toString(bool addLeadingM = false) const override;
             std::shared_ptr<api::DerivationPath> getAbstractParent() const override;
-            std::vector<int32_t> toVector() const override;
+            std::vector<int64_t> toVector() const override;
 
             DerivationPath getParent() const;
-            int32_t getLastChildNum() const;
-            int32_t getNonHardenedChildNum(int index) const;
-            int32_t getNonHardenedLastChildNum() const;
+            int64_t getLastChildNum() const;
+            int64_t getNonHardenedChildNum(int64_t index) const;
+            int64_t getNonHardenedLastChildNum() const;
             bool isRoot() const;
             bool isLastChildHardened() const;
  
-            int32_t operator[](int32_t index) const;
+            int64_t operator[](int64_t index) const;
             DerivationPath operator+(const DerivationPath& derivationPath) const;
             bool operator==(const DerivationPath& path) const;
             bool operator!=(const DerivationPath& path) const;
 
         public:
-            static std::vector<int32_t> parse(const std::string& path);
+            static std::vector<int64_t> parse(const std::string& path);
             static DerivationPath fromScheme(
                 const std::string& scheme,
                 int coinType,
@@ -80,9 +80,9 @@ namespace ledger {
             );
 
         private:
-            inline void assertIndexIsValid(int32_t index, const std::string& method) const;
+            inline void assertIndexIsValid(int64_t index, const std::string& method) const;
 
-            std::vector<int32_t> _path;
+            std::vector<int64_t> _path;
         };
     }
 }

--- a/ledger-core/src/core/utils/DerivationScheme.cpp
+++ b/ledger-core/src/core/utils/DerivationScheme.cpp
@@ -148,7 +148,7 @@ namespace ledger {
         }
 
         DerivationPath DerivationScheme::getPath() {
-            std::function<int32_t (const DerivationSchemeNode&)> map = [] (const DerivationSchemeNode &item) -> int32_t {
+            std::function<int64_t (const DerivationSchemeNode&)> map = [] (const DerivationSchemeNode &item) -> int64_t {
                 return item.value | (item.hardened ? 0x80000000 : 0x00);
             };
             auto segments = functional::map(_scheme, map);


### PR DESCRIPTION
Since we modified `DerivationPath` to inherit from its api, we use `int32_t` (because of djinni limitation) instead of `uint32_t`. 
The problem is hardened derivation value is between 2^31 and 2^32 so the value cannot fit into its type anymore.

I found a "solution" : USE `int64_t` !

![troll](https://user-images.githubusercontent.com/6042495/73007654-300ee180-3e0d-11ea-8bdd-c5695491e2c1.gif)

One more thing I refactorized a bit the `DerivationPath::parse` method