### PR TITLE
Add support for ordered migration rollbacks.

### DIFF
--- a/core/test/common/balance_history.cpp
+++ b/core/test/common/balance_history.cpp
@@ -193,7 +193,7 @@ TEST(BalanceHistory, CorrectBalancesPerDay2) {
     }
 
     for (auto i = 3; i < 18; ++i) {
-        EXPECT_EQ(*balances[4], 22);
+        EXPECT_EQ(*balances[i], 22);
     }
 
     for (auto i = 18; i < 21; ++i) {

--- a/ledger-core/inc/core/database/DatabaseSessionPool.hpp
+++ b/ledger-core/inc/core/database/DatabaseSessionPool.hpp
@@ -87,21 +87,6 @@ namespace ledger {
                 tr.commit();
             }
 
-            /// Run migration forward for the ledger-core library.
-            ///
-            /// This is a special case because we don’t want to register ourselves for rollback,
-            /// since we will call that function explicitly.
-            template <>
-            void forwardMigration<CoreMigration>() {
-                soci::session sql(getPool());
-                uint32_t const version = getDatabaseMigrationVersion<CoreMigration>(sql);
-
-                soci::transaction tr(sql);
-                Migration<CoreMigration::CURRENT_VERSION, CoreMigration>::forward(sql, version);
-
-                tr.commit();
-            }
-
             /// Rollback all migrations for a given migration system.
             void rollbackMigrations() {
                 soci::session sql(getPool());
@@ -134,5 +119,20 @@ namespace ledger {
             // the database
             std::vector<std::function<void (soci::session& sql)>> _rollbackMigrations;
         };
+
+        /// Run migration forward for the ledger-core library.
+        ///
+        /// This is a special case because we don’t want to register ourselves for rollback,
+        /// since we will call that function explicitly.
+        template <>
+        void DatabaseSessionPool::forwardMigration<CoreMigration>() {
+          soci::session sql(getPool());
+          uint32_t const version = getDatabaseMigrationVersion<CoreMigration>(sql);
+
+          soci::transaction tr(sql);
+          Migration<CoreMigration::CURRENT_VERSION, CoreMigration>::forward(sql, version);
+
+          tr.commit();
+        }
     }
 }

