### PR TITLE
Fix static order initialization in BitcoinLikeCurrencies

### DIFF
--- a/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeCurrencies.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeCurrencies.hpp
@@ -43,29 +43,29 @@
 namespace ledger {
     namespace core {
         namespace currencies {
-            extern LIBCORE_EXPORT const api::Currency BITCOIN;
-            extern LIBCORE_EXPORT const api::Currency BITCOIN_TESTNET;
-            extern LIBCORE_EXPORT const api::Currency BITCOIN_CASH;
-            extern LIBCORE_EXPORT const api::Currency BITCOIN_GOLD;
-            extern LIBCORE_EXPORT const api::Currency ZCASH;
-            extern LIBCORE_EXPORT const api::Currency ZENCASH;
-            extern LIBCORE_EXPORT const api::Currency LITECOIN;
-            extern LIBCORE_EXPORT const api::Currency PEERCOIN;
-            extern LIBCORE_EXPORT const api::Currency DIGIBYTE;
-            extern LIBCORE_EXPORT const api::Currency HCASH;
-            extern LIBCORE_EXPORT const api::Currency QTUM;
-            extern LIBCORE_EXPORT const api::Currency STEALTHCOIN;
-            extern LIBCORE_EXPORT const api::Currency VERTCOIN;
-            extern LIBCORE_EXPORT const api::Currency VIACOIN;
-            extern LIBCORE_EXPORT const api::Currency DASH;
-            extern LIBCORE_EXPORT const api::Currency DOGECOIN;
-            extern LIBCORE_EXPORT const api::Currency STRATIS;
-            extern LIBCORE_EXPORT const api::Currency KOMODO;
-            extern LIBCORE_EXPORT const api::Currency POSWALLET;
-            extern LIBCORE_EXPORT const api::Currency PIVX;
-            extern LIBCORE_EXPORT const api::Currency CLUBCOIN;
-            extern LIBCORE_EXPORT const api::Currency DECRED;
-            extern LIBCORE_EXPORT const api::Currency STAKENET;
+            api::Currency bitcoin();
+            api::Currency bitcoin_testnet();
+            api::Currency bitcoin_cash();
+            api::Currency bitcoin_gold();
+            api::Currency zcash();
+            api::Currency zencash();
+            api::Currency litecoin();
+            api::Currency peercoin();
+            api::Currency digibyte();
+            api::Currency hcash();
+            api::Currency qtum();
+            api::Currency stealthcoin();
+            api::Currency vertcoin();
+            api::Currency viacoin();
+            api::Currency dash();
+            api::Currency dogecoin();
+            api::Currency stratis();
+            api::Currency komodo();
+            api::Currency poswallet();
+            api::Currency pivx();
+            api::Currency clubcoin();
+            api::Currency decred();
+            api::Currency stakenet();
         }
     }
 }

