### PR TITLE
Add WalletFixture class

### DIFF
--- a/ledger-core-ethereum/test/CMakeLists.txt
+++ b/ledger-core-ethereum/test/CMakeLists.txt
@@ -9,9 +9,13 @@ if (APPLE)
     add_definitions(-D__GLIBCXX__)
 endif (APPLE)
 
-add_executable(
-    ledger-core-ethereum-tests main.cpp Fixtures.cpp
-    KeychainTests.cpp SynchronizationTests.cpp TransactionTests.cpp
+add_executable(ledger-core-ethereum-tests 
+    main.cpp 
+    Fixtures.cpp
+    WalletTests.cpp
+    KeychainTests.cpp 
+    SynchronizationTests.cpp 
+    TransactionTests.cpp
 )
 
 target_link_libraries(ledger-core-ethereum-tests Core::ledger-core-static)
@@ -25,6 +29,7 @@ set(gtest_force_shared_crt ON CACHE BOOL "Build gtest with shared runtime" FORCE
 
 add_subdirectory(lib/googletest)
 
-add_test (NAME Ethereum-transaction COMMAND ledger-core-ethereum-tests --gtest_filter=EthereumMakeTransaction.*)
-add_test (NAME Ethereum-keychain COMMAND ledger-core-ethereum-tests --gtest_filter=EthereumKeychains.*)
-add_test (NAME Ethereum-synchronization COMMAND ledger-core-ethereum-tests --gtest_filter=EthereumLikeWalletSynchronization.*)
+add_test(NAME Ethereum-wallet COMMAND ledger-core-ethereum-tests --gtest_filter=EthereumWallets.*)
+add_test(NAME Ethereum-transaction COMMAND ledger-core-ethereum-tests --gtest_filter=EthereumMakeTransaction.*)
+add_test(NAME Ethereum-keychain COMMAND ledger-core-ethereum-tests --gtest_filter=EthereumKeychains.*)
+add_test(NAME Ethereum-synchronization COMMAND ledger-core-ethereum-tests --gtest_filter=EthereumLikeWalletSynchronization.*)

--- a/ledger-core-ethereum/test/WalletTests.cpp
+++ b/ledger-core-ethereum/test/WalletTests.cpp
@@ -1,0 +1,83 @@
+/*
+ *
+ * WalletTests
+ * ledger-core-ethereum
+ *
+ * Created by Alexis Le Provost on 30/01/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <core/api/ErrorCode.hpp>
+#include <core/api/ExtendedKeyAccountCreationInfo.hpp>
+
+#include <ethereum/EthereumLikeAccount.hpp>
+#include <ethereum/EthereumLikeCurrencies.hpp>
+#include <ethereum/EthereumLikeWallet.hpp>
+#include <ethereum/factories/EthereumLikeWalletFactory.hpp>
+
+#include <integration/WalletFixture.hpp>
+
+namespace {
+
+constexpr auto const OLD_NODE_ENDPOINT = "http://eth-ropsten.explorers.dev.aws.ledger.fr";
+constexpr auto const NEW_NODE_ENDPOINT = "http://eth-ropsten.explorers.prod.aws.ledger.fr";
+
+} // namespace
+
+class EthereumWallets : public WalletFixture<EthereumLikeWalletFactory> {
+
+};
+
+TEST_F(EthereumWallets, ChangeWalletConfig) {
+    auto currency = currencies::ethereum();
+    auto derivationScheme = "44'/<coin_type>'/<account>'/<node>/<address>";
+    
+    {
+        auto configuration = api::DynamicObject::newInstance();
+
+        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT, OLD_NODE_ENDPOINT);
+        configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME, derivationScheme);
+        
+        testWallet("ethereum", currency, TestStrategy::NEW_WALLET, configuration, [&derivationScheme](auto wallet, auto walletStore) {
+            auto configuration = wallet->getConfiguration();
+            
+            EXPECT_EQ(configuration->getString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT).value(), OLD_NODE_ENDPOINT);
+            EXPECT_EQ(configuration->getString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME).value(), derivationScheme); 
+        });
+    }
+
+    {
+        auto configuration = api::DynamicObject::newInstance();
+
+        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT, NEW_NODE_ENDPOINT);
+
+        testWallet("ethereum", currency, TestStrategy::EXISTING_WALLET, configuration, [&derivationScheme](auto wallet, auto walletStore) {
+            auto configuration = wallet->getConfiguration();
+            
+            EXPECT_EQ(configuration->getString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT).value(), NEW_NODE_ENDPOINT);
+            EXPECT_EQ(configuration->getString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME).value(), derivationScheme);  
+        });
+    }
+}

--- a/ledger-core/test/integration/WalletFixture.hpp
+++ b/ledger-core/test/integration/WalletFixture.hpp
@@ -1,0 +1,75 @@
+/*
+ *
+ * WalletFixture
+ * ledger-core
+ *
+ * Created by Alexis Le Provost on 27/01/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <core/wallet/AbstractWallet.hpp>
+#include <core/wallet/WalletStore.hpp>
+#include <core/collections/DynamicObject.hpp>
+
+#include "BaseFixture.hpp"
+
+template <class WalletFactory>
+class WalletFixture : public BaseFixture {
+    using FunctionType = std::function<void(std::shared_ptr<AbstractWallet>, std::shared_ptr<WalletStore>)>;
+
+public:
+    enum class TestStrategy {
+        NEW_WALLET,
+        EXISTING_WALLET
+    };
+
+    void testWallet(
+        std::string const &name,
+        api::Currency const &currency,
+        TestStrategy strategy,
+        FunctionType const &f) {
+
+        auto services = newDefaultServices();
+        auto walletStore = newWalletStore(services);
+        auto factory = std::make_shared<WalletFactory>(currency, services);
+
+        wait(walletStore->addCurrency(currency)); 
+        walletStore->registerFactory(currency, factory);
+
+        auto wallet = [&]() {
+            switch (strategy) {
+                case TestStrategy::NEW_WALLET:
+                    return wait(walletStore->createWallet(name, currency.name, api::DynamicObject::newInstance()));
+                case TestStrategy::EXISTING_WALLET:
+                default:
+                    return wait(walletStore->getWallet(name));
+            }
+        }();
+             
+        f(wallet, walletStore);
+    }
+};


### PR DESCRIPTION
This PR allow use to test wallet (new and existing one) really quickly and with less code than actual one. 

### What happens "under the hood"
The `testWallet` method will create `Services`, `WalletStore` and coin-specific wallet factory instances and register the `currency` given as input parameter before calling the user-specified callback (this function should contains the test code about wallet).

## Mandatory picture of a cat
![cat4](https://user-images.githubusercontent.com/6042495/73438534-7b197f00-434e-11ea-9259-010cfb000356.gif)