--- a/ledger-core/inc/core/database/DatabaseSessionPool.hpp
+++ b/ledger-core/inc/core/database/DatabaseSessionPool.hpp
@@ -107,13 +107,13 @@ namespace ledger {
                 soci::session sql(getPool());
 
                 // rollback coins first
-                for (auto rollbackCoinMigration : _rollbackMigrations) {
+                for (auto& rollbackCoinMigration : _rollbackMigrations) {
                     rollbackCoinMigration(sql);
                 }
 
                 _rollbackMigrations.clear();
 
-                int version = getDatabaseMigrationVersion<CoreMigration>(sql);
+                int const version = getDatabaseMigrationVersion<CoreMigration>(sql);
 
                 soci::transaction tr(sql);
                 Migration<CoreMigration::CURRENT_VERSION, CoreMigration>::backward(sql, version);

--- a/ledger-core/inc/core/database/DatabaseSessionPool.hpp
+++ b/ledger-core/inc/core/database/DatabaseSessionPool.hpp
@@ -70,14 +70,14 @@ namespace ledger {
             template <typename T>
             void forwardMigration() {
                 soci::session sql(getPool());
-                int version = getDatabaseMigrationVersion<T>(sql);
+                uint32_t const version = getDatabaseMigrationVersion<T>(sql);
 
                 soci::transaction tr(sql);
                 Migration<T::CURRENT_VERSION, T>::forward(sql, version);
 
                 // register rollback migration
                 _rollbackMigrations.emplace_back([](soci::session& sql) {
-                    int version = getDatabaseMigrationVersion<T>(sql);
+                    uint32_t const version = getDatabaseMigrationVersion<T>(sql);
 
                     soci::transaction tr(sql);
                     Migration<T::CURRENT_VERSION, T>::backward(sql, version);
@@ -94,7 +94,7 @@ namespace ledger {
             template <>
             void forwardMigration<CoreMigration>() {
                 soci::session sql(getPool());
-                int version = getDatabaseMigrationVersion<CoreMigration>(sql);
+                uint32_t const version = getDatabaseMigrationVersion<CoreMigration>(sql);
 
                 soci::transaction tr(sql);
                 Migration<CoreMigration::CURRENT_VERSION, CoreMigration>::forward(sql, version);
@@ -113,7 +113,7 @@ namespace ledger {
 
                 _rollbackMigrations.clear();
 
-                int const version = getDatabaseMigrationVersion<CoreMigration>(sql);
+                uint32_t const version = getDatabaseMigrationVersion<CoreMigration>(sql);
 
                 soci::transaction tr(sql);
                 Migration<CoreMigration::CURRENT_VERSION, CoreMigration>::backward(sql, version);

--- a/ledger-core/inc/core/database/Migrations.hpp
+++ b/ledger-core/inc/core/database/Migrations.hpp
@@ -104,10 +104,10 @@ namespace ledger {
 
                   if (currentVersion > 0) {
                       // if the migration number is greater than 0, we just perform the regular migration
-                      auto prevVersion = version - 1;
+                      auto constexpr prevVersion = version - 1;
                       sql << "UPDATE __database_meta__ SET version = :version WHERE id = :id", soci::use(prevVersion), soci::use(T::COIN_ID);
 
-                      Migration<version - 1, T>::backward(sql, currentVersion - 1);
+                      Migration<prevVersion, T>::backward(sql, currentVersion - 1);
                   } else if (currentVersion == 0) {
                       // here we want to remove the coin from the metadata table
                       sql << "DELETE FROM __database_meta__ WHERE id = :id", soci::use(T::COIN_ID);

--- a/ledger-core/inc/core/database/Migrations.hpp
+++ b/ledger-core/inc/core/database/Migrations.hpp
@@ -91,7 +91,7 @@ namespace ledger {
                           "VALUES (:id, 1)",
                           soci::use(T::COIN_ID);
                   } else {
-                      sql << "UPDATE __database_meta__ SET version = :version where id = :id", soci::use(version), soci::use(T::COIN_ID);
+                      sql << "UPDATE __database_meta__ SET version = :version WHERE id = :id", soci::use(version), soci::use(T::COIN_ID);
                   }
               }
           }
@@ -102,15 +102,15 @@ namespace ledger {
                   // we’re in sync with the database; perform the rollback normally
                   rollback<version, T>(sql);
 
-                  if (currentVersion >= 0) {
-                      // after rolling back this migration, we won’t have anything left, so we only
-                      // update the version for > 0
-                      if (currentVersion != 0) {
-                          auto prevVersion = version - 1;
-                          sql << "UPDATE __database_meta__ SET id = :id, version = :version", soci::use(T::COIN_ID), soci::use(prevVersion);
-                      }
+                  if (currentVersion > 0) {
+                      // if the migration number is greater than 0, we just perform the regular migration
+                      auto prevVersion = version - 1;
+                      sql << "UPDATE __database_meta__ SET version = :version WHERE id = :id", soci::use(prevVersion), soci::use(T::COIN_ID);
 
                       Migration<version - 1, T>::backward(sql, currentVersion - 1);
+                  } else if (currentVersion == 0) {
+                      // here we want to remove the coin from the metadata table
+                      sql << "DELETE FROM __database_meta__ WHERE id = :id", soci::use(T::COIN_ID);
                   }
               } else if (currentVersion < version) {
                   // we’re trying to rollback a migration that hasn’t been applied; try the previous

--- a/ledger-core/src/core/Services.cpp
+++ b/ledger-core/src/core/Services.cpp
@@ -232,7 +232,7 @@ namespace ledger {
                 // FIXME: drop coins first
 
                 // drop the main database first
-                //self->getDatabaseSessionPool()->performDatabaseMigrationUnsetup();
+                self->getDatabaseSessionPool()->performDatabaseMigrationUnsetup();
 
                 // then reset preferences
                 _externalPreferencesBackend->clear();

--- a/ledger-core/src/core/database/DatabaseSessionPool.cpp
+++ b/ledger-core/src/core/database/DatabaseSessionPool.cpp
@@ -85,10 +85,10 @@ namespace ledger {
 
         void DatabaseSessionPool::performDatabaseMigrationSetup() {
             soci::session sql(getPool());
-            int version = getDatabaseMigrationVersion<CoreMigration>(sql);
+            uint32_t const version = getDatabaseMigrationVersion<CoreMigration>(sql);
 
             // if the database doesn’t exist, we need to create its structure
-            if (version == -1) {
+            if (version == 0) {
               setupMigrations(sql);
             }
 

--- a/ledger-core/src/core/database/DatabaseSessionPool.cpp
+++ b/ledger-core/src/core/database/DatabaseSessionPool.cpp
@@ -100,7 +100,7 @@ namespace ledger {
         }
 
         void DatabaseSessionPool::performDatabaseMigrationUnsetup() {
-            rollbackMigration<CoreMigration>();
+            rollbackMigrations();
         }
 
         void DatabaseSessionPool::performChangePassword(const std::string &oldPassword,


### PR DESCRIPTION
# Content

We need to ensure all coins’s database migrations are rolled back before
rolling back the ledger-core one. This is due to the fact internally,
tables might have relationship and foreign keys. Some database backends
will automatically erase lines in child tables but the structure — i.e.
the tables themselves — will remain in database.

In the doubt, it’s better to drop tables in order.

Relates to LLC-509.

# Mandatory picture of the best animal on Earth and the cosmos

![](https://phaazon.net/media/uploads/pet_the_dog.gif)