--- a/ledger-core-bitcoin/src/bitcoin/BitcoinLikeCurrencies.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/BitcoinLikeCurrencies.cpp
@@ -36,183 +36,275 @@
 namespace ledger {
     namespace core {
         namespace currencies {
-            const api::Currency BITCOIN =
-                CurrencyBuilder("bitcoin")
-                .bip44(BITCOIN_COIN_ID)
-                .paymentUri("bitcoin")
-                    .unit("satoshi", 0, "satoshi")
-                    .unit("bitcoin", 8, "BTC")
-                    .unit("milli-bitcoin", 5, "mBTC")
-                    .unit("micro-bitcoin", 2, "μBTC");
+                api::Currency bitcoin() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("bitcoin")
+                                        .bip44(BITCOIN_COIN_ID)
+                                        .paymentUri("bitcoin")
+                                        .unit("satoshi", 0, "satoshi")
+                                        .unit("bitcoin", 8, "BTC")
+                                        .unit("milli-bitcoin", 5, "mBTC")
+                                        .unit("micro-bitcoin", 2, "μBTC");
 
-            const api::Currency BITCOIN_TESTNET =
-                    CurrencyBuilder("bitcoin_testnet")
-                            .bip44(BITCOIN_TESTNET_COIN_ID)
-                            .paymentUri("bitcoin")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("bitcoin", 8, "BTC")
-                            .unit("milli-bitcoin", 5, "mBTC")
-                            .unit("micro-bitcoin", 2, "μBTC");
+                        return CURRENCY;
+                }
 
-            const api::Currency BITCOIN_CASH =
-                    CurrencyBuilder("bitcoin_cash")
-                            .bip44(BITCOIN_CASH_COIN_ID)
-                            .paymentUri("bitcoin_cash")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("bitcoin cash", 8, "BCH")
-                            .unit("mBCH", 5, "mBCH")
-                            .unit("bit", 2, "bit");
+                api::Currency bitcoin_testnet() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("bitcoin_testnet")
+                                .bip44(BITCOIN_TESTNET_COIN_ID)
+                                .paymentUri("bitcoin")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("bitcoin", 8, "BTC")
+                                .unit("milli-bitcoin", 5, "mBTC")
+                                .unit("micro-bitcoin", 2, "μBTC");
 
-            const api::Currency BITCOIN_GOLD =
-                    CurrencyBuilder("bitcoin_gold")
-                            .bip44(BITCOIN_GOLD_COIN_ID)
-                            .paymentUri("bitcoin_gold")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("bitcoin gold", 8, "BTG")
-                            .unit("mBTG", 5, "mBTG")
-                            .unit("bit", 2, "bit");
+                        return CURRENCY;
+                }
 
-            const api::Currency ZCASH =
-                    CurrencyBuilder("zcash")
-                            .bip44(133)
-                            .paymentUri("zcash")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("zcash", 8, "ZEC");
+                api::Currency bitcoin_cash() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("bitcoin_cash")
+                                .bip44(BITCOIN_CASH_COIN_ID)
+                                .paymentUri("bitcoin_cash")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("bitcoin cash", 8, "BCH")
+                                .unit("mBCH", 5, "mBCH")
+                                .unit("bit", 2, "bit");
 
-            const api::Currency ZENCASH =
-                    CurrencyBuilder("zencash")
-                            .bip44(ZCASH_COIN_ID)
-                            .paymentUri("zencash")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("zencash", 8, "ZEN");
+                        return CURRENCY;
+                }
 
-            const api::Currency LITECOIN =
-                    CurrencyBuilder("litecoin")
-                            .bip44(LITE_COIN_ID)
-                            .paymentUri("litecoin")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("litecoin", 8, "LTC")
-                            .unit("milli-litecoin", 5, "mLTC")
-                            .unit("micro-litecoin", 2, "μLTC");
+                api::Currency bitcoin_gold() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("bitcoin_gold")
+                                .bip44(BITCOIN_GOLD_COIN_ID)
+                                .paymentUri("bitcoin_gold")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("bitcoin gold", 8, "BTG")
+                                .unit("mBTG", 5, "mBTG")
+                                .unit("bit", 2, "bit");
 
-            const api::Currency PEERCOIN =
-                    CurrencyBuilder("peercoin")
-                            .bip44(PEERCOIN_COIN_ID)
-                            .paymentUri("peercoin")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("peercoin", 6, "PPC")
-                            .unit("milli-peercoin", 3, "mPPC");
+                        return CURRENCY;
+                }
 
-            const api::Currency DIGIBYTE =
-                    CurrencyBuilder("digibyte")
-                            .bip44(DIGIBYTE_COIN_ID)
-                            .paymentUri("digibyte")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("digibyte", 8, "DGB");
+                api::Currency zcash() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("zcash")
+                                .bip44(133)
+                                .paymentUri("zcash")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("zcash", 8, "ZEC");
 
-            const api::Currency HCASH =
-                    CurrencyBuilder("hcash")
-                            .bip44(HCASH_COIN_ID)
-                            .paymentUri("hcash")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("hshare", 8, "HSR");
+                        return CURRENCY;
+                }
 
-            const api::Currency QTUM =
-                    CurrencyBuilder("qtum")
-                            .bip44(QTUM_COIN_ID)
-                            .paymentUri("qtum")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("qtum", 8, "QTUM");
+                api::Currency zencash() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("zencash")
+                                .bip44(ZCASH_COIN_ID)
+                                .paymentUri("zencash")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("zencash", 8, "ZEN");
 
