### PR TITLE
Migrate all the modularized projects to the new callback2 mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ tags
 *.a
 /ledger-core/idl/core.yaml
 /**/inc/**/api
+/**/jni

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "djinni"]
     path = djinni
-    url = https://github.com/phaazon/djinni.git
-    branch = feature/high-order-callbacks
+    url = https://github.com/LedgerHQ/djinni.git
 [submodule "toolchains/polly"]
     path = toolchains/polly
     url = https://github.com/ruslo/polly.git

--- a/ledger-core-bitcoin/idl/callback.djinni
+++ b/ledger-core-bitcoin/idl/callback.djinni
@@ -1,0 +1,17 @@
+@extern "../../ledger-core/idl/core.yaml"
+
+# Callback triggered by main completed task, returning optional result as list of template type T.
+ListCallback = interface[T] +j +o +s +n {
+    # Method triggered when main task complete.
+    # @params result optional of type list<T>, non null if main task failed
+    # @params error optional of type Error, non null if main task succeeded
+    onCallback(result: optional<list<T>>, error: optional<Error>);
+}
+
+# Callback triggered by main completed task, returning optional result of template type T.
+Callback = interface[T] +j +o +s +n {
+    # Method triggered when main task complete.
+    # @params result optional of type T, non null if main task failed
+    # @params error optional of type Error, non null if main task succeeded
+    onCallback(result: optional<T>, error: optional<Error>);
+}

--- a/ledger-core-bitcoin/idl/idl.djinni
+++ b/ledger-core-bitcoin/idl/idl.djinni
@@ -1,6 +1,7 @@
 @extern "../../ledger-core/idl/core.yaml"
 
 @import "addresses.djinni"
+@import "callback.djinni"
 @import "script.djinni"
 
 
@@ -70,7 +71,7 @@ BitcoinLikeInput = interface +c {
     getSequence(): i64;
 
     # Get the previous transaction associated with the input.
-    getPreviousTransaction(callback: callback2<void, optional<binary>, optional<Error>>);
+    getPreviousTransaction(callback: callback2<optional<binary>>);
 
     # Easy way to set the P2PKH script signature. Shorthand for input.pushToScriptSig(input.getPublicKeys()[0], signature).
     setP2PKHSigScript(signature: binary);
@@ -167,11 +168,11 @@ BitcoinLikeTransaction = interface +c {
     # Estimate the size of the raw transaction in bytes. This method returns a minimum estimated size and a maximum estimated
     # size.
     getEstimatedSize(): EstimatedSize;
-    # Sign all inputs for given transaction. 
+    # Sign all inputs for given transaction.
     # Build DER encoded signature from RSV data.
     # @return SIGNING_SUCCEED if succeed case else refers to BitcoinLikeSignatureState enumeration
     setSignatures(signatures: list<BitcoinLikeSignature>, override: bool): BitcoinLikeSignatureState;
-    # Sign all inputs for given transaction. 
+    # Sign all inputs for given transaction.
     # @return SIGNING_SUCCEED if succeed case else refers to BitcoinLikeSignatureState enumeration
     setDERSignatures(signatures: list<binary>, override: bool): BitcoinLikeSignatureState;
 }
@@ -276,7 +277,7 @@ BitcoinLikeTransactionBuilder = interface +c {
     setFeesPerByte(fees: Amount): BitcoinLikeTransactionBuilder;
 
     # Build a transaction from the given builder parameters.
-    build(callback: callback2<void, optional<BitcoinLikeTransaction>, optional<Error>>);
+    build(callback: callback2<optional<BitcoinLikeTransaction>>);
 
     # Creates a clone of this builder.
     # @return A copy of the current builder instance.
@@ -296,19 +297,19 @@ BitcoinLikeAccount = interface +c {
     # @param from, integer, lower bound for account's UTXO's index
     # @param to, integer, upper bound for account's UTXO's index
     # @param callback, ListCallback object which returns a list of BitcoinLikeOutput if getUTXO succeed
-    getUTXO(from: i32, to: i32, callback: callback2<void, optional<list<BitcoinLikeOutput>>, optional<Error>>);
+    getUTXO(from: i32, to: i32, callback: callback2<optional<list<BitcoinLikeOutput>>>);
     # Get UTXOs count of account.
     # @param callback, Callback object which returns number of UTXO owned by this account
-    getUTXOCount(callback: callback2<void, optional<i32>, optional<Error>>);
-    broadcastRawTransaction(transaction: binary, callback: callback2<void, optional<string>, optional<Error>>);
-    broadcastTransaction(transaction: BitcoinLikeTransaction, callback: callback2<void, optional<string>, optional<Error>>);
+    getUTXOCount(callback: callback2<optional<i32>>);
+    broadcastRawTransaction(transaction: binary, callback: callback2<optional<string>>);
+    broadcastTransaction(transaction: BitcoinLikeTransaction, callback: callback2<optional<string>>);
     buildTransaction(partial: optional<bool>): BitcoinLikeTransactionBuilder;
     # Get fees from network, fees are ordered in descending order (i.e. fastest to slowest confirmation)
     # Note: it would have been better to have this method on BitcoinLikeWallet
     # but since BitcoinLikeWallet is not used anywhere, it's better to keep all
     # specific methods under the same specific class so it will be easy to segratate
     # when the right time comes !
-    getFees(callback: callback2<void, optional<list<BigInt>>, optional<Error>>);
+    getFees(callback: callback2<optional<list<BigInt>>>);
 }
 
 # A bitcoin-like wallet.

--- a/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeAccount.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/BitcoinLikeAccount.hpp
@@ -38,11 +38,14 @@
 #include <core/wallet/AbstractAccount.hpp>
 
 #include <bitcoin/BitcoinLikeWallet.hpp>
+#include <bitcoin/api/BigIntListCallback.hpp>
 #include <bitcoin/api/BitcoinLikeAccount.hpp>
 #include <bitcoin/api/BitcoinLikePickingStrategy.hpp>
 #include <bitcoin/api/BitcoinLikePreparedTransaction.hpp>
 #include <bitcoin/api/BitcoinLikeOutput.hpp>
+#include <bitcoin/api/BitcoinLikeOutputListCallback.hpp>
 #include <bitcoin/api/BitcoinLikeTransactionRequest.hpp>
+#include <bitcoin/api/StringCallback.hpp>
 #include <bitcoin/operations/BitcoinLikeOperation.hpp>
 #include <bitcoin/keychains/BitcoinLikeKeychain.hpp>
 #include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
@@ -106,21 +109,28 @@ namespace ledger {
 
             std::shared_ptr<api::EventBus> synchronize() override;
 
-            void broadcastRawTransaction(const std::vector<uint8_t> &transaction,
-                                         const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<api::Error>)> & callback) override;
+            void broadcastRawTransaction(
+				const std::vector<uint8_t> &transaction,
+				const std::shared_ptr<api::StringCallback> & callback
+			) override;
 
-            void broadcastTransaction(const std::shared_ptr<api::BitcoinLikeTransaction> &transaction,
-                                      const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<api::Error>)> & callback) override;
+            void broadcastTransaction(
+				const std::shared_ptr<api::BitcoinLikeTransaction> &transaction,
+				const std::shared_ptr<api::StringCallback> & callback
+			) override;
 
             std::shared_ptr<api::BitcoinLikeTransactionBuilder> buildTransaction(std::experimental::optional<bool> partial) override;
 
             std::shared_ptr<api::OperationQuery> queryOperations() override;
 
-            void getUTXO(int32_t from, int32_t to,
-                         const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>>, std::experimental::optional<api::Error>)> & callback) override;
+            void getUTXO(
+				int32_t from,
+				int32_t to,
+				const std::shared_ptr<api::BitcoinLikeOutputListCallback> & callback
+			) override;
             Future<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>> getUTXO();
             Future<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>> getUTXO(int32_t from, int32_t to);
-            void getUTXOCount(const std::function<void(std::experimental::optional<int32_t>, std::experimental::optional<api::Error>)> & callback) override;
+            void getUTXOCount(const std::shared_ptr<api::I32Callback> & callback) override;
             Future<int32_t> getUTXOCount();
 
             Future<AddressList> getFreshPublicAddresses() override;
@@ -133,7 +143,7 @@ namespace ledger {
 
             Future<api::ErrorCode> eraseDataSince(const std::chrono::system_clock::time_point & date) override ;
 
-            void getFees(const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::BigInt>>>, std::experimental::optional<api::Error>)> & callback) override ;
+            void getFees(const std::shared_ptr<api::BigIntListCallback> & callback) override ;
         protected:
             bool checkIfWalletIsEmpty();
 

--- a/ledger-core-bitcoin/inc/bitcoin/io/BitcoinLikeInput.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/io/BitcoinLikeInput.hpp
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <bitcoin/api/BinaryCallback.hpp>
 #include <bitcoin/api/BitcoinLikeInput.hpp>
 #include <bitcoin/api/BitcoinLikeOperation.hpp>
 #include <bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
@@ -68,11 +69,7 @@ public:
 
   int64_t getSequence() override;
 
-  void getPreviousTransaction(
-      const std::function<void(
-          std::experimental::optional<std::vector<uint8_t>>,
-          std::experimental::optional<::ledger::core::api::Error>)> &callback)
-      override;
+  void getPreviousTransaction(const std::shared_ptr<api::BinaryCallback> & callback) override;
 
   void setP2PKHSigScript(const std::vector<uint8_t> &signature) override;
 

--- a/ledger-core-bitcoin/inc/bitcoin/io/BitcoinLikeWritableInput.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/io/BitcoinLikeWritableInput.hpp
@@ -34,6 +34,7 @@
 #include <core/utils/DerivationPath.hpp>
 
 #include <bitcoin/BitcoinLikeAccount.hpp>
+#include <bitcoin/api/BinaryCallback.hpp>
 #include <bitcoin/api/BitcoinLikeInput.hpp>
 #include <bitcoin/scripts/BitcoinLikeScript.hpp>
 
@@ -72,7 +73,7 @@ namespace ledger {
             void pushToScriptSig(const std::vector<uint8_t> &data) override;
             void setSequence(int32_t sequence) override;
             int64_t getSequence() override;
-            void getPreviousTransaction(const std::function<void(std::experimental::optional<std::vector<uint8_t>>, std::experimental::optional<api::Error>)> & callback) override;
+            void getPreviousTransaction(const std::shared_ptr<api::BinaryCallback> & callback) override;
             Future<std::vector<uint8_t>> getPreviousTransaction();
             void setP2PKHSigScript(const std::vector<uint8_t> &signature) override;
 

--- a/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeTransactionBuilder.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/transactions/BitcoinLikeTransactionBuilder.hpp
@@ -41,6 +41,7 @@
 #include <core/async/Future.hpp>
 #include <core/math/BigInt.hpp>
 
+#include <bitcoin/api/BitcoinLikeTransactionCallback.hpp>
 #include <bitcoin/api/BitcoinLikeNetworkParameters.hpp>
 #include <bitcoin/api/BitcoinLikePickingStrategy.hpp>
 #include <bitcoin/api/BitcoinLikeTransaction.hpp>
@@ -108,7 +109,7 @@ namespace ledger {
 
             void reset() override;
 
-            void build(const std::function<void(std::shared_ptr<api::BitcoinLikeTransaction>, std::experimental::optional<api::Error>)> & callback) override;
+            void build(const std::shared_ptr<api::BitcoinLikeTransactionCallback> & callback) override;
             Future<std::shared_ptr<api::BitcoinLikeTransaction>> build();
         private:
             api::Currency _currency;

--- a/ledger-core-bitcoin/src/bitcoin/BitcoinLikeAccount.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/BitcoinLikeAccount.cpp
@@ -84,7 +84,7 @@
                 out.currencyName = getWallet()->getCurrency().name;
                 out.walletUid = wallet->getWalletUid();
                 out.date = tx.receivedAt;
-                
+
                 if (out.block.nonEmpty())
                     out.block.getValue().currencyName = wallet->getCurrency().name;
             }
@@ -171,9 +171,9 @@
                 strings::join(senders, snds, ",");
 
                 BitcoinLikeOperation operation(getWallet(), transaction);
-                
+
                 inflateOperation(operation, wallet, transaction);
-                
+
                 operation.senders = std::move(senders);
                 operation.recipients = std::move(recipients);
                 operation.fees = std::move(BigInt().assignI64(fees));
@@ -322,8 +322,11 @@
                 return eventPublisher->getEventBus();
             }
 
-            void BitcoinLikeAccount::getUTXO(int32_t from, int32_t to,
-                                            const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>>, std::experimental::optional<api::Error>)> & callback) {
+            void BitcoinLikeAccount::getUTXO(
+				int32_t from,
+				int32_t to,
+				const std::shared_ptr<api::BitcoinLikeOutputListCallback> & callback
+			) {
                 getUTXO(from, to).callback(getMainExecutionContext(), callback);
             }
 
@@ -344,7 +347,7 @@
                 });
             }
 
