### PR TITLE
Sync token removal in reorganisation use case

### DIFF
--- a/core/idl/wallet/configuration.djinni
+++ b/core/idl/wallet/configuration.djinni
@@ -95,6 +95,9 @@ Configuration = interface +c {
 
     # Time to Live for block cache
     const TTL_CACHE: string = "TTL_CACHE";
+
+    # Syncronization token deactivation
+    const DEACTIVATE_SYNC_TOKEN: string = "DEACTIVATE_SYNC_TOKEN";
 }
 
 # Configuration of wallet pools.

--- a/core/src/api/Configuration.cpp
+++ b/core/src/api/Configuration.cpp
@@ -31,4 +31,6 @@ std::string const Configuration::TRUST_LIMIT = {"TRUST_LIMIT"};
 
 std::string const Configuration::TTL_CACHE = {"TTL_CACHE"};
 
+std::string const Configuration::DEACTIVATE_SYNC_TOKEN = {"DEACTIVATE_SYNC_TOKEN"};
+
 } } }  // namespace ledger::core::api

--- a/core/src/api/Configuration.hpp
+++ b/core/src/api/Configuration.hpp
@@ -58,6 +58,9 @@ public:
 
     /** Time to Live for block cache */
     static std::string const TTL_CACHE;
+
+    /** Syncronization token deactivation */
+    static std::string const DEACTIVATE_SYNC_TOKEN;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/wallet/common/synchronizers/AbstractBlockchainExplorerAccountSynchronizer.h
+++ b/core/src/wallet/common/synchronizers/AbstractBlockchainExplorerAccountSynchronizer.h
@@ -233,7 +233,7 @@ namespace ledger {
                 const auto deactivateToken =
                         buddy->configuration->getBoolean(api::Configuration::DEACTIVATE_SYNC_TOKEN).value_or(false);
                 auto getSyncToken = deactivateToken ? Future<void *>::successful(nullptr) : _explorer->startSession();
-                return getSyncToken.template map<Unit>(account->getContext(), [buddy, deactivateToken] (void * const& t) -> Unit {
+                return getSyncToken.template map<Unit>(account->getContext(), [buddy, deactivateToken] (void * const t) -> Unit {
                     buddy->logger->info("Synchronization token obtained");
                     if (!deactivateToken && t) {
                         buddy->token = Option<void *>(t);
@@ -340,7 +340,7 @@ namespace ledger {
                             return self->_explorer->startSession();
                         });
 
-                        return startSession.template flatMap<Unit>(ImmediateExecutionContext::INSTANCE, [=] (void * const &session) {
+                        return startSession.template flatMap<Unit>(ImmediateExecutionContext::INSTANCE, [=] (void * const session) {
                             if (!deactivateToken && session) {
                                 buddy->token = Option<void *>(session);
                             } else {
@@ -355,8 +355,8 @@ namespace ledger {
 
                             //Get its block/block height
                             auto &failedBatch = buddy->savedState.getValue().batches[currentBatchIndex];
-                            auto failedBlockHeight = failedBatch.blockHeight;
-                            auto failedBlockHash = failedBatch.blockHash;
+                            auto const failedBlockHeight = failedBatch.blockHeight;
+                            auto const failedBlockHash = failedBatch.blockHash;
 
                             if (failedBlockHeight > 0) {
                                 //Delete data related to failedBlock (and all blocks above it)

--- a/core/src/wallet/common/synchronizers/AbstractBlockchainExplorerAccountSynchronizer.h
+++ b/core/src/wallet/common/synchronizers/AbstractBlockchainExplorerAccountSynchronizer.h
@@ -232,10 +232,10 @@ namespace ledger {
                 auto self = getSharedFromThis();
                 const auto deactivateToken =
                         buddy->configuration->getBoolean(api::Configuration::DEACTIVATE_SYNC_TOKEN).value_or(false);
-                auto getSyncToken = deactivateToken ? Future<Unit>::successful(unit) : _explorer->startSession();
+                auto getSyncToken = deactivateToken ? Future<void *>::successful(nullptr) : _explorer->startSession();
                 return getSyncToken.template map<Unit>(account->getContext(), [buddy, deactivateToken] (void * const& t) -> Unit {
                     buddy->logger->info("Synchronization token obtained");
-                    if (!deactivateToken) {
+                    if (!deactivateToken && t) {
                         buddy->token = Option<void *>(t);
                     }
                     return unit;
@@ -330,72 +330,82 @@ namespace ledger {
                         buddy->savedState.nonEmpty()) {
                         buddy->logger->info("Recovering from reorganization");
 
+                        // Try to get a new sync token
                         const auto deactivateToken =
                                 buddy->configuration->getBoolean(api::Configuration::DEACTIVATE_SYNC_TOKEN).value_or(false);
-                        if (!deactivateToken) {
-                            auto tryStartSession = Try<Future<void *>>::from([=](){
-                                return self->_explorer->startSession();
-                            });
-                            if (tryStartSession.isFailure()) {
-                                buddy->logger->warn("Failed to get new synchronization token for account#{} of wallet {}",
+                        auto startSession = Future<void *>::async(ImmediateExecutionContext::INSTANCE, [=](){
+                            if (deactivateToken) {
+                                return Future<void *>::successful(nullptr);
+                            }
+                            return self->_explorer->startSession();
+                        });
+
+                        return startSession.template flatMap<Unit>(ImmediateExecutionContext::INSTANCE, [=] (void * const &session) {
+                            if (!deactivateToken && session) {
+                                buddy->token = Option<void *>(session);
+                            } else {
+                                buddy->logger->warn(
+                                        "Failed to get new synchronization token for account#{} of wallet {}",
                                         buddy->account->getIndex(),
                                         buddy->account->getWallet()->getName());
                                 // WARNING: we have too many issues with that sync token because of blockchain explorer,
                                 // when we fail on reorg we try without sync token
                                 buddy->token = Option<void *>();
-                            } else {
-                                buddy->token = tryStartSession.getValue();
-                            }
-                        } else {
-                            buddy->token = Option<void *>();
-                        }
-
-                        //Get its block/block height
-                        auto& failedBatch = buddy->savedState.getValue().batches[currentBatchIndex];
-                        auto failedBlockHeight = failedBatch.blockHeight;
-                        auto failedBlockHash = failedBatch.blockHash;
-
-                        if (failedBlockHeight > 0) {
-                            //Delete data related to failedBlock (and all blocks above it)
-                            buddy->logger->info("Deleting blocks above block height: {}", failedBlockHeight);
-
-                            soci::session sql(buddy->wallet->getDatabase()->getPool());
-                            sql << "DELETE FROM blocks where height >= :failedBlockHeight", soci::use(failedBlockHeight);
-
-                            //Get last block not part from reorg
-                            auto lastBlock = BlockDatabaseHelper::getLastBlock(sql, buddy->wallet->getCurrency().name);
-
-                            //Resync from the "beginning" if no last block in DB
-                            int64_t lastBlockHeight = 0;
-                            std::string lastBlockHash;
-                            if (lastBlock.nonEmpty()) {
-                                lastBlockHeight = lastBlock.getValue().height;
-                                lastBlockHash = lastBlock.getValue().blockHash;
                             }
 
-                            //Update savedState's batches
-                            for (auto &batch : buddy->savedState.getValue().batches) {
-                                if (batch.blockHeight > lastBlockHeight) {
-                                    batch.blockHeight = (uint32_t)lastBlockHeight;
-                                    batch.blockHash = lastBlockHash;
+                            //Get its block/block height
+                            auto &failedBatch = buddy->savedState.getValue().batches[currentBatchIndex];
+                            auto failedBlockHeight = failedBatch.blockHeight;
+                            auto failedBlockHash = failedBatch.blockHash;
+
+                            if (failedBlockHeight > 0) {
+                                //Delete data related to failedBlock (and all blocks above it)
+                                buddy->logger->info("Deleting blocks above block height: {}", failedBlockHeight);
+
+                                soci::session sql(buddy->wallet->getDatabase()->getPool());
+                                sql << "DELETE FROM blocks where height >= :failedBlockHeight", soci::use(
+                                        failedBlockHeight);
+
+                                //Get last block not part from reorg
+                                auto lastBlock = BlockDatabaseHelper::getLastBlock(sql,
+                                                                                   buddy->wallet->getCurrency().name);
+
+                                //Resync from the "beginning" if no last block in DB
+                                int64_t lastBlockHeight = 0;
+                                std::string lastBlockHash;
+                                if (lastBlock.nonEmpty()) {
+                                    lastBlockHeight = lastBlock.getValue().height;
+                                    lastBlockHash = lastBlock.getValue().blockHash;
                                 }
+
+                                //Update savedState's batches
+                                for (auto &batch : buddy->savedState.getValue().batches) {
+                                    if (batch.blockHeight > lastBlockHeight) {
+                                        batch.blockHeight = (uint32_t) lastBlockHeight;
+                                        batch.blockHash = lastBlockHash;
+                                    }
+                                }
+
+                                //Save new savedState
+                                buddy->preferences->editor()->template putObject<BlockchainExplorerAccountSynchronizationSavedState>(
+                                        "state", buddy->savedState.getValue())->commit();
+
+                                //Synchronize same batch now with an existing block (of hash lastBlockHash)
+                                //if failedBatch was not the deepest block part of that reorg, this recursive call
+                                //will ensure to get (and delete from DB) to the deepest failed block (part of reorg)
+                                buddy->logger->info("Relaunch synchronization after recovering from reorganization");
+
+                                return self->synchronizeBatches(currentBatchIndex, buddy);
                             }
-
-                            //Save new savedState
-                            buddy->preferences->editor()->template putObject<BlockchainExplorerAccountSynchronizationSavedState>(
-                                    "state", buddy->savedState.getValue())->commit();
-
-                            //Synchronize same batch now with an existing block (of hash lastBlockHash)
-                            //if failedBatch was not the deepest block part of that reorg, this recursive call
-                            //will ensure to get (and delete from DB) to the deepest failed block (part of reorg)
-                            buddy->logger->info("Relaunch synchronization after recovering from reorganization");
-
-                            return self->synchronizeBatches(currentBatchIndex, buddy);
-                        }
-                    } else {
-                        return Future<Unit>::failure(exception);
+                            return Future<Unit>::successful(unit);
+                        }).recover(ImmediateExecutionContext::INSTANCE, [buddy] (const Exception& ex) -> Unit {
+                            buddy->logger->warn(
+                                    "Failed to recover from reorganisation for account#{} of wallet {}",
+                                    buddy->account->getIndex(),
+                                    buddy->account->getWallet()->getName());
+                            return unit;
+                        });
                     }
-
                     return Future<Unit>::successful(unit);
                 });
             };

--- a/core/src/wallet/common/synchronizers/AbstractBlockchainExplorerAccountSynchronizer.h
+++ b/core/src/wallet/common/synchronizers/AbstractBlockchainExplorerAccountSynchronizer.h
@@ -322,6 +322,10 @@ namespace ledger {
                         buddy->savedState.nonEmpty()) {
                         buddy->logger->info("Recovering from reorganization");
 
+                        // WARNING: we have too many issues with that sync token because of blockchain explorer,
+                        // when we fail on reorg we try without sync token
+                        buddy->token = Option<void *>();
+
                         //Get its block/block height
                         auto& failedBatch = buddy->savedState.getValue().batches[currentBatchIndex];
                         auto failedBlockHeight = failedBatch.blockHeight;


### PR DESCRIPTION
Unset sync token when falling in reorg situation because explorers are not trustworthy on that feature
**HODL:** I will add a config to deactivate sync tokens