-            const api::Currency STEALTHCOIN =
-                    CurrencyBuilder("stealthcoin")
-                            .bip44(STEALTHCOIN_COIN_ID)
-                            .paymentUri("stealthcoin")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("stealthcoin", 6, "XST")
-                            .unit("milli-stealthcoin", 3, "mXST");
+                        return CURRENCY;
+                }
 
-            const api::Currency VERTCOIN =
-                    CurrencyBuilder("vertcoin")
-                            .bip44(VERTCOIN_COIN_ID)
-                            .paymentUri("vertcoin")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("vertcoin", 8, "VTC")
-                            .unit("milli-vertcoin", 5, "mVTC");
+                api::Currency litecoin() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("litecoin")
+                                .bip44(LITE_COIN_ID)
+                                .paymentUri("litecoin")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("litecoin", 8, "LTC")
+                                .unit("milli-litecoin", 5, "mLTC")
+                                .unit("micro-litecoin", 2, "μLTC");
 
-            const api::Currency VIACOIN =
-                    CurrencyBuilder("viacoin")
-                            .bip44(VIACOIN_COIN_ID)
-                            .paymentUri("viacoin")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("viacoin", 8, "VIA")
-                            .unit("milli-viacoin", 5, "mVIA");
+                        return CURRENCY;
+                }
 
-            const api::Currency DASH =
-                    CurrencyBuilder("dash")
-                            .bip44(DASH_COIN_ID)
-                            .paymentUri("dash")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("dash", 8, "DASH");
+                api::Currency peercoin() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("peercoin")
+                                .bip44(PEERCOIN_COIN_ID)
+                                .paymentUri("peercoin")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("peercoin", 6, "PPC")
+                                .unit("milli-peercoin", 3, "mPPC");
 
-            const api::Currency DOGECOIN =
-                    CurrencyBuilder("dogecoin")
-                            .bip44(DOGECOIN_COIN_ID)
-                            .paymentUri("dogecoin")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("dogecoin", 8, "DOGE")
-                            .unit("milli-dogecoin", 5, "mDOGE");
+                        return CURRENCY;
+                }
 
-            const api::Currency STRATIS =
-                    CurrencyBuilder("stratis")
-                            .bip44(STRATIS_COIN_ID)
-                            .paymentUri("stratis")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("stratis", 8, "STRAT");
+                api::Currency digibyte() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("digibyte")
+                                .bip44(DIGIBYTE_COIN_ID)
+                                .paymentUri("digibyte")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("digibyte", 8, "DGB");
 
-            const api::Currency KOMODO =
-                    CurrencyBuilder("komodo")
-                            .bip44(KOMODO_COIN_ID)
-                            .paymentUri("komodo")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("komodo", 8, "KMD");
+                        return CURRENCY;
+                }
 
-            const api::Currency POSWALLET =
-                    CurrencyBuilder("poswallet")
-                            .bip44(POSWALLET_COIN_ID)
-                            .paymentUri("poswallet")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("poswallet", 8, "POSW");
+                api::Currency hcash() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("hcash")
+                                .bip44(HCASH_COIN_ID)
+                                .paymentUri("hcash")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("hshare", 8, "HSR");
 
-            const api::Currency PIVX =
-                    CurrencyBuilder("pivx")
-                            .bip44(PIVX_COIN_ID)
-                            .paymentUri("pivx")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("pivx", 8, "PIVX")
-                            .unit("milli-pivx", 5, "mPIVX");
+                        return CURRENCY;
+                }
 
-            const api::Currency CLUBCOIN =
-                    CurrencyBuilder("clubcoin")
-                            .bip44(CLUBCOIN_COIN_ID)
-                            .paymentUri("clubcoin")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("clubcoin", 8, "CLUB");
+                api::Currency qtum() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("qtum")
+                                .bip44(QTUM_COIN_ID)
+                                .paymentUri("qtum")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("qtum", 8, "QTUM");
 
-            const api::Currency DECRED =
-                    CurrencyBuilder("decred")
-                            .bip44(DECRED_COIN_ID)
-                            .paymentUri("decred")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("decred", 8, "DCR")
-                            .unit("milli-decred", 5, "mDCR");
+                        return CURRENCY;
+                }
 
