### PR TITLE
Make fixes and changes to prepare the new WD release

### DIFF
--- a/core/src/database/migrations.hpp
+++ b/core/src/database/migrations.hpp
@@ -39,6 +39,9 @@
 
 namespace ledger {
     namespace core {
+        /// Maximum length of stored VARCHAR
+        static const int MAX_LENGTH_VAR_CHAR = 255;
+
         /// Get the current database migration version.
         int getDatabaseMigrationVersion(soci::session& sql);
 

--- a/core/src/wallet/common/synchronizers/AbstractBlockchainExplorerAccountSynchronizer.h
+++ b/core/src/wallet/common/synchronizers/AbstractBlockchainExplorerAccountSynchronizer.h
@@ -244,6 +244,8 @@ namespace ledger {
                         buddy->logger->warn("Failed to delete synchronization token {} for account#{} of wallet {}",
                                             static_cast<char *>(buddy->token.getValue()), buddy->account->getIndex(),
                                             buddy->account->getWallet()->getName());
+                        // We return a successful Unit because deleting the sync token should not be a "failure"
+                        // Note: in a near future we'll try to get rid of sync token mechanism
                         return Future<Unit>::successful(unit);
                     }
                     return tryKillSession.getValue();

--- a/core/src/wallet/ethereum/explorers/api/EthereumLikeTransactionParser.cpp
+++ b/core/src/wallet/ethereum/explorers/api/EthereumLikeTransactionParser.cpp
@@ -217,12 +217,12 @@ namespace ledger {
                     std::istringstream issNonce(value);
                     issNonce >> _transaction->nonce;
                 } else if (_lastKey == "input") {
-                    auto inputData = fromStringToBytes(value);
+                    const auto inputData = fromStringToBytes(value);
                     if (inputData.size() <= ledger::core::MAX_LENGTH_VAR_CHAR) {
                         if (isInternalTx) {
-                            _transaction->internalTransactions.back().inputData = inputData;
+                            _transaction->internalTransactions.back().inputData = std::move(inputData);
                         } else {
-                            _transaction->inputData = inputData;
+                            _transaction->inputData = std::move(inputData);
                         }
                     }
                 } else if (_lastKey == "contract" && !_transaction->erc20Transactions.empty()) {

--- a/core/src/wallet/ethereum/explorers/api/EthereumLikeTransactionParser.cpp
+++ b/core/src/wallet/ethereum/explorers/api/EthereumLikeTransactionParser.cpp
@@ -31,6 +31,7 @@
 #include "EthereumLikeTransactionParser.hpp"
 #include "utils/DateUtils.hpp"
 #include <math/Base58.hpp>
+#include <database/migrations.hpp>
 
 #define PROXY_PARSE(method, ...)                                    \
  auto& currentObject = _hierarchy.top();                            \
@@ -216,10 +217,13 @@ namespace ledger {
                     std::istringstream issNonce(value);
                     issNonce >> _transaction->nonce;
                 } else if (_lastKey == "input") {
-                    if (isInternalTx) {
-                        _transaction->internalTransactions.back().inputData = fromStringToBytes(value);
-                    } else {
-                        _transaction->inputData = fromStringToBytes(value);
+                    auto inputData = fromStringToBytes(value);
+                    if (inputData.size() <= ledger::core::MAX_LENGTH_VAR_CHAR) {
+                        if (isInternalTx) {
+                            _transaction->internalTransactions.back().inputData = inputData;
+                        } else {
+                            _transaction->inputData = inputData;
+                        }
                     }
                 } else if (_lastKey == "contract" && !_transaction->erc20Transactions.empty()) {
                     _transaction->erc20Transactions.back().contractAddress = value;


### PR DESCRIPTION
**Fix:** now that we are using a "real" database :trollface: we could notice some issues that we were not taking care of on DB side, as an example the input data is a `VARCHAR(255)` which is not always the case : https://explorers.api.live.ledger.com/blockchain/v3/eth/transactions/0xd1811f0c7b1dcb11bc9b28a3be194ec3d1bb273318d23e5353ee65ad6754a8e0
So now we check that and if not we drop input data. This information is used only to display details about transactions, so if an end user wants these details about their tx they have links to official explorers in the app to do so.

**Resilience:**
- Sync token deletion: issues raised by Live & Vault about failing to drop this token, now we wrap that deletion in a `Try` and if we fail to drop it we display a warning.
- `UNIQUE_CONSTRAINT` failure on `bitcoin_inputs`:issues raised by Live & Vault about failing sync when we have some issues with explorers, now we wrap the `putTransaction` in a `Try` to handle better failures caused by this DB update, as a consequence, he will miss some txs on his history and worst case his balance won't be updated but he will still be able to make transactions with previous state.
- Sync failure displaying a `Reorganization` error message: even if we have test covering that use case it seems that still some situations are not well handled. To avoid that we don't throw when `recoverWith` is not working, we allow to continue synchronization. This plus the above changes should not impact the clients (cf other impacts of above changes).