-            void BitcoinLikeAccount::getUTXOCount(const std::function<void(std::experimental::optional<int32_t>, std::experimental::optional<api::Error>)> & callback) {
+            void BitcoinLikeAccount::getUTXOCount(const std::shared_ptr<api::I32Callback> & callback) {
                 getUTXOCount().callback(getMainExecutionContext(), callback);
             }
 
@@ -537,8 +540,10 @@
                 return lastBlock.hasValue() ? static_cast<uint64_t >(lastBlock->height) : LLONG_MAX;
             }
 
-            void BitcoinLikeAccount::broadcastRawTransaction(const std::vector<uint8_t> &transaction,
-                                                             const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<::ledger::core::api::Error>)> & callback) {
+            void BitcoinLikeAccount::broadcastRawTransaction(
+				const std::vector<uint8_t> &transaction,
+				const std::shared_ptr<api::StringCallback> & callback
+			) {
                 auto self = getSelf();
                 _explorer->pushTransaction(transaction).map<std::string>(getContext(), [self, transaction] (const String& seq) -> std::string {
                     //Store newly broadcasted tx in db
@@ -612,8 +617,10 @@
                 }).callback(getContext(), callback);
             }
 
-            void BitcoinLikeAccount::broadcastTransaction(const std::shared_ptr<api::BitcoinLikeTransaction> &transaction,
-                                                          const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<::ledger::core::api::Error>)> & callback) {
+            void BitcoinLikeAccount::broadcastTransaction(
+				const std::shared_ptr<api::BitcoinLikeTransaction> &transaction,
+				const std::shared_ptr<api::StringCallback> & callback
+			) {
                 broadcastRawTransaction(transaction->serialize(), callback);
             }
 
@@ -689,7 +696,7 @@
                 return Future<api::ErrorCode>::successful(api::ErrorCode::FUTURE_WAS_SUCCESSFULL);
             }
 
-            void BitcoinLikeAccount::getFees(const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::BigInt>>>, std::experimental::optional<api::Error>)> & callback) {
+            void BitcoinLikeAccount::getFees(const std::shared_ptr<api::BigIntListCallback> & callback) {
                 return _explorer->getFees().callback(getContext(), callback);;
             }
 

--- a/ledger-core-bitcoin/src/bitcoin/io/BitcoinLikeInput.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/io/BitcoinLikeInput.cpp
@@ -111,7 +111,7 @@ namespace ledger {
             throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "void BitcoinLikeInput::setP2PKHSigScript(const std::vector<uint8_t> &signature)");
         }
 
-        void BitcoinLikeInput::getPreviousTransaction(const std::function<void(std::experimental::optional<std::vector<uint8_t>>, std::experimental::optional<::ledger::core::api::Error>)> & callback) {
+        void BitcoinLikeInput::getPreviousTransaction(const std::shared_ptr<api::BinaryCallback> & callback) {
             throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "void BitcoinLikeInput::getPreviousTransaction(const std::shared_ptr<api::BinaryCallback> &callback)");
         }
     }

--- a/ledger-core-bitcoin/src/bitcoin/io/BitcoinLikeWritableInput.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/io/BitcoinLikeWritableInput.cpp
@@ -126,7 +126,7 @@ namespace ledger {
             pushToScriptSig(_pubKeys[0]);
         }
 