-            const api::Currency STAKENET =
-                    CurrencyBuilder("stakenet")
-                            .bip44(STAKENET_COIN_ID)
-                            .paymentUri("stakenet")
-                            .unit("satoshi", 0, "satoshi")
-                            .unit("stakenet", 8, "XSN");
-        }
-    }
+                api::Currency stealthcoin() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("stealthcoin")
+                                .bip44(STEALTHCOIN_COIN_ID)
+                                .paymentUri("stealthcoin")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("stealthcoin", 6, "XST")
+                                .unit("milli-stealthcoin", 3, "mXST");
+
+                        return CURRENCY;
+                }
+
+                api::Currency vertcoin() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("vertcoin")
+                                .bip44(VERTCOIN_COIN_ID)
+                                .paymentUri("vertcoin")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("vertcoin", 8, "VTC")
+                                .unit("milli-vertcoin", 5, "mVTC");
+
+                        return CURRENCY;
+                }
+
+                api::Currency viacoin() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("viacoin")
+                                .bip44(VIACOIN_COIN_ID)
+                                .paymentUri("viacoin")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("viacoin", 8, "VIA")
+                                .unit("milli-viacoin", 5, "mVIA");
+
+                        return CURRENCY;
+                }
+
+                api::Currency dash() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("dash")
+                                .bip44(DASH_COIN_ID)
+                                .paymentUri("dash")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("dash", 8, "DASH");
+
+                        return CURRENCY;
+                }
+
+                api::Currency dogecoin() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("dogecoin")
+                                .bip44(DOGECOIN_COIN_ID)
+                                .paymentUri("dogecoin")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("dogecoin", 8, "DOGE")
+                                .unit("milli-dogecoin", 5, "mDOGE");
+
+                        return CURRENCY;
+                }
+
+                api::Currency stratis() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("stratis")
+                                .bip44(STRATIS_COIN_ID)
+                                .paymentUri("stratis")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("stratis", 8, "STRAT");
+
+                        return CURRENCY;
+                }
+
+                api::Currency komodo() {    
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("komodo")
+                                .bip44(KOMODO_COIN_ID)
+                                .paymentUri("komodo")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("komodo", 8, "KMD");
+
+                        return CURRENCY;
+                }
+
+                api::Currency poswallet() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("poswallet")
+                                .bip44(POSWALLET_COIN_ID)
+                                .paymentUri("poswallet")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("poswallet", 8, "POSW");
+
+                        return CURRENCY;
+                }
+
+                api::Currency pivx() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("pivx")
+                                .bip44(PIVX_COIN_ID)
+                                .paymentUri("pivx")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("pivx", 8, "PIVX")
+                                .unit("milli-pivx", 5, "mPIVX");
+
+                        return CURRENCY;
+                }
+
+                api::Currency clubcoin() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("clubcoin")
+                                .bip44(CLUBCOIN_COIN_ID)
+                                .paymentUri("clubcoin")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("clubcoin", 8, "CLUB");
+
+                        return CURRENCY;
+                }
+
+                api::Currency decred() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("decred")
+                                .bip44(DECRED_COIN_ID)
+                                .paymentUri("decred")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("decred", 8, "DCR")
+                                .unit("milli-decred", 5, "mDCR");
+
+                        return CURRENCY;
+                }
+
+                api::Currency stakenet() {
+                        static api::Currency const CURRENCY =
+                        CurrencyBuilder("stakenet")
+                                .bip44(STAKENET_COIN_ID)
+                                .paymentUri("stakenet")
+                                .unit("satoshi", 0, "satoshi")
+                                .unit("stakenet", 8, "XSN");
+
+                        return CURRENCY;
+                }
+       }
+   }
 }


### PR DESCRIPTION
As we discuss earlier some tests put in evidence that static currency variables are not initialized in the static context when used (and CPP doesn't garantee any static order initialization).

So to fix that we use now dedicated function to create and get currencies.

## Mandatory picture of the best animal ever
![dumb_cat](https://user-images.githubusercontent.com/6042495/73255374-51cae880-41c0-11ea-8e94-0b1334d6f18e.gif)

