### PR TITLE
Add XTZ account test

### DIFF
--- a/ledger-core-tezos/test/AccountTests.cpp
+++ b/ledger-core-tezos/test/AccountTests.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+
+#include <tezos/TezosLikeWallet.hpp>
+#include <tezos/TezosLikeCurrencies.hpp>
+#include <tezos/factories/TezosLikeWalletFactory.hpp>
+
+#include <integration/WalletFixture.hpp>
+
+struct TezosAccounts : public WalletFixture<TezosLikeWalletFactory> {
+
+};
+
+TEST_F(TezosAccounts, FirstXTZAccountInfo) {
+    auto const currency = currencies::tezos();
+
+    registerCurrency(currency);
+
+    auto wallet = wait(walletStore->createWallet("my_wallet", currency.name, api::DynamicObject::newInstance()));
+    auto info = wait(wallet->getNextAccountCreationInfo());
+
+    EXPECT_EQ(info.index, 0);
+    EXPECT_EQ(info.owners.size(), 1);
+    EXPECT_EQ(info.derivations.size(), 1);
+    EXPECT_EQ(info.owners[0], "main");
+    // TODO: XTZ is account-based; the expected derivation is completely
+    // questionable. 
+    // EXPECT_EQ(info.derivations[0], "44'/1729'/0'/0/0");
+}

--- a/ledger-core-tezos/test/AccountTests.cpp
+++ b/ledger-core-tezos/test/AccountTests.cpp
@@ -23,6 +23,7 @@ TEST_F(TezosAccounts, FirstXTZAccountInfo) {
     EXPECT_EQ(info.derivations.size(), 1);
     EXPECT_EQ(info.owners[0], "main");
     // TODO: XTZ is account-based; the expected derivation is completely
-    // questionable. 
-    // EXPECT_EQ(info.derivations[0], "44'/1729'/0'/0/0");
+    // questionable. However we check the derivation starts with "44'/1729'"
+    // as BIP44 suggests 
+    EXPECT_EQ(info.derivations[0].find("44'/1729'"), 0);
 }

--- a/ledger-core-tezos/test/CMakeLists.txt
+++ b/ledger-core-tezos/test/CMakeLists.txt
@@ -12,6 +12,7 @@ endif (APPLE)
 add_executable(
     ledger-core-tezos-tests main.cpp
     AddressTest.cpp Fixtures.cpp TransactionTests.cpp SynchronizationTests.cpp
+    AccountTests.cpp
 )
 
 target_link_libraries(ledger-core-tezos-tests Core::ledger-core-static)
@@ -28,3 +29,4 @@ add_subdirectory(lib/googletest)
 add_test (NAME Tezos-address COMMAND ledger-core-tezos-tests --gtest_filter=TezosAddress.*)
 add_test (NAME Tezos-transaction COMMAND ledger-core-tezos-tests --gtest_filter=TezosMakeTransaction.*)
 add_test (NAME Tezos-sync COMMAND ledger-core-tezos-tests --gtest_filter=TezosLikeWalletSynchronization.*)
+add_test (NAME Tezos-account COMMAND ledger-core-tezos-tests --gtest_filter=TezosAccounts.*)


### PR DESCRIPTION
As the previous PR all you have to know is in the title.

BTW, we have a long-rude discussion about the final test (e.g `info.derivation[0] == "44'/1729'/0/0/0"`) and decide to comment it. The comment just above the test explains why.

## Mandatory picture of a cat
![dancing_cat](https://user-images.githubusercontent.com/6042495/74354579-dff7bf00-4dbb-11ea-8e20-fd79517cf03f.gif)
