### PR TITLE
Implement Services and WalletStore API interfaces

### DIFF
--- a/ledger-core/idl/core.djinni
+++ b/ledger-core/idl/core.djinni
@@ -24,6 +24,7 @@
 @import "trust.djinni"
 @import "tuples.djinni"
 @import "wallet.djinni"
+@import "wallet_store.djinni"
 @import "websocket_client.djinni"
 
 LedgerCore = interface +c {

--- a/ledger-core/idl/services.djinni
+++ b/ledger-core/idl/services.djinni
@@ -10,10 +10,10 @@
 @import "thread_dispatcher.djinni"
 @import "websocket_client.djinni"
 
-# Class respresenting a set of services.
+# Class representing a set of services.
 Services = interface +c {
     # Create a new instance of Services object.
-    # @param name, string, name of the Services object
+    # @param tenant, string, tenant of the Services object
     # @param password, string, password to lock (empty string means no password)
     # @param http, HttpClient object, http client used for all calls made by applications
     # @param webSocketClient, WebSocketClient object, socket through which applications observe and get notified (explorer, DBs ...)
@@ -25,7 +25,7 @@ Services = interface +c {
     # @param configuration, DynamicObject object, desired configuration
     # @return Services object, instance of Services
     static newInstance(
-        name: string,
+        tenant: string,
         password: string,
         httpClient: HttpClient,
         webSocketClient: WebSocketClient,
@@ -39,19 +39,19 @@ Services = interface +c {
 
     # Return used logger to dump logs in defined log path by PathResolver.
     # @return Logger object
-    getLogger(): Logger;
+    const getLogger(): Logger;
 
-    # Return the name of the Services object
+    # Return the tenant of the Services object
     # @return string
-    getName(): string;
+    const getTenant(): string;
 
     # Return preferences (deduced from configuration).
     # @return Preferences object
-    getPreferences(): Preferences;
+    const getPreferences(): Preferences;
 
     # Get event bus (handler).
     # @param EventBus object
-    getEventBus(): EventBus;
+    const getEventBus(): EventBus;
 
     # Return last block of blockchain of a given currency (if it is supported by the wallet pool).
     # @param name, string, name of currency we are interested into getting it's blockchain's last block
@@ -113,10 +113,10 @@ ServicesBuilder = interface +c {
     # @param ServicesBuilder object, instance with services thread dispatcher set
     setThreadDispatcher(dispatcher: ThreadDispatcher): ServicesBuilder;
 
-    # Set name.
-    # @param name, string
-    # @return ServicesBuilder object, instance with services name set
-    setName(name: string): ServicesBuilder;
+    # Set tenant.
+    # @param tenant, string
+    # @return ServicesBuilder object, instance with services tenant set
+    setTenant(tenant: string): ServicesBuilder;
 
     # Set password.
     # @param password, string

--- a/ledger-core/idl/wallet_store.djinni
+++ b/ledger-core/idl/wallet_store.djinni
@@ -5,7 +5,7 @@
 
 # Class representing a cache of wallets.
 WalletStore = interface +c {
-    # Return number of wallets instanciated under wallet pool.
+    # Return number of wallets instantiated under the store.
     # @param callback, Callback object returns a 32 bits integer, count of wallets
     getWalletCount(callback: callback2<void, optional<i32>, optional<Error>>);
 
@@ -28,14 +28,14 @@ WalletStore = interface +c {
     # > that might have been created before remain intact
     updateWalletConfig(name: string, configuration: DynamicObject, callback: callback2<void, optional<ErrorCode>, optional<Error>>);
 
-    # Instanciate a new wallet under wallet pool.
+    # Instantiate a new wallet under the store.
     # @param name, string, name of newly created wallet
     # @param currency, Currency object, currency of the wallet
     # @param configuration, DynamicObject object, configuration of wallet (preferences)
     # @param callback, Callback object returning a Wallet object
     createWallet(name: string, currency: Currency, configuration: DynamicObject, callback: callback2<void, optional<Wallet>, optional<Error>>);
 
-    # Return all supported currencies by wallet pool, at least one wallet support one of returned currencies.
+    # Return all supported currencies by the wallet store, at least one wallet support one of returned currencies.
     # @param callback, ListCallback object, returns a list of Currency objects
     getCurrencies(callback: callback2<void, optional<list<Currency>>, optional<Error>>);
 

--- a/ledger-core/idl/wallet_store.djinni
+++ b/ledger-core/idl/wallet_store.djinni
@@ -1,0 +1,50 @@
+@import "configuration.djinni"
+@import "currency.djinni"
+@import "error.djinni"
+@import "wallet.djinni"
+
+# Class representing a cache of wallets.
+WalletStore = interface +c {
+    # Return number of wallets instanciated under wallet pool.
+    # @param callback, Callback object returns a 32 bits integer, count of wallets
+    getWalletCount(callback: callback2<void, optional<i32>, optional<Error>>);
+
+    # Get instanciated wallets having index in a given range.
+    # @param from, 32 bits integer, lower bound of indices to pick
+    # @param to, 32 bits integer, upper bound of indices to pick
+    # @param callback, ListCallback object returns a list of Wallet objects
+    getWallets(from: i32, size: i32, callback: callback2<void, optional<list<Wallet>>, optional<Error>>);
+
+    # Get wallet with a giver name.
+    # @param name, string, name of wallet to look for
+    # @param callback, Callback object returns a Wallet object
+    getWallet(name: string, callback: callback2<void, optional<Wallet>, optional<Error>>);
+
+    # Update wallet configuration
+    # @param name, string, name of wallet to update
+    # @param configuration, DynamicObject object, configuration object with fields to update
+    # @param callback, Callback object returns the error code, returns ErrorCode::FUTURE_WAS_SUCCESSFULL if everything is fine
+    # > Note: other fields that are not passed in 'configuration' parameter
+    # > that might have been created before remain intact
+    updateWalletConfig(name: string, configuration: DynamicObject, callback: callback2<void, optional<ErrorCode>, optional<Error>>);
+
+    # Instanciate a new wallet under wallet pool.
+    # @param name, string, name of newly created wallet
+    # @param currency, Currency object, currency of the wallet
+    # @param configuration, DynamicObject object, configuration of wallet (preferences)
+    # @param callback, Callback object returning a Wallet object
+    createWallet(name: string, currency: Currency, configuration: DynamicObject, callback: callback2<void, optional<Wallet>, optional<Error>>);
+
+    # Return all supported currencies by wallet pool, at least one wallet support one of returned currencies.
+    # @param callback, ListCallback object, returns a list of Currency objects
+    getCurrencies(callback: callback2<void, optional<list<Currency>>, optional<Error>>);
+
+    # Return currency of a specific wallet.
+    # @param name, wallet's name to look for
+    # @param callback, Callback object returning a Currency object
+    getCurrency(name: string, callback: callback2<void, optional<Currency>, optional<Error>>);
+
+    # Erase data (in user's DB) relative to wallet since given date.
+    # @param date, start date of data deletion
+    eraseDataSince(date: date, callback: callback2<void, optional<ErrorCode>, optional<Error>>);
+}

--- a/ledger-core/inc/core/wallet/WalletStore.hpp
+++ b/ledger-core/inc/core/wallet/WalletStore.hpp
@@ -8,6 +8,7 @@
 #include <core/api/Currency.hpp>
 #include <core/api/ErrorCode.hpp>
 #include <core/api/DynamicObject.hpp>
+#include <core/api/WalletStore.hpp>
 #include <core/async/DedicatedContext.hpp>
 #include <core/async/Future.hpp>
 #include <core/utils/Option.hpp>
@@ -21,7 +22,7 @@ namespace ledger {
         // A wallet store which maps wallet names to abstract wallets.
         //
         // This type is a current workaround as it implies downcasting wallets to their real representation.
-        class WalletStore final : public DedicatedContext, public std::enable_shared_from_this<WalletStore> {
+        class WalletStore final : public DedicatedContext, public std::enable_shared_from_this<WalletStore>, public api::WalletStore {
             std::shared_ptr<Services> _services;
 
             // Factories management
@@ -45,18 +46,48 @@ namespace ledger {
 
             // Currencies
             Option<api::Currency> getCurrency(std::string const& name) const;
+            void getCurrency(
+                const std::string & name,
+                const std::function<void(std::experimental::optional<api::Currency>, std::experimental::optional<api::Error>)> & callback
+            ) override;
+
             std::vector<api::Currency> const& getCurrencies() const;
+            void getCurrencies(
+                const std::function<void(std::experimental::optional<std::vector<api::Currency>>, std::experimental::optional<api::Error>)> & callback
+            ) override;
+
             Future<Unit> addCurrency(api::Currency const& currency);
             Future<Unit> removeCurrency(std::string const& currencyName);
 
             // Fetch wallet
             Future<int64_t> getWalletCount() const;
+            void getWalletCount(
+                const std::function<void(std::experimental::optional<int32_t>, std::experimental::optional<api::Error>)> & callback
+            ) override;
+
             Future<std::vector<std::shared_ptr<AbstractWallet>>> getWallets(int64_t from, int64_t size);
+            void getWallets(
+                int32_t from,
+                int32_t size,
+                const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::Wallet>>>, std::experimental::optional<api::Error>)> & callback
+            ) override;
+
             FuturePtr<AbstractWallet> getWallet(const std::string& name);
+            void getWallet(
+                const std::string & name,
+                const std::function<void(std::shared_ptr<api::Wallet>, std::experimental::optional<api::Error>)> & callback
+            ) override;
+
             Future<api::ErrorCode> updateWalletConfig(
                 std::string const& name,
                 std::shared_ptr<api::DynamicObject> const& configuration
             );
+            void updateWalletConfig(
+                const std::string & name,
+                const std::shared_ptr<api::DynamicObject> & configuration,
+                const std::function<void(std::experimental::optional<api::ErrorCode>, std::experimental::optional<api::Error>)> & callback
+            ) override;
+
             Future<std::vector<std::string>> getWalletNames(int64_t from, int64_t size) const;
 
             // Create wallet
@@ -65,9 +96,19 @@ namespace ledger {
                 std::string const& currencyName,
                 std::shared_ptr<api::DynamicObject> const& configuration
             );
+            void createWallet(
+                const std::string & name,
+                const api::Currency & currency,
+                const std::shared_ptr<api::DynamicObject> & configuration,
+                const std::function<void(std::shared_ptr<api::Wallet>, std::experimental::optional<api::Error>)> & callback
+            ) override;
 
             // Deletion
             Future<api::ErrorCode> eraseDataSince(const std::chrono::system_clock::time_point & date);
+            void eraseDataSince(
+                const std::chrono::system_clock::time_point & date,
+                const std::function<void(std::experimental::optional<api::ErrorCode>, std::experimental::optional<api::Error>)> & callback
+            ) override;
 
             // Factories
 
@@ -77,6 +118,7 @@ namespace ledger {
                 api::Currency const& currency,
                 std::shared_ptr<AbstractWalletFactory> const& factory
             );
+
             std::shared_ptr<AbstractWalletFactory> getFactory(std::string const& currencyName) const;
 
         private:

--- a/ledger-core/src/core/Services.cpp
+++ b/ledger-core/src/core/Services.cpp
@@ -1,7 +1,8 @@
+#include <core/Services.hpp>
 #include <core/api/PoolConfiguration.hpp>
 #include <core/api/Configuration.hpp>
 #include <core/api/ConfigurationDefaults.hpp>
-#include <core/Services.hpp>
+#include <core/debug/LoggerApi.hpp>
 
 namespace ledger {
     namespace core {
@@ -133,11 +134,11 @@ namespace ledger {
             return _configuration;
         }
 
-        const std::string &Services::getTenant() const {
+        std::string Services::getTenant() const {
             return _tenant;
         }
 
-        const std::string Services::getPassword() const {
+        std::string Services::getPassword() const {
             return _password;
         }
 
@@ -216,6 +217,14 @@ namespace ledger {
             });
         }
 
+        void Services::changePassword(
+            const std::string & oldPassword,
+            const std::string & newPassword,
+            const std::function<void(std::experimental::optional<api::ErrorCode>, std::experimental::optional<api::Error>)> & callback
+        ) {
+            changePassword(oldPassword, newPassword).callback(_threadDispatcher->getMainExecutionContext(), callback);
+        }
+
         Future<api::ErrorCode> Services::freshResetAll() {
             auto self = shared_from_this();
 
@@ -240,6 +249,53 @@ namespace ledger {
 
         std::shared_ptr<api::ExecutionContext> Services::getThreadPoolExecutionContext() const {
             return _threadPoolExecutionContext;
+        }
+
+        std::shared_ptr<api::Logger> Services::getLogger() const {
+            return std::make_shared<LoggerApi>(_logger);
+        }
+
+        std::shared_ptr<api::Preferences> Services::getPreferences() const {
+            return getExternalPreferences();
+        }
+
+        void Services::getLastBlock(
+            std::string const& currencyName,
+            std::function<void(std::experimental::optional<api::Block>, std::experimental::optional<api::Error>)> const & callback
+        ) {
+            getLastBlock(currencyName).callback(_threadDispatcher->getMainExecutionContext(), callback);
+        }
+
+        void Services::freshResetAll(
+            std::function<void(std::experimental::optional<api::ErrorCode>, std::experimental::optional<api::Error>)> const& callback
+        ) {
+            freshResetAll().callback(_threadDispatcher->getMainExecutionContext(), callback);
+        }
+
+        std::shared_ptr<api::Services> api::Services::newInstance(
+            const std::string & name,
+            const std::string & password,
+            const std::shared_ptr<HttpClient> & httpClient,
+            const std::shared_ptr<WebSocketClient> & webSocketClient,
+            const std::shared_ptr<PathResolver> & pathResolver,
+            const std::shared_ptr<LogPrinter> & logPrinter,
+            const std::shared_ptr<ThreadDispatcher> & dispatcher,
+            const std::shared_ptr<RandomNumberGenerator> & rng,
+            const std::shared_ptr<DatabaseBackend> & backend,
+            const std::shared_ptr<DynamicObject> & configuration
+        ) {
+            return ledger::core::Services::newInstance(
+                name,
+                password,
+                httpClient,
+                webSocketClient,
+                pathResolver,
+                logPrinter,
+                dispatcher,
+                rng,
+                backend,
+                configuration
+            );
         }
     }
 }


### PR DESCRIPTION
# Content

This PR provides support for `api::Services` and `api::WalletStore`, effectively making those objects callable from foreign interfaces.

# Mandatory picture of Satan’s Pet™ being discovered

![](https://phaazon.net/media/uploads/ima_bite_this_or_caress_it.gif)