### PR TITLE
Add SSL_SUPPORT configuration to build Core library with SSL support.

### DIFF
--- a/.circleci/build_lib.sh
+++ b/.circleci/build_lib.sh
@@ -16,7 +16,7 @@ export PATH=$PATH:~/cmake_folder/bin
 ###
 
 function command_target_jni {
-  add_to_cmake_params -DTARGET_JNI=ON -DPG_SUPPORT=ON -DPostgreSQL_INCLUDE_DIR=/usr/include/postgresql
+  add_to_cmake_params -DTARGET_JNI=ON -DPG_SUPPORT=ON -DPostgreSQL_INCLUDE_DIR=/usr/include/postgresql -DSSL_SUPPORT=ON #ACTIVATIN SSL ONLY WHEN USING PG FOR WD
 }
 
 function command_Release {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,11 @@ if (PG_SUPPORT)
     add_definitions("-DPG_SUPPORT")
 endif()
 
+# To add SSL support
+if (SSL_SUPPORT)
+    add_definitions("-DSSL_SUPPORT")
+endif()
+
 string(FIND "${CMAKE_OSX_SYSROOT}" "iphone" IS_IOS)
 if(IS_IOS GREATER_EQUAL 0 OR TARGET_JNI OR ANDROID)
     set(BUILD_TESTING OFF CACHE BOOL "iOS build fail otherwise" FORCE)

--- a/core/lib/openssl/CMakeLists.txt
+++ b/core/lib/openssl/CMakeLists.txt
@@ -43,8 +43,8 @@ if( MINGW OR MSVC)
 endif()
 
 add_subdirectory( crypto )
-if(BUILD_TESTS)
-  add_subdirectory( ssl )#needed for tests
+if(SSL_SUPPORT)
+  add_subdirectory( ssl )#needed for tests & PostgreSQL with SSL support
 endif()
 # add_subdirectory( apps )
 

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -174,6 +174,11 @@ else()
     target_include_directories(ledger-core-interface INTERFACE ../lib/openssl/include)
     target_include_directories(ledger-core-interface INTERFACE ../lib/openssl/crypto/blake)
 endif()
+
+if(SSL_SUPPORT)
+    target_link_libraries(ledger-core-interface INTERFACE ssl)
+endif()
+
 target_include_directories(ledger-core-interface INTERFACE ../lib/leveldb/include)
 target_include_directories(ledger-core-interface INTERFACE ../lib/boost)
 target_include_directories(ledger-core-interface INTERFACE ../lib/cereal/)

--- a/core/src/database/PostgreSQLBackend.cpp
+++ b/core/src/database/PostgreSQLBackend.cpp
@@ -34,6 +34,7 @@
 #include <soci-postgresql.h>
 
 #ifdef SSL_SUPPORT
+    #include <thread>
     #include <openssl/ssl.h>
 #endif
 
@@ -80,13 +81,16 @@ namespace ledger {
             throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "Change of password is not handled with PostgreSQL backend.");
         }
 
+        std::once_flag PostgreSQLBackend::sslFlag;
         void PostgreSQLBackend::initSSLLibraries() {
 #ifdef SSL_SUPPORT
-    #if OPENSSL_VERSION_NUMBER < 0x10100000L
-            SSL_library_init();
-    #else
-            OPENSSL_init_ssl(0, NULL);
-    #endif
+            std::call_once(PostgreSQLBackend::sslFlag, [] () {
+            #if OPENSSL_VERSION_NUMBER < 0x10100000L
+                SSL_library_init();
+            #else
+                OPENSSL_init_ssl(0, NULL);
+            #endif
+            });
 #endif
         }
     }

--- a/core/src/database/PostgreSQLBackend.cpp
+++ b/core/src/database/PostgreSQLBackend.cpp
@@ -32,17 +32,26 @@
 #include <utils/Exception.hpp>
 #include <api/ConfigurationDefaults.hpp>
 #include <soci-postgresql.h>
+
+#ifdef SSL_SUPPORT
+    #include <openssl/ssl.h>
+#endif
+
 using namespace soci;
 
 namespace ledger {
     namespace core {
         PostgreSQLBackend::PostgreSQLBackend() : DatabaseBackend(),
                                                  _connectionPoolSize(api::ConfigurationDefaults::DEFAULT_PG_CONNECTION_POOL_SIZE)
-        {}
+        {
+            initSSLLibraries();
+        }
 
         PostgreSQLBackend::PostgreSQLBackend(int32_t connectionPoolSize) : DatabaseBackend(),
                                                                            _connectionPoolSize(connectionPoolSize)
-        {}
+        {
+            initSSLLibraries();
+        }
 
         int32_t PostgreSQLBackend::getConnectionPoolSize() {
             return _connectionPoolSize;
@@ -69,6 +78,16 @@ namespace ledger {
                                             const std::string & newPassword,
                                             soci::session &session) {
             throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "Change of password is not handled with PostgreSQL backend.");
+        }
+
+        void PostgreSQLBackend::initSSLLibraries() {
+#ifdef SSL_SUPPORT
+    #if OPENSSL_VERSION_NUMBER < 0x10100000L
+            SSL_library_init();
+    #else
+            OPENSSL_init_ssl(0, NULL);
+    #endif
+#endif
         }
     }
 }

--- a/core/src/database/PostgreSQLBackend.h
+++ b/core/src/database/PostgreSQLBackend.h
@@ -32,7 +32,7 @@
 
 #include "DatabaseBackend.hpp"
 #include <memory>
-
+#include <mutex>
 namespace ledger {
     namespace core {
         class PostgreSQLBackend : public DatabaseBackend {
@@ -53,7 +53,7 @@ namespace ledger {
             void changePassword(const std::string & oldPassword,
                                 const std::string & newPassword,
                                 soci::session &session) override;
-
+            static std::once_flag sslFlag;
             static void initSSLLibraries();
         private:
             // Resolved path to db

--- a/core/src/database/PostgreSQLBackend.h
+++ b/core/src/database/PostgreSQLBackend.h
@@ -54,6 +54,7 @@ namespace ledger {
                                 const std::string & newPassword,
                                 soci::session &session) override;
 
+            static void initSSLLibraries();
         private:
             // Resolved path to db
             std::string _dbName;


### PR DESCRIPTION
This relates to : https://ledgerhq.atlassian.net/browse/INFRA-1572.

Before we didn't need SSL support because we were using only Crypto libraries on OpenSSL.
Eventually we were using SSL for tests because we were implementing our own Http client with SSL support.
We didn't face that issue before with any client because Http clients are provided by the host of the Core library.

We are not only building with support of SSL but in this commit we initialize of course the SSL libraries when using PG backend.