-        void BitcoinLikeWritableInput::getPreviousTransaction(const std::function<void(std::experimental::optional<std::vector<uint8_t>>, std::experimental::optional<api::Error>)> & callback) {
+        void BitcoinLikeWritableInput::getPreviousTransaction(const std::shared_ptr<api::BinaryCallback> & callback) {
             getPreviousTransaction().callback(_context, callback);
         }
 

--- a/ledger-core-bitcoin/src/bitcoin/transactions/BitcoinLikeTransactionBuilder.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/transactions/BitcoinLikeTransactionBuilder.cpp
@@ -141,7 +141,7 @@ namespace ledger {
         }
 
         void
-        BitcoinLikeTransactionBuilder::build(const std::function<void(std::shared_ptr<api::BitcoinLikeTransaction>, std::experimental::optional<api::Error>)> & callback) {
+        BitcoinLikeTransactionBuilder::build(const std::shared_ptr<api::BitcoinLikeTransactionCallback> & callback) {
             build().callback(_context, callback);
         }
 

--- a/ledger-core-ethereum/idl/callback.djinni
+++ b/ledger-core-ethereum/idl/callback.djinni
@@ -1,0 +1,17 @@
+@extern "../../ledger-core/idl/core.yaml"
+
+# Callback triggered by main completed task, returning optional result as list of template type T.
+ListCallback = interface[T] +j +o +s +n {
+    # Method triggered when main task complete.
+    # @params result optional of type list<T>, non null if main task failed
+    # @params error optional of type Error, non null if main task succeeded
+    onCallback(result: optional<list<T>>, error: optional<Error>);
+}
+
+# Callback triggered by main completed task, returning optional result of template type T.
+Callback = interface[T] +j +o +s +n {
+    # Method triggered when main task complete.
+    # @params result optional of type T, non null if main task failed
+    # @params error optional of type Error, non null if main task succeeded
+    onCallback(result: optional<T>, error: optional<Error>);
+}

--- a/ledger-core-ethereum/idl/erc20.djinni
+++ b/ledger-core-ethereum/idl/erc20.djinni
@@ -19,14 +19,14 @@ ERC20LikeAccount = interface +c {
     # Get the address of this ERC20 account.
     getAddress(): string;
     # Get the current balance of this ERC20 account.
-    getBalance(callback: callback2<void, BigInt, optional<Error>>);
+    getBalance(callback: callback2<BigInt>);
     # Get the balance history of this ERC20 account from a starting date (included) to an ending
     # date (included).
     getBalanceHistoryFor(start: date, end: date, period: TimePeriod): list<BigInt>;
     # Get the list of operations performed on this ERC20 account.
     getOperations(): list<ERC20LikeOperation>;
     # Retrieve raw data concerning a transaction of a given amount to a given address.
-    getTransferToAddressData(amount: BigInt, address: string, data: callback2<void, optional<binary>, optional<Error>>);
+    getTransferToAddressData(amount: BigInt, address: string, data: callback2<optional<binary>>);
     queryOperations(): OperationQuery;
 }
 

--- a/ledger-core-ethereum/idl/erc20.djinni
+++ b/ledger-core-ethereum/idl/erc20.djinni
@@ -19,7 +19,7 @@ ERC20LikeAccount = interface +c {
     # Get the address of this ERC20 account.
     getAddress(): string;
     # Get the current balance of this ERC20 account.
-    getBalance(callback: callback2<void, BigInt, optional<Error>>);
+    getBalance(callback: callback2<void, optional<BigInt>, optional<Error>>);
     # Get the balance history of this ERC20 account from a starting date (included) to an ending
     # date (included).
     getBalanceHistoryFor(start: date, end: date, period: TimePeriod): list<BigInt>;

--- a/ledger-core-ethereum/idl/erc20.djinni
+++ b/ledger-core-ethereum/idl/erc20.djinni
@@ -19,7 +19,7 @@ ERC20LikeAccount = interface +c {
     # Get the address of this ERC20 account.
     getAddress(): string;
     # Get the current balance of this ERC20 account.
-    getBalance(callback: callback2<void, optional<BigInt>, optional<Error>>);
+    getBalance(callback: callback2<void, BigInt, optional<Error>>);
     # Get the balance history of this ERC20 account from a starting date (included) to an ending
     # date (included).
     getBalanceHistoryFor(start: date, end: date, period: TimePeriod): list<BigInt>;

--- a/ledger-core-ethereum/idl/idl.djinni
+++ b/ledger-core-ethereum/idl/idl.djinni
@@ -1,6 +1,7 @@
 @extern "../../ledger-core/idl/core.yaml"
 
 @import "addresses.djinni"
+@import "callback.djinni"
 @import "erc20.djinni"
 
 # Class representing a Ethereum transaction.

--- a/ledger-core-ethereum/idl/idl.djinni
+++ b/ledger-core-ethereum/idl/idl.djinni
@@ -105,7 +105,7 @@ EthereumLikeTransactionBuilder = interface +c {
     setInputData(data: binary): EthereumLikeTransactionBuilder;
 
     # Build a transaction from the given builder parameters.
-    build(callback: callback2<void, optional<EthereumLikeTransaction>, optional<Error>>);
+    build(callback: callback2<optional<EthereumLikeTransaction>>);
 
     # Create a clone of this builder.
     # @return A copy of the current builder instance.
@@ -123,9 +123,9 @@ EthereumLikeTransactionBuilder = interface +c {
 # Class representing a Ethereum account.
 EthereumLikeAccount = interface +c {
     # Send a raw (binary) transaction on the Ethereum blockchain.
-    broadcastRawTransaction(transaction: binary, callback: callback2<void, optional<string>, optional<Error>>);
+    broadcastRawTransaction(transaction: binary, callback: callback2<optional<string>>);
     # Send a transaction on the Ethereum blockchain.
-    broadcastTransaction(transaction: EthereumLikeTransaction, callback: callback2<void, optional<string>, optional<Error>>);
+    broadcastTransaction(transaction: EthereumLikeTransaction, callback: callback2<optional<string>>);
     # Get a builder object to construct transactions.
     buildTransaction(): EthereumLikeTransactionBuilder;
     # Get the list of ERC20 accounts associated with this Ethereum account.
@@ -135,20 +135,20 @@ EthereumLikeAccount = interface +c {
     # but since EthereumLikeWallet is not used anywhere, it's better to keep all
     # specific methods under the same specific class so it will be easy to segratate
     # when the right time comes !
-    getGasPrice(callback: callback2<void, BigInt, optional<Error>>);
+    getGasPrice(callback: callback2<BigInt>);
     # Get estimated gas limit to set so the transaction will succeed
     # The passed address could be EOA or contract
     # This estimation is based on X last incoming txs (to address) that succeeded
     # Note: same note as above
-    getEstimatedGasLimit(address: string, callback: callback2<void, BigInt, optional<Error>>);
+    getEstimatedGasLimit(address: string, callback: callback2<BigInt>);
     # Get balance of ERC20 token
     # The passed address is an ERC20 account
     # Note: same note as above
-    getERC20Balance(erc20Address: string, callback: callback2<void, BigInt, optional<Error>>);
+    getERC20Balance(erc20Address: string, callback: callback2<BigInt>);
     # Get balance of ERC20 tokens
     # The passed addresses are ERC20 accounts
     # Note: same note as above
-    getERC20Balances(erc20Addresses: list<string>, callback: callback2<void, list<BigInt>, optional<Error>>);
+    getERC20Balances(erc20Addresses: list<string>, callback: callback2<list<BigInt>>);
 }
 
 # TODO I think we need to remove this (useful?) interface

--- a/ledger-core-ethereum/idl/idl.djinni
+++ b/ledger-core-ethereum/idl/idl.djinni
@@ -135,20 +135,20 @@ EthereumLikeAccount = interface +c {
     # but since EthereumLikeWallet is not used anywhere, it's better to keep all
     # specific methods under the same specific class so it will be easy to segratate
     # when the right time comes !
-    getGasPrice(callback: callback2<void, optional<BigInt>, optional<Error>>);
+    getGasPrice(callback: callback2<void, BigInt, optional<Error>>);
     # Get estimated gas limit to set so the transaction will succeed
     # The passed address could be EOA or contract
     # This estimation is based on X last incoming txs (to address) that succeeded
     # Note: same note as above
-    getEstimatedGasLimit(address: string, callback: callback2<void, optional<BigInt>, optional<Error>>);
+    getEstimatedGasLimit(address: string, callback: callback2<void, BigInt, optional<Error>>);
     # Get balance of ERC20 token
     # The passed address is an ERC20 account
     # Note: same note as above
-    getERC20Balance(erc20Address: string, callback: callback2<void, optional<BigInt>, optional<Error>>);
+    getERC20Balance(erc20Address: string, callback: callback2<void, BigInt, optional<Error>>);
     # Get balance of ERC20 tokens
     # The passed addresses are ERC20 accounts
     # Note: same note as above
-    getERC20Balances(erc20Addresses: list<string>, callback: callback2<void, optional<list<BigInt>>, optional<Error>>);
+    getERC20Balances(erc20Addresses: list<string>, callback: callback2<void, list<BigInt>, optional<Error>>);
 }
 
 # TODO I think we need to remove this (useful?) interface

--- a/ledger-core-ethereum/inc/ethereum/ERC20/ERC20LikeAccount.hpp
+++ b/ledger-core-ethereum/inc/ethereum/ERC20/ERC20LikeAccount.hpp
@@ -37,6 +37,8 @@
 #include <core/database/SociNumber.hpp>
 #include <core/operation/OperationQuery.hpp>
 
+#include <ethereum/api/BigIntCallback.hpp>
+#include <ethereum/api/BinaryCallback.hpp>
 #include <ethereum/api/ERC20LikeAccount.hpp>
 #include <ethereum/api/ERC20Token.hpp>
 #include <ethereum/ERC20/ERC20LikeOperation.hpp>
@@ -45,10 +47,8 @@
 #include <ethereum/database/EthereumLikeTransactionDatabaseHelper.hpp>
 #include <ethereum/operations/EthereumLikeOperationDatabaseHelper.hpp>
 
-
 namespace ledger {
     namespace core {
-
         class ERC20LikeAccount : public api::ERC20LikeAccount {
         public:
             ERC20LikeAccount(const std::string &accountUid,
@@ -59,7 +59,7 @@ namespace ledger {
             api::ERC20Token getToken() override ;
             std::string getAddress() override ;
             FuturePtr<api::BigInt> getBalance();
-            void getBalance(const std::function<void(std::shared_ptr<::ledger::core::api::BigInt>, std::experimental::optional<::ledger::core::api::Error>)> & callback) override ;
+            void getBalance(const std::shared_ptr<api::BigIntCallback> & callback) override ;
 
             std::vector<std::shared_ptr<api::BigInt>> getBalanceHistoryFor(
                 const std::chrono::system_clock::time_point& startDate,
@@ -78,9 +78,11 @@ namespace ledger {
             Future<std::vector<uint8_t>> getTransferToAddressData(const std::shared_ptr<api::BigInt> &amount,
                                                                   const std::string &address);
 
-            void getTransferToAddressData(const std::shared_ptr<api::BigInt> &amount,
-                                          const std::string &address,
-                                          const std::function<void(std::experimental::optional<std::vector<uint8_t>>, std::experimental::optional<::ledger::core::api::Error>)> &data) override;
+            void getTransferToAddressData(
+                const std::shared_ptr<api::BigInt> &amount,
+                const std::string &address,
+                const std::shared_ptr<api::BinaryCallback> & data
+            ) override;
 
             std::shared_ptr<api::OperationQuery> queryOperations() override ;
             void putOperation(soci::session &sql, const std::shared_ptr<ERC20LikeOperation> &operation, bool newOperation = false);

--- a/ledger-core-ethereum/inc/ethereum/EthereumLikeAccount.hpp
+++ b/ledger-core-ethereum/inc/ethereum/EthereumLikeAccount.hpp
@@ -38,8 +38,11 @@
 #include <core/wallet/AbstractAccount.hpp>
 #include <core/wallet/Amount.hpp>
 
+#include <ethereum/api/BigIntCallback.hpp>
+#include <ethereum/api/BigIntListCallback.hpp>
 #include <ethereum/api/EthereumLikeAccount.hpp>
 #include <ethereum/api/EthereumLikeTransactionBuilder.hpp>
+#include <ethereum/api/StringCallback.hpp>
 #include <ethereum/explorers/EthereumLikeBlockchainExplorer.hpp>
 #include <ethereum/synchronizers/EthereumLikeAccountSynchronizer.hpp>
 #include <ethereum/observers/EthereumLikeBlockchainObserver.hpp>
@@ -104,28 +107,28 @@ namespace ledger {
                                                                                                      const std::string &txHash,
                                                                                                      const std::vector<uint8_t> &rawTx);
 
-            void broadcastRawTransaction(const std::vector<uint8_t> & transaction, const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<::ledger::core::api::Error>)> & callback) override;
+            void broadcastRawTransaction(const std::vector<uint8_t> & transaction, const std::shared_ptr<api::StringCallback> & callback) override;
 
             void broadcastTransaction(const std::shared_ptr<api::EthereumLikeTransaction> & transaction,
-                                      const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<::ledger::core::api::Error>)> & callback) override;
+                                      const std::shared_ptr<api::StringCallback> & callback) override;
 
             std::shared_ptr<api::EthereumLikeTransactionBuilder> buildTransaction() override;
             std::shared_ptr<api::OperationQuery> queryOperations() override;
 
             std::vector<std::shared_ptr<api::ERC20LikeAccount>> getERC20Accounts() override ;
 
-            void getGasPrice(const std::function<void(std::experimental::optional<std::shared_ptr<::ledger::core::api::BigInt>>, std::experimental::optional<::ledger::core::api::Error>)> & callback) override;
+            void getGasPrice(const std::shared_ptr<api::BigIntCallback> & callback) override;
 
-            void getEstimatedGasLimit(const std::string & address, const std::function<void(std::experimental::optional<std::shared_ptr<::ledger::core::api::BigInt>>, std::experimental::optional<::ledger::core::api::Error>)> & callback) override ;
+            void getEstimatedGasLimit(const std::string & address, const std::shared_ptr<api::BigIntCallback> & callback) override ;
             FuturePtr<api::BigInt> getERC20Balance(const std::string & erc20Address);
-            void getERC20Balance(const std::string & erc20Address, const std::function<void(std::experimental::optional<std::shared_ptr<::ledger::core::api::BigInt>>, std::experimental::optional<::ledger::core::api::Error>)> & callback) override;
+            void getERC20Balance(const std::string & erc20Address, const std::shared_ptr<api::BigIntCallback> & callback) override;
 
             Future<std::vector<std::shared_ptr<api::BigInt>>> getERC20Balances(
                 const std::vector<std::string>& erc20Addresses
             );
             void getERC20Balances(
                 const std::vector<std::string> & erc20Addresses,
-                const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::BigInt>>>, std::experimental::optional<api::Error>)> & callback
+                const std::shared_ptr<api::BigIntListCallback> & callback
             ) override;
 
             void addERC20Accounts(soci::session &sql,

--- a/ledger-core-ethereum/inc/ethereum/builders/EthereumLikeTransactionBuilder.hpp
+++ b/ledger-core-ethereum/inc/ethereum/builders/EthereumLikeTransactionBuilder.hpp
@@ -40,6 +40,7 @@
 #include <core/wallet/Amount.hpp>
 
 #include <ethereum/EthereumLikeTransaction.hpp>
+#include <ethereum/api/EthereumLikeTransactionCallback.hpp>
 #include <ethereum/api/EthereumLikeTransactionBuilder.hpp>
 #include <ethereum/explorers/EthereumLikeBlockchainExplorer.hpp>
 
@@ -61,10 +62,10 @@ namespace ledger {
         };
 
         using EthereumLikeTransactionBuildFunction = std::function<Future<std::shared_ptr<api::EthereumLikeTransaction>> (const EthereumLikeTransactionBuildRequest&, const std::shared_ptr<EthereumLikeBlockchainExplorer> &)>;
-        
+
         class EthereumLikeTransactionBuilder : public api::EthereumLikeTransactionBuilder, public std::enable_shared_from_this<EthereumLikeTransactionBuilder>{
         public:
-            
+
             explicit EthereumLikeTransactionBuilder(const std::shared_ptr<api::ExecutionContext>& context,
                                                     const api::Currency& params,
                                                     const std::shared_ptr<EthereumLikeBlockchainExplorer> &explorer,
@@ -72,22 +73,22 @@ namespace ledger {
                                                     const EthereumLikeTransactionBuildFunction& buildFunction);
 
             EthereumLikeTransactionBuilder(const EthereumLikeTransactionBuilder& cpy);
-            
+
             std::shared_ptr<api::EthereumLikeTransactionBuilder> sendToAddress(const std::shared_ptr<api::Amount> & amount,
                                                                                const std::string & address) override;
 
             std::shared_ptr<api::EthereumLikeTransactionBuilder> wipeToAddress(const std::string & address) override;
-            
+
             std::shared_ptr<api::EthereumLikeTransactionBuilder> setGasPrice(const std::shared_ptr<api::Amount> & gasPrice) override;
             std::shared_ptr<api::EthereumLikeTransactionBuilder> setGasLimit(const std::shared_ptr<api::Amount> & gasLimit) override;
             std::shared_ptr<api::EthereumLikeTransactionBuilder> setInputData(const std::vector<uint8_t> & data) override;
 
-            void build(const std::function<void(std::shared_ptr<api::EthereumLikeTransaction>, std::experimental::optional<::ledger::core::api::Error>)> & callback) override;
+            void build(const std::shared_ptr<api::EthereumLikeTransactionCallback> & callback) override;
 
             Future<std::shared_ptr<api::EthereumLikeTransaction>> build();
 
             std::shared_ptr<api::EthereumLikeTransactionBuilder> clone() override;
-            
+
             void reset() override;
 
             static std::shared_ptr<api::EthereumLikeTransaction> parseRawTransaction(const api::Currency & currency,
@@ -100,7 +101,7 @@ namespace ledger {
             EthereumLikeTransactionBuildRequest _request;
             std::shared_ptr<api::ExecutionContext> _context;
             std::shared_ptr<spdlog::logger> _logger;
-            
-        };       
+
+        };
     }
 }

--- a/ledger-core-ethereum/src/ethereum/ERC20/ERC20LikeAccount.cpp
+++ b/ledger-core-ethereum/src/ethereum/ERC20/ERC20LikeAccount.cpp
@@ -82,7 +82,7 @@ namespace ledger {
             return parentAccount->getERC20Balance(_token.contractAddress);
         }
 
-        void ERC20LikeAccount::getBalance(const std::function<void(std::shared_ptr<::ledger::core::api::BigInt>, std::experimental::optional<::ledger::core::api::Error>)> & callback) {
+        void ERC20LikeAccount::getBalance(const std::shared_ptr<api::BigIntCallback> & callback) {
             getBalance().callback(getContext(), callback);
         }
 
@@ -236,9 +236,11 @@ namespace ledger {
             });
         }
 
-        void ERC20LikeAccount::getTransferToAddressData(const std::shared_ptr<api::BigInt> &amount,
-                                                        const std::string &address,
-                                                        const std::function<void(std::experimental::optional<std::vector<uint8_t>>, std::experimental::optional<::ledger::core::api::Error>)> &data) {
+        void ERC20LikeAccount::getTransferToAddressData(
+            const std::shared_ptr<api::BigInt> &amount,
+            const std::string &address,
+            const std::shared_ptr<api::BinaryCallback> & data
+        ) {
             auto context = _account.lock()->getWallet()->getMainExecutionContext();
             getTransferToAddressData(amount, address).callback(context, data);
         }

--- a/ledger-core-ethereum/src/ethereum/EthereumLikeAccount.cpp
+++ b/ledger-core-ethereum/src/ethereum/EthereumLikeAccount.cpp
@@ -590,8 +590,10 @@ namespace ledger {
             return txExplorer;
         }
 
-        void EthereumLikeAccount::broadcastRawTransaction(const std::vector<uint8_t> & transaction,
-                                                          const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<::ledger::core::api::Error>)> & callback) {
+        void EthereumLikeAccount::broadcastRawTransaction(
+            const std::vector<uint8_t> & transaction,
+            const std::shared_ptr<api::StringCallback> & callback
+        ) {
             auto self = getSelf();
             _explorer->pushTransaction(transaction).map<std::string>(getContext(), [self, transaction] (const String& seq) -> std::string {
                 auto txHash = seq.str();
@@ -606,8 +608,10 @@ namespace ledger {
             }).callback(getMainExecutionContext(), callback);
         }
 
-        void EthereumLikeAccount::broadcastTransaction(const std::shared_ptr<api::EthereumLikeTransaction> & transaction,
-                                                       const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<::ledger::core::api::Error>)> & callback) {
+        void EthereumLikeAccount::broadcastTransaction(
+            const std::shared_ptr<api::EthereumLikeTransaction> & transaction,
+            const std::shared_ptr<api::StringCallback> & callback
+        ) {
                 broadcastRawTransaction(transaction->serialize(), callback);
         }
 
@@ -617,34 +621,38 @@ namespace ledger {
         }
 
         void EthereumLikeAccount::getGasPrice(
-            const std::function<void(std::experimental::optional<std::shared_ptr<::ledger::core::api::BigInt>>, std::experimental::optional<::ledger::core::api::Error>)> & callback) {
+            const std::shared_ptr<api::BigIntCallback> & callback
+        ) {
             _explorer->getGasPrice().mapPtr<api::BigInt>(getMainExecutionContext(), [] (const std::shared_ptr<BigInt> &gasPrice) -> std::shared_ptr<api::BigInt> {
-                return std::make_shared<BigInt>(*gasPrice);
+                return std::static_pointer_cast<api::BigInt>(gasPrice);
             }).callback(getMainExecutionContext(), callback);
         }
 
         void EthereumLikeAccount::getEstimatedGasLimit(
             const std::string & address,
-            const std::function<void(std::experimental::optional<std::shared_ptr<::ledger::core::api::BigInt>>, std::experimental::optional<::ledger::core::api::Error>)>& callback) {
+            const std::shared_ptr<api::BigIntCallback> & callback
+        ) {
             _explorer->getEstimatedGasLimit(address).mapPtr<api::BigInt>(getMainExecutionContext(), [] (const std::shared_ptr<BigInt> &gasPrice) -> std::shared_ptr<api::BigInt> {
-                return std::make_shared<BigInt>(*gasPrice);
+                return std::static_pointer_cast<api::BigInt>(gasPrice);
             }).callback(getMainExecutionContext(), callback);
         }
 
         FuturePtr<api::BigInt> EthereumLikeAccount::getERC20Balance(const std::string & erc20Address) {
             return _explorer->getERC20Balance(_keychain->getAddress()->toEIP55(), erc20Address).mapPtr<api::BigInt>(getMainExecutionContext(), [] (const std::shared_ptr<BigInt> &erc20Balance) -> std::shared_ptr<api::BigInt> {
-                return std::make_shared<BigInt>(*erc20Balance);
+                return std::static_pointer_cast<api::BigInt>(erc20Balance);
             });
         }
 
-        void EthereumLikeAccount::getERC20Balance(const std::string & erc20Address,
-                                                  const std::function<void(std::experimental::optional<std::shared_ptr<::ledger::core::api::BigInt>>, std::experimental::optional<::ledger::core::api::Error>)> & callback) {
+        void EthereumLikeAccount::getERC20Balance(
+            const std::string & erc20Address,
+            const std::shared_ptr<api::BigIntCallback> & callback
+        ) {
             getERC20Balance(erc20Address).callback(getMainExecutionContext(), callback);
         }
 
         void EthereumLikeAccount::getERC20Balances(
             const std::vector<std::string> & erc20Addresses,
-            const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::BigInt>>>, std::experimental::optional<api::Error>)> & callback
+            const std::shared_ptr<api::BigIntListCallback> & callback
         ) {
             getERC20Balances(erc20Addresses).callback(getMainExecutionContext(), callback);
         }

--- a/ledger-core-ethereum/src/ethereum/builders/EthereumLikeTransactionBuilder.cpp
+++ b/ledger-core-ethereum/src/ethereum/builders/EthereumLikeTransactionBuilder.cpp
@@ -92,7 +92,7 @@ namespace ledger {
             return shared_from_this();
         }
 
-        void EthereumLikeTransactionBuilder::build(const std::function<void(std::shared_ptr<api::EthereumLikeTransaction>, std::experimental::optional<::ledger::core::api::Error>)> & callback) {
+        void EthereumLikeTransactionBuilder::build(const std::shared_ptr<api::EthereumLikeTransactionCallback> & callback) {
             build().callback(_context, callback);
         }
 

--- a/ledger-core-ethereum/test/SynchronizationTests.cpp
+++ b/ledger-core-ethereum/test/SynchronizationTests.cpp
@@ -395,6 +395,8 @@ std::pair<std::shared_ptr<LambdaEventReceiver>, ledger::core::Future<bool>> crea
 TEST_F(EthereumLikeWalletSynchronization, ReorgLastBlock) {
     auto walletName = "e847815f-488a-4301-b67c-378a5e9c8a61";
     {
+        backend = std::static_pointer_cast<DatabaseBackend>(DatabaseBackend::getSqlite3Backend());
+
         auto fakeHttp = std::make_shared<test::FakeHttpClient>();
         auto services = Services::newInstance(
             "my_ppol",

--- a/ledger-core-ripple/idl/callback.djinni
+++ b/ledger-core-ripple/idl/callback.djinni
@@ -1,0 +1,17 @@
+@extern "../../ledger-core/idl/core.yaml"
+
+# Callback triggered by main completed task, returning optional result as list of template type T.
+ListCallback = interface[T] +j +o +s +n {
+    # Method triggered when main task complete.
+    # @params result optional of type list<T>, non null if main task failed
+    # @params error optional of type Error, non null if main task succeeded
+    onCallback(result: optional<list<T>>, error: optional<Error>);
+}
+
+# Callback triggered by main completed task, returning optional result of template type T.
+Callback = interface[T] +j +o +s +n {
+    # Method triggered when main task complete.
+    # @params result optional of type T, non null if main task failed
+    # @params error optional of type Error, non null if main task succeeded
+    onCallback(result: optional<T>, error: optional<Error>);
+}

--- a/ledger-core-ripple/idl/idl.djinni
+++ b/ledger-core-ripple/idl/idl.djinni
@@ -77,12 +77,12 @@ RippleLikeTransaction = interface +c {
 	getLedgerSequence(): BigInt;
 	# Get Signing public Key
 	getSigningPubKey(): binary;
-  # Get all memos associated with the transaction.
-  getMemos(): list<RippleLikeMemo>;
-  # Add a memo to a transaction.
-  addMemo(memo: RippleLikeMemo);
-  # An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account
-  getDestinationTag(): optional<i64>;
+	# Get all memos associated with the transaction.
+	getMemos(): list<RippleLikeMemo>;
+	# Add a memo to a transaction.
+	addMemo(memo: RippleLikeMemo);
+	# An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account
+	getDestinationTag(): optional<i64>;
 }
 
 #Class representing a Ripple Operation
@@ -122,15 +122,15 @@ RippleLikeTransactionBuilder = interface +c {
 	# @return A reference on the same builder in order to chain calls.
 	setFees(fees: Amount): RippleLikeTransactionBuilder;
 
-  # Add a memo.
-  # @return A reference on the same builder in order to chain calls.
-  addMemo(memo: RippleLikeMemo): RippleLikeTransactionBuilder;
+	# Add a memo.
+	# @return A reference on the same builder in order to chain calls.
+	addMemo(memo: RippleLikeMemo): RippleLikeTransactionBuilder;
 
-  # An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account
-  setDestinationTag(tag: i64): RippleLikeTransactionBuilder;
+	# An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account
+	setDestinationTag(tag: i64): RippleLikeTransactionBuilder;
 
 	# Build a transaction from the given builder parameters.
-	build(callback: callback2<void, optional<RippleLikeTransaction>, optional<Error>>);
+	build(callback: callback2<optional<RippleLikeTransaction>>);
 
 	# Creates a clone of this builder.
 	# @return A copy of the current builder instance.
@@ -145,24 +145,24 @@ RippleLikeTransactionBuilder = interface +c {
 
 #Class representing a Ripple account
 RippleLikeAccount = interface +c {
-	broadcastRawTransaction(transaction: binary, callback: callback2<void, optional<string>, optional<Error>>);
-	broadcastTransaction(transaction: RippleLikeTransaction, callback: callback2<void, optional<string>, optional<Error>>);
+	broadcastRawTransaction(transaction: binary, callback: callback2<optional<string>>);
+	broadcastTransaction(transaction: RippleLikeTransaction, callback: callback2<optional<string>>);
 	buildTransaction(): RippleLikeTransactionBuilder;
-  # Get fees from network
-  # Note: it would have been better to have this method on RippleLikeWallet
-  # but since RippleLikeWallet is not used anywhere, it's better to keep all
-  # specific methods under the same specific class so it will be easy to segratate
-  # when the right time comes !
-  getFees(callback: callback2<void, optional<Amount>, optional<Error>>);
-  # Get base reserve (dust to leave on an XRP account) from network
-  # Note: same note as above
-  getBaseReserve(callback: callback2<void, optional<Amount>, optional<Error>>);
-  # Check whether an account has been activated or not
-  # Here activation, means that the XRP account received a first transaction with a minimum amount
-  # greater or equal to XRP base reserve
-  # @param: address to check
-  # @return: true if valid address and has been activated, false otherwise
-  isAddressActivated(address: string, isActivated: callback2<void, optional<bool>, optional<Error>>);
+	# Get fees from network
+	# Note: it would have been better to have this method on RippleLikeWallet
+	# but since RippleLikeWallet is not used anywhere, it's better to keep all
+	# specific methods under the same specific class so it will be easy to segratate
+	# when the right time comes !
+	getFees(callback: callback2<optional<Amount>>);
+	# Get base reserve (dust to leave on an XRP account) from network
+	# Note: same note as above
+	getBaseReserve(callback: callback2<optional<Amount>>);
+	# Check whether an account has been activated or not
+	# Here activation, means that the XRP account received a first transaction with a minimum amount
+	# greater or equal to XRP base reserve
+	# @param: address to check
+	# @return: true if valid address and has been activated, false otherwise
+	isAddressActivated(address: string, isActivated: callback2<optional<bool>>);
 }
 
 RippleConfiguration = interface +c {
@@ -170,11 +170,11 @@ RippleConfiguration = interface +c {
 }
 
 RippleConfigurationDefaults = interface +c {
-	  const RIPPLE_DEFAULT_API_ENDPOINT: string = "https://data.ripple.com";
-	  const RIPPLE_OBSERVER_NODE_ENDPOINT_S2: string = "https://s2.ripple.com";
-	  const RIPPLE_OBSERVER_NODE_ENDPOINT_S3: string = "https://s3.ripple.com";
-	  const RIPPLE_OBSERVER_WS_ENDPOINT_S2: string = "wss://s2.ripple.com";
-	  const RIPPLE_OBSERVER_WS_ENDPOINT_S3: string = "wss://s3.ripple.com";
-	  const RIPPLE_DEFAULT_PORT: string = "51234";
-    const RIPPLE_DEFAULT_LAST_LEDGER_SEQUENCE_OFFSET: i32 = 4;
+	const RIPPLE_DEFAULT_API_ENDPOINT: string = "https://data.ripple.com";
+	const RIPPLE_OBSERVER_NODE_ENDPOINT_S2: string = "https://s2.ripple.com";
+	const RIPPLE_OBSERVER_NODE_ENDPOINT_S3: string = "https://s3.ripple.com";
+	const RIPPLE_OBSERVER_WS_ENDPOINT_S2: string = "wss://s2.ripple.com";
+	const RIPPLE_OBSERVER_WS_ENDPOINT_S3: string = "wss://s3.ripple.com";
+	const RIPPLE_DEFAULT_PORT: string = "51234";
+	const RIPPLE_DEFAULT_LAST_LEDGER_SEQUENCE_OFFSET: i32 = 4;
 }

--- a/ledger-core-ripple/idl/idl.djinni
+++ b/ledger-core-ripple/idl/idl.djinni
@@ -1,6 +1,7 @@
 @extern "../../ledger-core/idl/core.yaml"
 
 @import "addresses.djinni"
+@import "callback.djinni"
 @import "memo.djinni"
 
 # Main Ripple interface file.

--- a/ledger-core-ripple/inc/ripple/RippleLikeAccount.hpp
+++ b/ledger-core-ripple/inc/ripple/RippleLikeAccount.hpp
@@ -38,8 +38,10 @@
 #include <core/wallet/AbstractAccount.hpp>
 #include <core/wallet/Amount.hpp>
 
+#include <ripple/api/BoolCallback.hpp>
 #include <ripple/api/RippleLikeAccount.hpp>
 #include <ripple/api/RippleLikeTransactionBuilder.hpp>
+#include <ripple/api/StringCallback.hpp>
 #include <ripple/explorers/RippleLikeBlockchainExplorer.hpp>
 #include <ripple/observers/RippleLikeBlockchainObserver.hpp>
 #include <ripple/keychains/RippleLikeKeychain.hpp>
@@ -100,27 +102,27 @@ namespace ledger {
 
             void broadcastRawTransaction(
                 const std::vector<uint8_t> & transaction,
-                const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<api::Error>)> & callback
+                const std::shared_ptr<api::StringCallback> & callback
             ) override;
 
             void broadcastTransaction(
                 const std::shared_ptr<api::RippleLikeTransaction> & transaction,
-                const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<api::Error>)> & callback
+                const std::shared_ptr<api::StringCallback> & callback
             ) override;
 
             std::shared_ptr<api::RippleLikeTransactionBuilder> buildTransaction() override;
 
             std::shared_ptr<api::OperationQuery> queryOperations() override;
 
-            void getFees(const std::function<void(std::experimental::optional<std::shared_ptr<api::Amount>>, std::experimental::optional<api::Error>)> & callback) override;
+            void getFees(const std::shared_ptr<api::AmountCallback> & callback) override;
             FuturePtr<api::Amount> getFees();
 
-            void getBaseReserve(const std::function<void(std::experimental::optional<std::shared_ptr<api::Amount>>, std::experimental::optional<api::Error>)> & callback) override;
+            void getBaseReserve(const std::shared_ptr<api::AmountCallback> & callback) override;
             FuturePtr<api::Amount> getBaseReserve();
 
             void isAddressActivated(
                 const std::string& address,
-                const std::function<void(std::experimental::optional<bool>, std::experimental::optional<api::Error>)>& isActivated
+                const std::shared_ptr<api::BoolCallback> & isActivated
             ) override;
             Future<bool> isAddressActivated(const std::string &address);
 

--- a/ledger-core-ripple/inc/ripple/transaction_builders/RippleLikeTransactionBuilder.hpp
+++ b/ledger-core-ripple/inc/ripple/transaction_builders/RippleLikeTransactionBuilder.hpp
@@ -40,6 +40,7 @@
 #include <core/wallet/Amount.hpp>
 
 #include <ripple/api/RippleLikeTransactionBuilder.hpp>
+#include <ripple/api/RippleLikeTransactionCallback.hpp>
 #include <ripple/explorers/RippleLikeBlockchainExplorer.hpp>
 #include <ripple/transaction_builders/RippleLikeTransactionBuildRequest.hpp>
 
@@ -72,7 +73,7 @@ namespace ledger {
 
             std::shared_ptr<api::RippleLikeTransactionBuilder> setDestinationTag(int64_t tag) override;
 
-            void build(const std::function<void(std::shared_ptr<api::RippleLikeTransaction>, std::experimental::optional<api::Error>)> & callback) override;
+            void build(const std::shared_ptr<api::RippleLikeTransactionCallback> & callback) override;
 
             Future<std::shared_ptr<api::RippleLikeTransaction>> build();
 

--- a/ledger-core-ripple/src/ripple/RippleLikeAccount.cpp
+++ b/ledger-core-ripple/src/ripple/RippleLikeAccount.cpp
@@ -400,7 +400,7 @@ namespace ledger {
 
         void RippleLikeAccount::broadcastRawTransaction(
             const std::vector<uint8_t> & transaction,
-            const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<api::Error>)> & callback
+            const std::shared_ptr<api::StringCallback> & callback
         ) {
             _explorer->pushTransaction(transaction).map<std::string>(getContext(),
                                                                      [](const String &seq) -> std::string {
@@ -411,7 +411,7 @@ namespace ledger {
 
         void RippleLikeAccount::broadcastTransaction(
             const std::shared_ptr<api::RippleLikeTransaction> & transaction,
-            const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<api::Error>)> & callback
+            const std::shared_ptr<api::StringCallback> & callback
         ) {
             broadcastRawTransaction(transaction->serialize(), callback);
         }
@@ -473,7 +473,7 @@ namespace ledger {
                                                                   buildFunction);
         }
 
-        void RippleLikeAccount::getFees(const std::function<void(std::experimental::optional<std::shared_ptr<api::Amount>>, std::experimental::optional<api::Error>)> & callback) {
+        void RippleLikeAccount::getFees(const std::shared_ptr<api::AmountCallback> & callback) {
             getFees().callback(getMainExecutionContext(), callback);
         }
 
@@ -485,7 +485,7 @@ namespace ledger {
             });
         }
 
-        void RippleLikeAccount::getBaseReserve(const std::function<void(std::experimental::optional<std::shared_ptr<api::Amount>>, std::experimental::optional<api::Error>)> & callback) {
+        void RippleLikeAccount::getBaseReserve(const std::shared_ptr<api::AmountCallback> & callback) {
             getBaseReserve().callback(getMainExecutionContext(), callback);
         }
 
@@ -499,7 +499,7 @@ namespace ledger {
 
         void RippleLikeAccount::isAddressActivated(
             const std::string& address,
-            const std::function<void(std::experimental::optional<bool>, std::experimental::optional<api::Error>)>& isActivated
+            const std::shared_ptr<api::BoolCallback> & isActivated
         ) {
             isAddressActivated(address).callback(getMainExecutionContext(), isActivated);
         }

--- a/ledger-core-ripple/src/ripple/transaction_builders/RippleLikeTransactionBuilder.cpp
+++ b/ledger-core-ripple/src/ripple/transaction_builders/RippleLikeTransactionBuilder.cpp
@@ -109,7 +109,7 @@ namespace ledger {
             _request.destinationTag = tag;
             return shared_from_this();
         }
-        void RippleLikeTransactionBuilder::build(const std::function<void(std::shared_ptr<api::RippleLikeTransaction>, std::experimental::optional<api::Error>)> & callback) {
+        void RippleLikeTransactionBuilder::build(const std::shared_ptr<api::RippleLikeTransactionCallback> & callback) {
             build().callback(_context, callback);
         }
 

--- a/ledger-core-tezos/idl/callback.djinni
+++ b/ledger-core-tezos/idl/callback.djinni
@@ -1,0 +1,17 @@
+@extern "../../ledger-core/idl/core.yaml"
+
+# Callback triggered by main completed task, returning optional result as list of template type T.
+ListCallback = interface[T] +j +o +s +n {
+    # Method triggered when main task complete.
+    # @params result optional of type list<T>, non null if main task failed
+    # @params error optional of type Error, non null if main task succeeded
+    onCallback(result: optional<list<T>>, error: optional<Error>);
+}
+
+# Callback triggered by main completed task, returning optional result of template type T.
+Callback = interface[T] +j +o +s +n {
+    # Method triggered when main task complete.
+    # @params result optional of type T, non null if main task failed
+    # @params error optional of type Error, non null if main task succeeded
+    onCallback(result: optional<T>, error: optional<Error>);
+}

--- a/ledger-core-tezos/idl/idl.djinni
+++ b/ledger-core-tezos/idl/idl.djinni
@@ -1,6 +1,7 @@
 @extern "../../ledger-core/idl/core.yaml"
 
 @import "addresses.djinni"
+@import "callback.djinni"
 @import "configuration.djinni"
 
 TezosOperationTag = enum {

--- a/ledger-core-tezos/idl/idl.djinni
+++ b/ledger-core-tezos/idl/idl.djinni
@@ -98,7 +98,7 @@ TezosLikeTransactionBuilder = interface +c {
 	setStorageLimit(storageLimit: BigInt): TezosLikeTransactionBuilder;
 
 	# Build a transaction from the given builder parameters.
-	build(callback: callback2<void, TezosLikeTransaction, optional<Error>>);
+	build(callback: callback2<TezosLikeTransaction>);
 
 	# Creates a clone of this builder.
 	# @return A copy of the current builder instance.
@@ -113,21 +113,21 @@ TezosLikeTransactionBuilder = interface +c {
 
 #Class representing a Tezos account
 TezosLikeAccount = interface +c {
-	broadcastRawTransaction(transaction: binary, callback: callback2<void, optional<string>, optional<Error>>);
-	broadcastTransaction(transaction: TezosLikeTransaction, callback: callback2<void, optional<string>, optional<Error>>);
+	broadcastRawTransaction(transaction: binary, callback: callback2<optional<string>>);
+	broadcastTransaction(transaction: TezosLikeTransaction, callback: callback2<optional<string>>);
 	buildTransaction(): TezosLikeTransactionBuilder;
 	# Get needed storage to proceed a tx
 	# @param address to which we want to send tx
 	# @return needed storage to interact with address/contract
 	# Note: same note as for getGasPrice method on EthereumLikeAccount
-	getStorage(address: string, callback: callback2<void, optional<BigInt>, optional<Error>>);
+	getStorage(address: string, callback: callback2<optional<BigInt>>);
 	# Get estimated gas limit to set so the transaction will succeed
 	# The passed address could be implicit address or contract
 	# This estimation is based on X last incoming txs (to address) that succeeded
 	# Note: same note as for getFees method on BitcoinLikeAccount
-	getEstimatedGasLimit(address: string, callback: callback2<void, optional<BigInt>, optional<Error>>);
+	getEstimatedGasLimit(address: string, callback: callback2<optional<BigInt>>);
 	# Get fees from network
-	getFees(callback: callback2<void, optional<BigInt>, optional<Error>>);
+	getFees(callback: callback2<optional<BigInt>>);
 	# Get originated accounts by current account
 	getOriginatedAccounts(): list<TezosLikeOriginatedAccount>;
 }
@@ -140,9 +140,9 @@ TezosLikeOriginatedAccount = interface +c {
 	# Could be empty if not yet revealed
 	getPublicKey(): optional<string>;
 	# Get balance of originated account
-	getBalance(callback: callback2<void, Amount, optional<Error>>);
+	getBalance(callback: callback2<Amount>);
 	# Get balance history of originated account
-	getBalanceHistory(start: date, end: date, period: TimePeriod, callback: callback2<void, optional<list<Amount>>, optional<Error>>);
+	getBalanceHistory(start: date, end: date, period: TimePeriod, callback: callback2<optional<list<Amount>>>);
 	# Know if possible to spend from this account
 	# By default originations from libcore set it to true
 	isSpendable(): bool;

--- a/ledger-core-tezos/inc/tezos/TezosLikeAccount.hpp
+++ b/ledger-core-tezos/inc/tezos/TezosLikeAccount.hpp
@@ -32,6 +32,8 @@
 
 #include <time.h>
 
+#include <tezos/api/BigIntCallback.hpp>
+#include <tezos/api/StringCallback.hpp>
 #include <tezos/api/TezosLikeAccount.hpp>
 #include <tezos/api/TezosLikeTransactionBuilder.hpp>
 #include <tezos/explorers/TezosLikeBlockchainExplorer.hpp>
@@ -101,11 +103,15 @@ namespace ledger {
 
             std::string getRestoreKey() override;
 
-            void broadcastRawTransaction(const std::vector<uint8_t> &transaction,
-                                         const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<::ledger::core::api::Error>)>& callback) override;
+            void broadcastRawTransaction(
+                const std::vector<uint8_t> &transaction,
+                const std::shared_ptr<api::StringCallback> & callback
+            ) override;
 
-            void broadcastTransaction(const std::shared_ptr<api::TezosLikeTransaction> &transaction,
-                                      const std::function<void(std::experimental::optional<std::string>, std::experimental::optional<::ledger::core::api::Error>)>& callback) override;
+            void broadcastTransaction(
+                const std::shared_ptr<api::TezosLikeTransaction> &transaction,
+                const std::shared_ptr<api::StringCallback> & callback
+            ) override;
 
             std::shared_ptr<api::TezosLikeTransactionBuilder> buildTransaction() override;
             std::shared_ptr<api::TezosLikeTransactionBuilder> buildTransaction(const std::string &senderAddress);
@@ -114,12 +120,14 @@ namespace ledger {
 
             void getEstimatedGasLimit(
                 const std::string & address,
-                const std::function<void(std::experimental::optional<std::shared_ptr<api::BigInt>>, std::experimental::optional<api::Error>)> & callback) override;
+                const std::shared_ptr<api::BigIntCallback> & callback
+            ) override;
             FuturePtr<BigInt> getEstimatedGasLimit(const std::string &address);
 
             void getStorage(
                 const std::string & address,
-                const std::function<void(std::experimental::optional<std::shared_ptr<api::BigInt>>, std::experimental::optional<api::Error>)> & callback) override;
+                const std::shared_ptr<api::BigIntCallback> & callback
+            ) override;
 
             FuturePtr<BigInt> getStorage(const std::string &address);
 
@@ -128,8 +136,9 @@ namespace ledger {
             void addOriginatedAccounts(soci::session &sql, const std::vector<TezosLikeOriginatedAccountDatabaseEntry> &originatedEntries);
 
             void getFees(
-                const std::function<void(std::experimental::optional<std::shared_ptr<api::BigInt>>, std::experimental::optional<api::Error>)> & callback) override;
-            
+                const std::shared_ptr<api::BigIntCallback> & callback
+            ) override;
+
             FuturePtr<BigInt> getFees();
 
         private:

--- a/ledger-core-tezos/inc/tezos/delegation/TezosLikeOriginatedAccount.hpp
+++ b/ledger-core-tezos/inc/tezos/delegation/TezosLikeOriginatedAccount.hpp
@@ -43,7 +43,7 @@
 
 namespace ledger {
     namespace core {
-        
+
         class TezosLikeOriginatedAccount : public api::TezosLikeOriginatedAccount {
         public:
             TezosLikeOriginatedAccount(const std::string &uid,
@@ -59,13 +59,15 @@ namespace ledger {
 
             std::experimental::optional<std::string> getPublicKey() override;
 
-            void getBalance(const std::function<void(std::shared_ptr<api::Amount>, std::experimental::optional<api::Error>)> & callback) override;
+            void getBalance(const std::shared_ptr<api::AmountCallback> & callback) override;
             FuturePtr<api::Amount> getBalance(const std::shared_ptr<api::ExecutionContext>& context);
 
-            void getBalanceHistory(const std::chrono::system_clock::time_point & start,
-                                   const std::chrono::system_clock::time_point & end,
-                                   api::TimePeriod period,
-                                   const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::Amount>>>, std::experimental::optional<api::Error>)>& callback) override;
+            void getBalanceHistory(
+                const std::chrono::system_clock::time_point & start,
+                const std::chrono::system_clock::time_point & end,
+                api::TimePeriod period,
+                const std::shared_ptr<api::AmountListCallback> & callback
+            ) override;
 
             Future<std::vector<std::shared_ptr<api::Amount>>> getBalanceHistory(const std::shared_ptr<api::ExecutionContext>& context,
                                                                                 const std::chrono::system_clock::time_point & start,

--- a/ledger-core-tezos/inc/tezos/transactions/TezosLikeTransactionBuilder.hpp
+++ b/ledger-core-tezos/inc/tezos/transactions/TezosLikeTransactionBuilder.hpp
@@ -33,6 +33,7 @@
 #include <spdlog/logger.h>
 
 #include <tezos/api/TezosLikeTransactionBuilder.hpp>
+#include <tezos/api/TezosLikeTransactionCallback.hpp>
 #include <tezos/api/TezosOperationTag.hpp>
 #include <tezos/explorers/TezosLikeBlockchainExplorer.hpp>
 
@@ -93,7 +94,7 @@ namespace ledger {
             std::shared_ptr<api::TezosLikeTransactionBuilder>
             setStorageLimit(const std::shared_ptr<api::BigInt> & storageLimit) override;
 
-            void build(const std::function<void(std::shared_ptr<api::TezosLikeTransaction>, std::experimental::optional<api::Error>)> &callback) override;
+            void build(const std::shared_ptr<api::TezosLikeTransactionCallback> & callback) override;
 
             Future<std::shared_ptr<api::TezosLikeTransaction>> build();
 

--- a/ledger-core-tezos/src/tezos/TezosLikeAccount.cpp
+++ b/ledger-core-tezos/src/tezos/TezosLikeAccount.cpp
@@ -240,7 +240,8 @@ namespace ledger {
 
         void TezosLikeAccount::getEstimatedGasLimit(
             const std::string & address,
-            const std::function<void(std::experimental::optional<std::shared_ptr<api::BigInt>>, std::experimental::optional<api::Error>)> & callback) {
+            const std::shared_ptr<api::BigIntCallback> & callback
+        ) {
             getEstimatedGasLimit(address).mapPtr<api::BigInt>(getMainExecutionContext(), [] (const std::shared_ptr<BigInt> &gasLimit) -> std::shared_ptr<api::BigInt> {
                 return std::make_shared<BigInt>(*gasLimit);
             }).callback(getMainExecutionContext(), callback);
@@ -252,7 +253,8 @@ namespace ledger {
 
         void TezosLikeAccount::getStorage(
             const std::string & address,
-            const std::function<void(std::experimental::optional<std::shared_ptr<api::BigInt>>, std::experimental::optional<api::Error>)> & callback) {
+            const std::shared_ptr<api::BigIntCallback> & callback
+        ) {
             getStorage(address).mapPtr<api::BigInt>(getMainExecutionContext(), [] (const std::shared_ptr<BigInt> &storage) -> std::shared_ptr<api::BigInt> {
                 return std::make_shared<BigInt>(*storage);
             }).callback(getMainExecutionContext(), callback);

--- a/ledger-core-tezos/src/tezos/TezosLikeAccount2.cpp
+++ b/ledger-core-tezos/src/tezos/TezosLikeAccount2.cpp
@@ -198,8 +198,10 @@ namespace ledger {
             return _keychain->getRestoreKey();
         }
 
-        void TezosLikeAccount::broadcastRawTransaction(const std::vector<uint8_t> &transaction,
-                                                       const std::function<void(std::experimental::optional<std::string>, const std::experimental::optional<api::Error>)> &callback) {
+        void TezosLikeAccount::broadcastRawTransaction(
+            const std::vector<uint8_t> &transaction,
+            const std::shared_ptr<api::StringCallback> & callback
+        ) {
             _explorer->pushTransaction(transaction)
                     .map<std::string>(getContext(),
                                       [](const String &seq) -> std::string {
@@ -216,8 +218,10 @@ namespace ledger {
                     .callback(getMainExecutionContext(), callback);
         }
 
-        void TezosLikeAccount::broadcastTransaction(const std::shared_ptr<api::TezosLikeTransaction> &transaction,
-                                                    const std::function<void(std::experimental::optional<std::string>, const std::experimental::optional<api::Error>)> &callback) {
+        void TezosLikeAccount::broadcastTransaction(
+            const std::shared_ptr<api::TezosLikeTransaction> &transaction,
+            const std::shared_ptr<api::StringCallback> & callback
+        ) {
             broadcastRawTransaction(transaction->serialize(), callback);
         }
 
@@ -397,7 +401,8 @@ namespace ledger {
         }
 
         void TezosLikeAccount::getFees(
-            const std::function<void(std::experimental::optional<std::shared_ptr<api::BigInt>>, std::experimental::optional<api::Error>)> & callback) {
+            const std::shared_ptr<api::BigIntCallback> & callback
+        ) {
             getFees().mapPtr<api::BigInt>(getMainExecutionContext(), [] (const std::shared_ptr<BigInt> &fees) -> std::shared_ptr<api::BigInt>
             {
                 if (!fees) {

--- a/ledger-core-tezos/src/tezos/delegation/TezosLikeOriginatedAccount.cpp
+++ b/ledger-core-tezos/src/tezos/delegation/TezosLikeOriginatedAccount.cpp
@@ -70,7 +70,7 @@ namespace ledger {
             return _publicKey.toOptional();
         }
 
-        void TezosLikeOriginatedAccount::getBalance(const std::function<void(std::shared_ptr<api::Amount>, std::experimental::optional<api::Error>)> & callback) {
+        void TezosLikeOriginatedAccount::getBalance(const std::shared_ptr<api::AmountCallback> & callback) {
             auto localAccount = _originatorAccount.lock();
             if (!localAccount) {
                 throw make_exception(api::ErrorCode::NULL_POINTER, "Account was released.");
@@ -103,10 +103,12 @@ namespace ledger {
         }
 
 
-        void TezosLikeOriginatedAccount::getBalanceHistory(const std::chrono::system_clock::time_point & start,
-                                                           const std::chrono::system_clock::time_point & end,
-                                                           api::TimePeriod period,
-                                                           const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::Amount>>>, std::experimental::optional<api::Error>)> & callback) {
+        void TezosLikeOriginatedAccount::getBalanceHistory(
+            const std::chrono::system_clock::time_point & start,
+            const std::chrono::system_clock::time_point & end,
+            api::TimePeriod period,
+            const std::shared_ptr<api::AmountListCallback> & callback
+        ) {
             auto localAccount = _originatorAccount.lock();
             if (!localAccount) {
                 throw make_exception(api::ErrorCode::NULL_POINTER, "Account was released.");

--- a/ledger-core-tezos/src/tezos/transactions/TezosLikeTransactionBuilder.cpp
+++ b/ledger-core-tezos/src/tezos/transactions/TezosLikeTransactionBuilder.cpp
@@ -110,7 +110,8 @@ namespace ledger {
         }
 
         void TezosLikeTransactionBuilder::build(
-            const std::function<void(std::shared_ptr<api::TezosLikeTransaction>, std::experimental::optional<api::Error>)> &callback) {
+                const std::shared_ptr<api::TezosLikeTransactionCallback> & callback
+        ) {
             build().callback(_context, callback);
         }
 

--- a/ledger-core/idl/account.djinni
+++ b/ledger-core/idl/account.djinni
@@ -44,7 +44,7 @@ Account = interface +c {
 
     # Get balance of account.
     # @param callback, if getBalacne, Callback returning an Amount object which represents account's balance
-    getBalance(callback: callback2<void, optional<Amount>, optional<Error>>);
+    getBalance(callback: callback2<optional<Amount>>);
 
     # Get balance of account at a precise interval with a certain granularity.
     # @param start, lower bound of search range
@@ -55,7 +55,7 @@ Account = interface +c {
         start: string,
         end: string,
         period: TimePeriod,
-        callback: callback2<void, optional<list<Amount>>, optional<Error>>
+        callback: callback2<optional<list<Amount>>>
     );
 
     # Get synchronization status of account.
@@ -79,7 +79,7 @@ Account = interface +c {
     getOperationPreferences(uid: string): Preferences;
 
     #TODO
-    getFreshPublicAddresses(callback: callback2<void, optional<list<Address>>, optional<Error>>);
+    getFreshPublicAddresses(callback: callback2<optional<list<Address>>>);
 
     # Get event bus through which account is notified on synchronization status.
     # @return EventBus object
@@ -97,14 +97,14 @@ Account = interface +c {
 
     # Get Last block of blockchain on which account operates.
     # @param callback, Callback returning, if getLastBlock succeeds, a Block object
-    getLastBlock(callback: callback2<void, optional<Block>, optional<Error>>);
+    getLastBlock(callback: callback2<optional<Block>>);
 
     # Get the key used to generate the account.
     getRestoreKey(): string;
 
     # Erase data (in user's DB) relative to wallet since given date.
     # @param date, start date of data deletion
-    eraseDataSince(date: date, callback: callback2<void, optional<ErrorCode>, optional<Error>>);
+    eraseDataSince(date: date, callback: callback2<optional<ErrorCode>>);
 }
 
 # Structure of informations needed for account creation.

--- a/ledger-core/idl/callback.djinni
+++ b/ledger-core/idl/callback.djinni
@@ -1,0 +1,17 @@
+@import "error.djinni"
+# Callback triggered by main completed task, returning optional result as list of template type T.
+ListCallback = interface[T] +j +o +s +n {
+    # Method triggered when main task complete.
+    # @params result optional of type list<T>, non null if main task failed
+    # @params error optional of type Error, non null if main task succeeded
+    onCallback(result: optional<list<T>>, error: optional<Error>);
+}
+
+# Callback triggered by main completed task, returning optional result of template type T.
+Callback = interface[T] +j +o +s +n {
+    # Method triggered when main task complete.
+    # @params result optional of type T, non null if main task failed
+    # @params error optional of type Error, non null if main task succeeded
+    onCallback(result: optional<T>, error: optional<Error>);
+}
+

--- a/ledger-core/idl/core.djinni
+++ b/ledger-core/idl/core.djinni
@@ -3,6 +3,7 @@
 @import "amount.djinni"
 @import "block.djinni"
 @import "configuration.djinni"
+@import "callback.djinni"
 @import "crypto.djinni"
 @import "currency.djinni"
 @import "database.djinni"

--- a/ledger-core/idl/operation.djinni
+++ b/ledger-core/idl/operation.djinni
@@ -97,7 +97,7 @@ OperationQuery = interface +c {
 
     # Execute query to retrieve operations.
     # @param callback, if execute method succeed, return a list of Operation objects
-    execute(callback: callback2<void, optional<list<Operation>>, optional<Error>>);
+    execute(callback: callback2<optional<list<Operation>>>);
 }
 
 # Class representing an operation.

--- a/ledger-core/idl/services.djinni
+++ b/ledger-core/idl/services.djinni
@@ -56,7 +56,7 @@ Services = interface +c {
     # Return last block of blockchain of a given currency (if it is supported by the wallet pool).
     # @param name, string, name of currency we are interested into getting it's blockchain's last block
     # @param callback, Callback object returns a Block object
-    getLastBlock(currencyName: string, callback: callback2<void, optional<Block>, optional<Error>>);
+    getLastBlock(currencyName: string, callback: callback2<optional<Block>>);
 
     # Reset wallet pool.
     #
@@ -74,7 +74,7 @@ Services = interface +c {
     # > that doesn’t include having lots of objects in memory.
     #
     # The return value is always true and doesn’t convey any useful information for now.
-    freshResetAll(callback: callback2<void, optional<ErrorCode>, optional<Error>>);
+    freshResetAll(callback: callback2<optional<ErrorCode>>);
 
     # Change Database password.
     #
@@ -83,7 +83,7 @@ Services = interface +c {
     #
     # WARNING: be careful to have no other instances of Services using
     # same database / preferences.
-    changePassword(oldPassword: string, newPassword: string, callback: callback2<void, optional<ErrorCode>, optional<Error>>);
+    changePassword(oldPassword: string, newPassword: string, callback: callback2<optional<ErrorCode>>);
 }
 
 # Class representing a services builder.
@@ -140,7 +140,7 @@ ServicesBuilder = interface +c {
 
     # Create services.
     # @param callback, callback returning a Services instance
-    build(listener: callback2<void, optional<Services>, optional<Error>>);
+    build(listener: callback2<optional<Services>>);
 
     # Create an instance of the services builder.
     # @return ServicesBuilder object

--- a/ledger-core/idl/wallet.djinni
+++ b/ledger-core/idl/wallet.djinni
@@ -16,21 +16,21 @@ Wallet = interface +c {
     # Get account with specific index.
     # @param index, 32-bit integer, index of account in wallet
     # @param callback, Callback returning, if getAccount succeed, an Account object with given index
-    getAccount(index: i32, callback: callback2<void, optional<Account>, optional<Error>>);
+    getAccount(index: i32, callback: callback2<optional<Account>>);
 
     # Get number of accounts instanciated under wallet.
     # @param callback, Callback returning, if getAccountCount succeed, a 32-bit integer representing number of accounts
-    getAccountCount(callback: callback2<void, optional<i32>, optional<Error>>);
+    getAccountCount(callback: callback2<optional<i32>>);
 
     # Get list of accounts instanciated under wallet in a given range.
     # @param offset, 32-bit integer from which we retrieve accounts
     # @param count, 32-bit integer, number of accounts to retrieve
     # @param callback, ListCallback returning, if getAccounts succeed, list of Accounts object
-    getAccounts(offset: i32, count: i32, callback: callback2<void, optional<list<Account>>, optional<Error>>);
+    getAccounts(offset: i32, count: i32, callback: callback2<optional<list<Account>>>);
 
     # Get index of next account to create.
     # @return callback, Callback returning a 32-bit integer
-    getNextAccountIndex(callback: callback2<void, optional<i32>, optional<Error>>);
+    getNextAccountIndex(callback: callback2<optional<i32>>);
 
     # Return event bus through which wallet synchronizes it's accounts and interact with blockchain.
     # @return EventBus object
@@ -63,31 +63,31 @@ Wallet = interface +c {
 
     # Get last block of blockchain the wallet operates on.
     # @param callback, Callback returning a Block object
-    getLastBlock(callback: callback2<void, optional<Block>, optional<Error>>);
+    getLastBlock(callback: callback2<optional<Block>>);
 
     # Return infos about the creation of specific account.
     # @param accountIndex, 32-bit account, index of account in wallet
     # @param callback, Callback returning an AccountCreationInfo
     getAccountCreationInfo(
         accountIndex: i32,
-        callback: callback2<void, optional<AccountCreationInfo>, optional<Error>>
+        callback: callback2<optional<AccountCreationInfo>>
     );
 
     #TODO
     getExtendedKeyAccountCreationInfo(
         accountIndex: i32,
-        callback: callback2<void, optional<ExtendedKeyAccountCreationInfo>, optional<Error>>
+        callback: callback2<optional<ExtendedKeyAccountCreationInfo>>
     );
 
     # Return infos about the next created account.
     # @param callback, Callback returning an AccountCreationInfo
     getNextAccountCreationInfo(
-        callback: callback2<void, optional<AccountCreationInfo>, optional<Error>>
+        callback: callback2<optional<AccountCreationInfo>>
     );
 
     #TODO
     getNextExtendedKeyAccountCreationInfo(
-        callback: callback2<void, optional<ExtendedKeyAccountCreationInfo>, optional<Error>>
+        callback: callback2<optional<ExtendedKeyAccountCreationInfo>>
     );
 
     # Get account from given account creation infos.
@@ -95,20 +95,20 @@ Wallet = interface +c {
     # @param callback, Callback returning an Account object with given creation infos
     newAccountWithInfo(
         accountCreationInfo: AccountCreationInfo,
-        callback: callback2<void, optional<Account>, optional<Error>>
+        callback: callback2<optional<Account>>
     );
 
     #TODO
     newAccountWithExtendedKeyInfo(
         extendedKeyAccountCreationInfo: ExtendedKeyAccountCreationInfo,
-        callback: callback2<void, optional<Account>, optional<Error>>
+        callback: callback2<optional<Account>>
     );
 
     # Erase data (in user's DB) relative to wallet since given date.
     # @param date, start date of data deletion
     eraseDataSince(
         date: date,
-        callback: callback2<void, optional<ErrorCode>, optional<Error>>
+        callback: callback2<optional<ErrorCode>>
     );
 
     # Return wallet's configuration

--- a/ledger-core/inc/core/async/Future.hpp
+++ b/ledger-core/inc/core/async/Future.hpp
@@ -253,26 +253,6 @@ namespace ledger {
                 });
             };
 
-            void callback(const Context& context, const std::function<void(std::experimental::optional<T>, std::experimental::optional<api::Error>)> & cb) {
-                onComplete(context, [cb] (const Try<T>& result) {
-                    if (result.isSuccess()) {
-                        cb(result.toOption().toOptional(), Option<api::Error>().toOptional());
-                    } else {
-                        cb(Option<T>().toOptional(), Option<api::Error>(result.getFailure().toApiError()).toOptional());
-                    }
-                });
-            };
-
-            void callback(const Context& context, const std::function<void(T, std::experimental::optional<api::Error>)> & cb) {
-                onComplete(context, [cb] (const Try<T>& result) {
-                    if (result.isSuccess()) {
-                        cb(result.getValue(), Option<api::Error>().toOptional());
-                    } else {
-                        cb(nullptr, Option<api::Error>(result.getFailure().toApiError()).toOptional());
-                    }
-                });
-            };
-
             static Future<T> successful(T value) {
                 Promise<T> p;
                 p.success(value);

--- a/ledger-core/inc/core/operation/OperationQuery.hpp
+++ b/ledger-core/inc/core/operation/OperationQuery.hpp
@@ -34,6 +34,7 @@
 #include <type_traits>
 #include <unordered_map>
 
+#include <core/api/OperationListCallback.hpp>
 #include <core/api/OperationQuery.hpp>
 #include <core/api/OperationOrderKey.hpp>
 #include <core/api/enum_from_string.hpp>
@@ -136,7 +137,7 @@ namespace ledger {
                 return this->shared_from_this();
             }
 
-            void execute(const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::Operation>>>, std::experimental::optional<api::Error>)> & callback) override
+            void execute(const std::shared_ptr<api::OperationListCallback> & callback) override
             {
                 execute().callback(_mainContext, callback);
             }

--- a/ledger-core/inc/core/wallet/AbstractAccount.hpp
+++ b/ledger-core/inc/core/wallet/AbstractAccount.hpp
@@ -33,8 +33,12 @@
 
 #include <core/Services.hpp>
 #include <core/api/Account.hpp>
+#include <core/api/AddressListCallback.hpp>
+#include <core/api/AmountCallback.hpp>
+#include <core/api/AmountListCallback.hpp>
 #include <core/api/Address.hpp>
 #include <core/api/Block.hpp>
+#include <core/api/BlockCallback.hpp>
 #include <core/api/TimePeriod.hpp>
 #include <core/async/Future.hpp>
 #include <core/events/EventPublisher.hpp>
@@ -69,19 +73,19 @@ namespace ledger {
             virtual std::shared_ptr<AbstractWallet> getWallet();
             const std::shared_ptr<api::ExecutionContext> getMainExecutionContext() const;
 
-            void getLastBlock(const std::function<void(std::experimental::optional<api::Block>, std::experimental::optional<api::Error>)> & callback) override;
+            void getLastBlock(const std::shared_ptr<api::BlockCallback> & callback) override;
             Future<api::Block> getLastBlock();
 
-            void getBalance(const std::function<void(std::shared_ptr<api::Amount>, std::experimental::optional<api::Error>)> & callback) override;
+            void getBalance(const std::shared_ptr<api::AmountCallback> & callback) override;
             virtual FuturePtr<Amount> getBalance() = 0;
 
-            void getFreshPublicAddresses(const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::Address>>>, std::experimental::optional<api::Error>)> & callback) override;
+            void getFreshPublicAddresses(const std::shared_ptr<api::AddressListCallback> & callback) override;
             virtual Future<AddressList> getFreshPublicAddresses() = 0;
             void getBalanceHistory(
                 const std::string & start,
                 const std::string & end,
                 api::TimePeriod period,
-                const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::Amount>>>, std::experimental::optional<api::Error>)> & callback
+                const std::shared_ptr<api::AmountListCallback> & callback
             ) override;
             virtual Future<std::vector<std::shared_ptr<api::Amount>>> getBalanceHistory(
                 const std::string & start,
@@ -95,7 +99,7 @@ namespace ledger {
 
             void emitEventsNow();
 
-            void eraseDataSince(const std::chrono::system_clock::time_point & date, const std::function<void(std::experimental::optional<api::ErrorCode>, std::experimental::optional<api::Error>)> & callback) override ;
+            void eraseDataSince(const std::chrono::system_clock::time_point & date, const std::shared_ptr<api::ErrorCodeCallback> & callback) override ;
             virtual Future<api::ErrorCode> eraseDataSince(const std::chrono::system_clock::time_point & date) = 0;
 
         protected:

--- a/ledger-core/inc/core/wallet/AbstractWallet.hpp
+++ b/ledger-core/inc/core/wallet/AbstractWallet.hpp
@@ -33,11 +33,18 @@
 
 #include <core/Services.hpp>
 #include <core/api/Account.hpp>
+#include <core/api/AccountCallback.hpp>
+#include <core/api/AccountListCallback.hpp>
 #include <core/api/AccountCreationInfo.hpp>
+#include <core/api/AccountCreationInfoCallback.hpp>
 #include <core/api/Block.hpp>
+#include <core/api/BlockCallback.hpp>
 #include <core/api/Currency.hpp>
 #include <core/api/DynamicObject.hpp>
+#include <core/api/ErrorCodeCallback.hpp>
 #include <core/api/ExtendedKeyAccountCreationInfo.hpp>
+#include <core/api/ExtendedKeyAccountCreationInfoCallback.hpp>
+#include <core/api/I32Callback.hpp>
 #include <core/api/Wallet.hpp>
 #include <core/async/DedicatedContext.hpp>
 #include <core/collections/DynamicObject.hpp>
@@ -78,60 +85,60 @@ namespace ledger {
             /// Ripple.
             virtual bool hasMultipleAddresses() const = 0;
 
-            void getNextAccountIndex(const std::function<void(std::experimental::optional<int32_t>, std::experimental::optional<api::Error>)> & callback) override;
+            void getNextAccountIndex(const std::shared_ptr<api::I32Callback> & callback) override;
             Future<int32_t> getNextAccountIndex();
 
             Future<int32_t> getAccountCount();
-            void getAccountCount(const std::function<void(std::experimental::optional<int32_t>, std::experimental::optional<api::Error>)> & callback) override;
+            void getAccountCount(const std::shared_ptr<api::I32Callback> & callback) override;
 
-            void getLastBlock(const std::function<void(std::experimental::optional<api::Block>, std::experimental::optional<api::Error>)> & callback) override;
+            void getLastBlock(const std::shared_ptr<api::BlockCallback> & callback) override;
             Future<api::Block> getLastBlock();
 
             void getAccount(
                 int32_t index,
-                const std::function<void(std::shared_ptr<api::Account>, std::experimental::optional<api::Error>)> & callback
+                const std::shared_ptr<api::AccountCallback> & callback
             ) override;
             FuturePtr<api::Account> getAccount(int32_t index);
 
             void getAccounts(
                 int32_t offset,
                 int32_t count,
-                const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::Account>>>, std::experimental::optional<api::Error>)> & callback
+                const std::shared_ptr<api::AccountListCallback> & callback
             ) override;
             Future<std::vector<std::shared_ptr<api::Account>>> getAccounts(int32_t offset, int32_t count);
 
             void getNextAccountCreationInfo(
-                const std::function<void(std::experimental::optional<api::AccountCreationInfo>, std::experimental::optional<api::Error>)> & callback
+                const std::shared_ptr<api::AccountCreationInfoCallback> & callback
             ) override;
 
             void getNextExtendedKeyAccountCreationInfo(
-                const std::function<void(std::experimental::optional<api::ExtendedKeyAccountCreationInfo>, std::experimental::optional<api::Error>)> & callback
+                const std::shared_ptr<api::ExtendedKeyAccountCreationInfoCallback> & callback
             ) override;
 
             void getAccountCreationInfo(
                 int32_t accountIndex,
-                const std::function<void(std::experimental::optional<api::AccountCreationInfo>, std::experimental::optional<api::Error>)> & callback
+                const std::shared_ptr<api::AccountCreationInfoCallback> & callback
             ) override;
 
             void getExtendedKeyAccountCreationInfo(
                 int32_t accountIndex,
-                const std::function<void(std::experimental::optional<api::ExtendedKeyAccountCreationInfo>, std::experimental::optional<api::Error>)> & callback
+                const std::shared_ptr<api::ExtendedKeyAccountCreationInfoCallback> & callback
             ) override;
 
             void newAccountWithInfo(
                 const api::AccountCreationInfo & accountCreationInfo,
-                const std::function<void(std::shared_ptr<api::Account>, std::experimental::optional<api::Error>)> & callback
+                const std::shared_ptr<api::AccountCallback> & callback
             ) override;
 
             void newAccountWithExtendedKeyInfo(
                 const api::ExtendedKeyAccountCreationInfo & extendedKeyAccountCreationInfo,
-                const std::function<void(std::shared_ptr<api::Account>, std::experimental::optional<api::Error>)> & callback
+                const std::shared_ptr<api::AccountCallback> & callback
             ) override;
 
             void eraseDataSince(
                 const std::chrono::system_clock::time_point & date,
-                const std::function<void(std::experimental::optional<api::ErrorCode>, std::experimental::optional<api::Error>)> & callback
-            ) override ;
+                const std::shared_ptr<api::ErrorCodeCallback> & callback
+            ) override;
             Future<api::ErrorCode> eraseDataSince(const std::chrono::system_clock::time_point & date);
 
             std::shared_ptr<api::DynamicObject> getConfiguration() override;

--- a/ledger-core/src/core/wallet/AbstractAccount.cpp
+++ b/ledger-core/src/core/wallet/AbstractAccount.cpp
@@ -121,11 +121,11 @@ namespace ledger {
             return _externalPreferences;
         }
 
-        void AbstractAccount::getFreshPublicAddresses(const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::Address>>>, std::experimental::optional<api::Error>)> & callback) {
+        void AbstractAccount::getFreshPublicAddresses(const std::shared_ptr<api::AddressListCallback> & callback) {
             getFreshPublicAddresses().callback(getMainExecutionContext(), callback);
         }
 
-        void AbstractAccount::getBalance(const std::function<void(std::shared_ptr<api::Amount>, std::experimental::optional<api::Error>)> & callback) {
+        void AbstractAccount::getBalance(const std::shared_ptr<api::AmountCallback> & callback) {
             getBalance().callback(getMainExecutionContext(), callback);
         }
 
@@ -133,7 +133,7 @@ namespace ledger {
             const std::string & start,
             const std::string & end,
             api::TimePeriod period,
-            const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::Amount>>>, std::experimental::optional<api::Error>)> & callback
+            const std::shared_ptr<api::AmountListCallback> & callback
         ) {
             getBalanceHistory(start, end, period).callback(getMainExecutionContext(), callback);
         }
@@ -186,11 +186,11 @@ namespace ledger {
             return getWallet()->getLastBlock();
         }
 
-        void AbstractAccount::getLastBlock(const std::function<void(std::experimental::optional<api::Block>, std::experimental::optional<api::Error>)> & callback) {
+        void AbstractAccount::getLastBlock(const std::shared_ptr<api::BlockCallback> & callback) {
             getLastBlock().callback(getMainExecutionContext(), callback);
         }
 
-        void AbstractAccount::eraseDataSince(const std::chrono::system_clock::time_point & date, const std::function<void(std::experimental::optional<api::ErrorCode>, std::experimental::optional<api::Error>)> & callback) {
+        void AbstractAccount::eraseDataSince(const std::chrono::system_clock::time_point & date, const std::shared_ptr<api::ErrorCodeCallback> & callback) {
             eraseDataSince(date).callback(getMainExecutionContext(), callback);
         }
     }

--- a/ledger-core/src/core/wallet/AbstractWallet.cpp
+++ b/ledger-core/src/core/wallet/AbstractWallet.cpp
@@ -149,7 +149,7 @@ namespace ledger {
         }
 
         void AbstractWallet::getNextAccountIndex(
-            const std::function<void(std::experimental::optional<int32_t>, std::experimental::optional<api::Error>)> & callback
+            const std::shared_ptr<api::I32Callback> & callback
         ) {
             getNextAccountIndex().callback(getMainExecutionContext(), callback);
         }
@@ -178,20 +178,18 @@ namespace ledger {
             });
         }
 
-        void AbstractWallet::getAccountCount(
-            const std::function<void(std::experimental::optional<int32_t>, std::experimental::optional<api::Error>)> & callback
-        ) {
+        void AbstractWallet::getAccountCount(const std::shared_ptr<api::I32Callback> & callback) {
             getAccountCount().callback(getMainExecutionContext(), callback);
         }
 
         void AbstractWallet::getNextAccountCreationInfo(
-            const std::function<void(std::experimental::optional<api::AccountCreationInfo>, std::experimental::optional<api::Error>)> & callback
+            const std::shared_ptr<api::AccountCreationInfoCallback> & callback
         ) {
             this->getNextAccountCreationInfo().callback(getMainExecutionContext(), callback);
         }
 
         void AbstractWallet::getNextExtendedKeyAccountCreationInfo(
-            const std::function<void(std::experimental::optional<api::ExtendedKeyAccountCreationInfo>, std::experimental::optional<api::Error>)> & callback
+            const std::shared_ptr<api::ExtendedKeyAccountCreationInfoCallback> & callback
         ) {
             this->getNextExtendedKeyAccountCreationInfo().callback(getMainExecutionContext(), callback);
         }
@@ -214,36 +212,37 @@ namespace ledger {
             );
         }
 
-        void AbstractWallet::getAccountCreationInfo(int32_t accountIndex,
-            const std::function<void(std::experimental::optional<api::AccountCreationInfo>, std::experimental::optional<api::Error>)> & callback
+        void AbstractWallet::getAccountCreationInfo(
+            int32_t accountIndex,
+            const std::shared_ptr<api::AccountCreationInfoCallback> & callback
         ) {
             getAccountCreationInfo(accountIndex).callback(getMainExecutionContext(), callback);
         }
 
         void AbstractWallet::getExtendedKeyAccountCreationInfo(
             int32_t accountIndex,
-            const std::function<void(std::experimental::optional<api::ExtendedKeyAccountCreationInfo>, std::experimental::optional<api::Error>)> & callback
+            const std::shared_ptr<api::ExtendedKeyAccountCreationInfoCallback> & callback
         ) {
             getExtendedKeyAccountCreationInfo(accountIndex).callback(getMainExecutionContext(), callback);
         }
 
         void AbstractWallet::newAccountWithInfo(
             const api::AccountCreationInfo & accountCreationInfo,
-            const std::function<void(std::shared_ptr<api::Account>, std::experimental::optional<api::Error>)> & callback
+            const std::shared_ptr<api::AccountCallback> & callback
         ) {
             newAccountWithInfo(accountCreationInfo).callback(getMainExecutionContext(), callback);
         }
 
         void AbstractWallet::newAccountWithExtendedKeyInfo(
             const api::ExtendedKeyAccountCreationInfo & extendedKeyAccountCreationInfo,
-            const std::function<void(std::shared_ptr<api::Account>, std::experimental::optional<api::Error>)> & callback
+            const std::shared_ptr<api::AccountCallback> & callback
         ) {
             newAccountWithExtendedKeyInfo(extendedKeyAccountCreationInfo).callback(getMainExecutionContext(), callback);
         }
 
         void AbstractWallet::getAccount(
             int32_t index,
-            const std::function<void(std::shared_ptr<api::Account>, std::experimental::optional<api::Error>)> & callback
+            const std::shared_ptr<api::AccountCallback> & callback
         ) {
             getAccount(index).callback(getMainExecutionContext(), callback);
         }
@@ -275,7 +274,7 @@ namespace ledger {
         void AbstractWallet::getAccounts(
             int32_t offset,
             int32_t count,
-            const std::function<void(std::experimental::optional<std::vector<std::shared_ptr<api::Account>>>, std::experimental::optional<api::Error>)> & callback
+            const std::shared_ptr<api::AccountListCallback> & callback
         ) {
             getAccounts(offset, count).callback(getMainExecutionContext(), callback);
         }
@@ -311,14 +310,14 @@ namespace ledger {
         }
 
         void AbstractWallet::getLastBlock(
-            const std::function<void(std::experimental::optional<api::Block>, std::experimental::optional<api::Error>)> & callback
+            const std::shared_ptr<api::BlockCallback> & callback
         ) {
             getLastBlock().callback(getMainExecutionContext(), callback);
         }
 
         void AbstractWallet::eraseDataSince(
             const std::chrono::system_clock::time_point & date,
-            const std::function<void(std::experimental::optional<api::ErrorCode>, std::experimental::optional<api::Error>)> & callback
+            const std::shared_ptr<api::ErrorCodeCallback> & callback
         ) {
             eraseDataSince(date).callback(getMainExecutionContext(), callback);
         }

--- a/tools/idl_interfaces.sh
+++ b/tools/idl_interfaces.sh
@@ -59,7 +59,7 @@ function generate_subcore_interface {
     # This option will be the name of the imported header and the correponding variable (defined
     # by EXPORT_MACRO_NAME option) should be exactly same name in upper case
 
-    ./djinni/src/run \
+    ../djinni/src/run \
         --idl $SUBCORE_DIR/idl/idl.djinni \
         --cpp-out $SUBCORE_API_DIR \
         --cpp-namespace ledger::core::api \

--- a/tools/idl_interfaces.sh
+++ b/tools/idl_interfaces.sh
@@ -24,7 +24,7 @@ function generate_core_interface {
     rm -rf $CORE_API_DIR
     mkdir -p $CORE_API_DIR
 
-    ../djinni/src/run \
+    ./djinni/src/run \
         --idl $CORE_IDL_DIR/core.djinni \
         --cpp-out $CORE_API_DIR \
         --cpp-namespace ledger::core::api \
@@ -59,7 +59,7 @@ function generate_subcore_interface {
     # This option will be the name of the imported header and the correponding variable (defined
     # by EXPORT_MACRO_NAME option) should be exactly same name in upper case
 
-    ../djinni/src/run \
+    ./djinni/src/run \
         --idl $SUBCORE_DIR/idl/idl.djinni \
         --cpp-out $SUBCORE_API_DIR \
         --cpp-namespace ledger::core::api \

--- a/tools/idl_interfaces.sh
+++ b/tools/idl_interfaces.sh
@@ -24,7 +24,7 @@ function generate_core_interface {
     rm -rf $CORE_API_DIR
     mkdir -p $CORE_API_DIR
 
-    ./djinni/src/run \
+    ../djinni/src/run \
         --idl $CORE_IDL_DIR/core.djinni \
         --cpp-out $CORE_API_DIR \
         --cpp-namespace ledger::core::api \
@@ -32,7 +32,7 @@ function generate_core_interface {
         --cpp-optional-header "<core/utils/Optional.hpp>" \
         --export-header-name libcore_export \
         --jni-include-cpp-prefix "../../api/" \
-        --jni-out $CORE_CPP_JNI_DIRECTORY/jni \
+        --jni-out $CORE_CPP_JNI_DIR \
         --java-out api/core/java \
         --java-package co.ledger.core \
         --yaml-out $CORE_IDL_DIR \

--- a/tools/idl_interfaces.sh
+++ b/tools/idl_interfaces.sh
@@ -16,6 +16,7 @@ function generate_core_interface {
     CORE_DIR=$1 # Ledger Core library directory
     CORE_IDL_DIR=$CORE_DIR/idl
     CORE_API_DIR=$CORE_DIR/inc/core/api
+    CORE_CPP_JNI_DIR=$CORE_DIR/inc/core/jni
 
     echo -e "Generating ledger-core API"
 
@@ -30,6 +31,10 @@ function generate_core_interface {
         --cpp-optional-template std::experimental::optional \
         --cpp-optional-header "<core/utils/Optional.hpp>" \
         --export-header-name libcore_export \
+        --jni-include-cpp-prefix "../../api/" \
+        --jni-out $CORE_CPP_JNI_DIRECTORY/jni \
+        --java-out api/core/java \
+        --java-package co.ledger.core \
         --yaml-out $CORE_IDL_DIR \
         --yaml-out-file core.yaml \
         --trace $trace

--- a/tools/lc
+++ b/tools/lc
@@ -44,6 +44,7 @@ cmd_project_new() {
 
   echo "—> generating IDL entry point"
   cp ./tools/templates/idl.djinni $project_name/idl/
+  cp ./tools/templates/callback.djinni $project_name/idl/
 
   echo "—> creating migrations files"
   sed s/\$project_name/$capitalized_coin_name/g ./tools/templates/Migrations.hpp > $project_name/inc/$coin_name/database/Migrations.hpp

--- a/tools/templates/callback.djinni
+++ b/tools/templates/callback.djinni
@@ -1,0 +1,17 @@
+@extern "../../ledger-core/idl/core.yaml"
+
+# Callback triggered by main completed task, returning optional result as list of template type T.
+ListCallback = interface[T] +j +o +s +n {
+    # Method triggered when main task complete.
+    # @params result optional of type list<T>, non null if main task failed
+    # @params error optional of type Error, non null if main task succeeded
+    onCallback(result: optional<list<T>>, error: optional<Error>);
+}
+
+# Callback triggered by main completed task, returning optional result of template type T.
+Callback = interface[T] +j +o +s +n {
+    # Method triggered when main task complete.
+    # @params result optional of type T, non null if main task failed
+    # @params error optional of type Error, non null if main task succeeded
+    onCallback(result: optional<T>, error: optional<Error>);
+}

--- a/tools/templates/idl.djinni
+++ b/tools/templates/idl.djinni
@@ -1,4 +1,11 @@
+# Do not remove this line; it brings in everything from the ledger-core interface
 @extern "../../ledger-core/idl/core.yaml"
+# This line is important only if you plan to use the callback2 type in your IDL; it’s currently a
+# bit tricky and relates to LLC-532; every time you use the callback2 type, it will get erased and
+# replaced by either a specialization of Callback or ListCallback. For instance,
+# callback2<void, optional<Foo>, optional<Error>> will first be replaced by Callback<Foo> and in a
+# second and final phase, to FooCallback (FooCallback interface will be generated too).
+@import "callback.djinni"
 
 # Your interface goes here. You can create additional .djinni files in the idl/ directory and import
 # them here with the @import "<foo.djinni>" syntax. Don’t forget to add an @import line to expose


### PR DESCRIPTION
# Content

This PR allows to bind the `design/modularization` projects to JNI, JS, React Native, etc, by adapting the interfaces to support the `callback2` changes from `djinni` in https://github.com/LedgerHQ/djinni/pull/43.

# Mandatory picture of the best animal on Earth (and the cosmos)

![](https://phaazon.net/media/uploads/moon_rover.gif)