### PR TITLE
Backport PostgreSQL support 

### DIFF
--- a/ledger-core-bitcoin/inc/bitcoin/database/Migrations.hpp
+++ b/ledger-core-bitcoin/inc/bitcoin/database/Migrations.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <core/api/DatabaseBackendType.hpp>
 #include <core/database/Migrations.hpp>
 
 #include <bitcoin/BitcoinLikeCoinID.hpp>
@@ -13,22 +14,22 @@ namespace ledger {
         };
 
         // migrations
-        template <> void migrate<1, BitcoinMigration>(soci::session& sql);
-        template <> void rollback<1, BitcoinMigration>(soci::session& sql);
+        template <> void migrate<1, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<1, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType type);
 
-        template <> void migrate<2, BitcoinMigration>(soci::session& sql);
-        template <> void rollback<2, BitcoinMigration>(soci::session& sql);
+        template <> void migrate<2, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<2, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType type);
 
-        template <> void migrate<3, BitcoinMigration>(soci::session& sql);
-        template <> void rollback<3, BitcoinMigration>(soci::session& sql);
+        template <> void migrate<3, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<3, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType type);
 
-        template <> void migrate<4, BitcoinMigration>(soci::session& sql);
-        template <> void rollback<4, BitcoinMigration>(soci::session& sql);
+        template <> void migrate<4, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<4, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType type);
 
-        template <> void migrate<5, BitcoinMigration>(soci::session& sql);
-        template <> void rollback<5, BitcoinMigration>(soci::session& sql);
+        template <> void migrate<5, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<5, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType type);
 
-        template <> void migrate<6, BitcoinMigration>(soci::session& sql);
-        template <> void rollback<6, BitcoinMigration>(soci::session& sql);
+        template <> void migrate<6, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<6, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType type);
   }
 }

--- a/ledger-core-bitcoin/src/bitcoin/database/Migrations.cpp
+++ b/ledger-core-bitcoin/src/bitcoin/database/Migrations.cpp
@@ -5,7 +5,7 @@ namespace ledger {
         int constexpr BitcoinMigration::COIN_ID;
         uint32_t constexpr BitcoinMigration::CURRENT_VERSION;
 
-        template <> void migrate<1, BitcoinMigration>(soci::session& sql) {
+        template <> void migrate<1, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType) {
             // Bitcoin currency table
             sql << "CREATE TABLE bitcoin_currencies("
                 "name VARCHAR(255) PRIMARY KEY NOT NULL REFERENCES currencies(name) ON DELETE CASCADE ON UPDATE CASCADE,"
@@ -78,7 +78,7 @@ namespace ledger {
                 ")";
         }
 
-        template <> void rollback<1, BitcoinMigration>(soci::session& sql) {
+        template <> void rollback<1, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType) {
             // Bitcoin operation table
             sql << "DROP TABLE bitcoin_operations";
 
@@ -101,24 +101,24 @@ namespace ledger {
             sql << "DROP TABLE bitcoin_currencies";
         }
 
-        template <> void migrate<2, BitcoinMigration>(soci::session& sql) {
+        template <> void migrate<2, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "ALTER TABLE bitcoin_currencies ADD COLUMN timestamp_delay BIGINT DEFAULT 0";
             sql << "ALTER TABLE bitcoin_currencies ADD COLUMN sighash_type VARCHAR(255) DEFAULT 01";
         }
 
-        template <> void rollback<2, BitcoinMigration>(soci::session& sql) {
+        template <> void rollback<2, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType) {
             // not supported in standard ways by SQLite :(
         }
 
-        template <> void migrate<3, BitcoinMigration>(soci::session& sql) {
+        template <> void migrate<3, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "ALTER TABLE bitcoin_currencies ADD COLUMN additional_BIPs TEXT DEFAULT ''";
         }
 
-        template <> void rollback<3, BitcoinMigration>(soci::session& sql) {
+        template <> void rollback<3, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType) {
             // not supported in standard ways by SQLite :(
         }
 
-        template <> void migrate<4, BitcoinMigration>(soci::session& sql) {
+        template <> void migrate<4, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType) {
             auto count = 0;
             sql << "SELECT COUNT(*) FROM bitcoin_currencies WHERE identifier = 'dgb'", soci::into(count);
             if (count > 0) {
@@ -126,11 +126,11 @@ namespace ledger {
             }
         }
 
-        template <> void rollback<4, BitcoinMigration>(soci::session& sql) {
+        template <> void rollback<4, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType) {
             // cannot rollback
         }
 
-        template <> void migrate<5, BitcoinMigration>(soci::session& sql) {
+        template <> void migrate<5, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "CREATE TABLE bech32_parameters("
                     "name VARCHAR(255) PRIMARY KEY NOT NULL REFERENCES bitcoin_currencies(name) ON DELETE CASCADE ON UPDATE CASCADE,"
                     "hrp VARCHAR(255) NOT NULL,"
@@ -141,15 +141,15 @@ namespace ledger {
                     ")";
         }
 
-        template <> void rollback<5, BitcoinMigration>(soci::session& sql) {
+        template <> void rollback<5, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "DROP TABLE bech32_parameters";
         }
 
-        template <> void migrate<6, BitcoinMigration>(soci::session& sql) {
+        template <> void migrate<6, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "ALTER TABLE bitcoin_outputs ADD COLUMN block_height BIGINT";
         }
 
-        template <> void rollback<6, BitcoinMigration>(soci::session& sql) {
+        template <> void rollback<6, BitcoinMigration>(soci::session& sql, api::DatabaseBackendType) {
         }
     }
 }

--- a/ledger-core-ethereum/inc/ethereum/database/Migrations.hpp
+++ b/ledger-core-ethereum/inc/ethereum/database/Migrations.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <core/api/DatabaseBackendType.hpp>
 #include <core/database/Migrations.hpp>
+
 #include <ethereum/EthereumLikeCoinID.hpp>
 
 namespace ledger {
@@ -12,11 +14,11 @@ namespace ledger {
         };
 
         // migrations
-        template <> void migrate<1, EthereumMigration>(soci::session& sql);
-        template <> void rollback<1, EthereumMigration>(soci::session& sql);
-        template <> void migrate<2, EthereumMigration>(soci::session& sql);
-        template <> void rollback<2, EthereumMigration>(soci::session& sql);
-        template <> void migrate<3, EthereumMigration>(soci::session& sql);
-        template <> void rollback<3, EthereumMigration>(soci::session& sql);
+        template <> void migrate<1, EthereumMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<1, EthereumMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void migrate<2, EthereumMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<2, EthereumMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void migrate<3, EthereumMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<3, EthereumMigration>(soci::session& sql, api::DatabaseBackendType type);
   }
 }

--- a/ledger-core-ripple/inc/ripple/database/Migrations.hpp
+++ b/ledger-core-ripple/inc/ripple/database/Migrations.hpp
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include <core/api/DatabaseBackendType.hpp>
 #include <core/database/Migrations.hpp>
 
 #include <ripple/RippleLikeCoinID.hpp>
@@ -43,15 +44,15 @@ namespace ledger {
         };
 
         // migrations
-        template <> void migrate<1, XRPMigration>(soci::session& sql);
-        template <> void rollback<1, XRPMigration>(soci::session& sql);
-        template <> void migrate<2, XRPMigration>(soci::session& sql);
-        template <> void rollback<2, XRPMigration>(soci::session& sql);
-        template <> void migrate<3, XRPMigration>(soci::session& sql);
-        template <> void rollback<3, XRPMigration>(soci::session& sql);
-        template <> void migrate<4, XRPMigration>(soci::session& sql);
-        template <> void rollback<4, XRPMigration>(soci::session& sql);
-        template <> void migrate<5, XRPMigration>(soci::session& sql);
-        template <> void rollback<5, XRPMigration>(soci::session& sql);
+        template <> void migrate<1, XRPMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<1, XRPMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void migrate<2, XRPMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<2, XRPMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void migrate<3, XRPMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<3, XRPMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void migrate<4, XRPMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<4, XRPMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void migrate<5, XRPMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<5, XRPMigration>(soci::session& sql, api::DatabaseBackendType type);
   }
 }

--- a/ledger-core-ripple/src/ripple/database/Migrations.cpp
+++ b/ledger-core-ripple/src/ripple/database/Migrations.cpp
@@ -35,7 +35,7 @@ namespace ledger {
         int constexpr XRPMigration::COIN_ID;
         uint32_t constexpr XRPMigration::CURRENT_VERSION;
 
-        template <> void migrate<1, XRPMigration>(soci::session& sql) {
+        template <> void migrate<1, XRPMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "CREATE TABLE ripple_currencies("
                     "name VARCHAR(255) PRIMARY KEY NOT NULL REFERENCES currencies(name) ON DELETE CASCADE ON UPDATE CASCADE,"
                     "identifier VARCHAR(255) NOT NULL,"
@@ -70,14 +70,14 @@ namespace ledger {
                     ")";
         }
 
-        template <> void rollback<1, XRPMigration>(soci::session& sql) {
+        template <> void rollback<1, XRPMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "DROP TABLE ripple_operations";
             sql << "DROP TABLE ripple_transactions";
             sql << "DROP TABLE ripple_accounts";
             sql << "DROP TABLE ripple_currencies";
         }
 
-        template <> void migrate<2, XRPMigration>(soci::session& sql) {
+        template <> void migrate<2, XRPMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "CREATE TABLE ripple_memos("
                    "transaction_uid VARCHAR(255) NOT NULL REFERENCES ripple_transactions(transaction_uid) ON DELETE CASCADE,"
                    "data VARCHAR(1024),"
@@ -87,31 +87,31 @@ namespace ledger {
                    ")";
         }
 
-        template <> void rollback<2, XRPMigration>(soci::session& sql) {
+        template <> void rollback<2, XRPMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "DROP TABLE ripple_memos";
         }
 
-        template <> void migrate<3, XRPMigration>(soci::session& sql) {
+        template <> void migrate<3, XRPMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "ALTER TABLE ripple_transactions ADD COLUMN sequence BIGINT";
         }
 
-        template <> void rollback<3, XRPMigration>(soci::session& sql) {
+        template <> void rollback<3, XRPMigration>(soci::session& sql, api::DatabaseBackendType) {
         }
 
-        template <> void migrate<4, XRPMigration>(soci::session& sql) {
+        template <> void migrate<4, XRPMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "ALTER TABLE ripple_transactions ADD COLUMN destination_tag BIGINT";
         }
 
-        template <> void rollback<4, XRPMigration>(soci::session& sql) {
+        template <> void rollback<4, XRPMigration>(soci::session& sql, api::DatabaseBackendType) {
         }
 
-        template <> void migrate<5, XRPMigration>(soci::session& sql) {
+        template <> void migrate<5, XRPMigration>(soci::session& sql, api::DatabaseBackendType) {
             // 1 if success, 0 otherwise
             // <https://xrpl.org/transaction-results.html>
             sql << "ALTER TABLE ripple_transactions ADD COLUMN status INTEGER";
         }
 
-        template <> void rollback<5, XRPMigration>(soci::session& sql) {
+        template <> void rollback<5, XRPMigration>(soci::session& sql, api::DatabaseBackendType) {
         }
     }
 }

--- a/ledger-core-ripple/test/CMakeLists.txt
+++ b/ledger-core-ripple/test/CMakeLists.txt
@@ -30,4 +30,4 @@ add_test (NAME Ripple-address COMMAND ledger-core-ripple-tests --gtest_filter=Ri
 add_test (NAME Ripple-keychain COMMAND ledger-core-ripple-tests --gtest_filter=RippleKeychains.*)
 add_test (NAME Ripple-transaction COMMAND ledger-core-ripple-tests --gtest_filter=RippleMakeTransaction.*)
 add_test (NAME Ripple-sync COMMAND ledger-core-ripple-tests --gtest_filter=RippleLikeWalletSynchronization.*)
-add_test (NAME Ripple-account COMMAND ledger-core-ripple-test --gtest_filter=RippleAccounts.*)
+add_test (NAME Ripple-account COMMAND ledger-core-ripple-tests --gtest_filter=RippleAccounts.*)

--- a/ledger-core-tezos/inc/tezos/database/Migrations.hpp
+++ b/ledger-core-tezos/inc/tezos/database/Migrations.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <tezos/TezosLikeCoinID.hpp>
-
+#include <core/api/DatabaseBackendType.hpp>
 #include <core/database/Migrations.hpp>
+
+#include <tezos/TezosLikeCoinID.hpp>
 
 namespace ledger {
     namespace core {
@@ -13,13 +14,13 @@ namespace ledger {
         };
 
         // migrations
-        template <> void migrate<1, TezosMigration>(soci::session& sql);
-        template <> void rollback<1, TezosMigration>(soci::session& sql);
+        template <> void migrate<1, TezosMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<1, TezosMigration>(soci::session& sql, api::DatabaseBackendType type);
 
-        template <> void migrate<2, TezosMigration>(soci::session& sql);
-        template <> void rollback<2, TezosMigration>(soci::session& sql);
+        template <> void migrate<2, TezosMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<2, TezosMigration>(soci::session& sql, api::DatabaseBackendType type);
 
-        template <> void migrate<3, TezosMigration>(soci::session& sql);
-        template <> void rollback<3, TezosMigration>(soci::session& sql);
+        template <> void migrate<3, TezosMigration>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<3, TezosMigration>(soci::session& sql, api::DatabaseBackendType type);
   }
 }

--- a/ledger-core-tezos/src/tezos/database/Migrations.cpp
+++ b/ledger-core-tezos/src/tezos/database/Migrations.cpp
@@ -5,7 +5,7 @@ namespace ledger {
         int constexpr TezosMigration::COIN_ID;
         uint32_t constexpr TezosMigration::CURRENT_VERSION;
 
-        template <> void migrate<1, TezosMigration>(soci::session& sql) {
+        template <> void migrate<1, TezosMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "CREATE TABLE tezos_currencies("
                     "name VARCHAR(255) PRIMARY KEY NOT NULL REFERENCES currencies(name) ON DELETE CASCADE ON UPDATE CASCADE,"
                     "identifier VARCHAR(255) NOT NULL,"
@@ -63,7 +63,7 @@ namespace ledger {
                     ")";
         }
 
-        template <> void rollback<1, TezosMigration>(soci::session& sql) {
+        template <> void rollback<1, TezosMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "DROP TABLE tezos_originated_operations";
 
             sql << "DROP TABLE tezos_originated_accounts";
@@ -78,19 +78,19 @@ namespace ledger {
         }
 
 
-        template <> void migrate<2, TezosMigration>(soci::session& sql) {
+        template <> void migrate<2, TezosMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "ALTER TABLE tezos_accounts RENAME COLUMN address TO public_key";
         }
 
-        template <> void rollback<2, TezosMigration>(soci::session& sql) {
+        template <> void rollback<2, TezosMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "ALTER TABLE tezos_accounts RENAME COLUMN public_key TO address";
         }
 
-        template <> void migrate<3, TezosMigration>(soci::session& sql) {
+        template <> void migrate<3, TezosMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "ALTER TABLE tezos_transactions ADD COLUMN status BIGINT";
         }
 
-        template <> void rollback<3, TezosMigration>(soci::session& sql) {
+        template <> void rollback<3, TezosMigration>(soci::session& sql, api::DatabaseBackendType) {
         }
     }
 }

--- a/ledger-core/CMakeLists.txt
+++ b/ledger-core/CMakeLists.txt
@@ -31,6 +31,10 @@ set(CMAKE_MACOSX_RPATH 1)
 
 add_definitions("-DSQLITE_HAS_CODEC")
 
+if (PG_SUPPORT)
+    add_definitions("-DPG_SUPPORT")
+endif()
+
 string(FIND "${CMAKE_OSX_SYSROOT}" "iphone" IS_IOS)
 if(IS_IOS GREATER_EQUAL 0 OR TARGET_JNI OR ANDROID)
     set(BUILD_TESTING OFF CACHE BOOL "iOS build fail otherwise" FORCE)
@@ -84,6 +88,7 @@ install(
         fmt
         crypto
         soci_sqlite3
+        soci_postgresql
         soci_core_static
         leveldb
         spdlog

--- a/ledger-core/idl/configuration.djinni
+++ b/ledger-core/idl/configuration.djinni
@@ -59,6 +59,9 @@ ConfigurationDefaults = interface +c {
 
     # Default TTL for cache
     const DEFAULT_TTL_CACHE : i32 = 30;
+
+    # Default connection pool size for PostgreSQL
+    const DEFAULT_PG_CONNECTION_POOL_SIZE: i32 = 25;
 }
 
 # Overall configuration.

--- a/ledger-core/idl/database.djinni
+++ b/ledger-core/idl/database.djinni
@@ -1,3 +1,9 @@
+# An enum representing a type of database backend (ones supported now through SOCI).
+DatabaseBackendType = enum {
+    SQLite3;
+    PostgreSQL;
+}
+
 # An enum representing a SQL type.
 DatabaseValueType = enum {
     string; date; double; integer; long_long; unsigned_long_long; blob;
@@ -242,6 +248,10 @@ DatabaseBackend = interface +c {
     # Create an instance of SQLite3 database.
     # @return DatabaseBackend object
     static getSqlite3Backend(): DatabaseBackend;
+
+    # Create an instance of PostgreSQL database.
+    # @return DatabaseBackend object
+    static getPostgreSQLBackend(connectionPoolSize: i32): DatabaseBackend;
 
     # Create a database backend instance from the given DatabaseEngine implementation.
     static createBackendFromEngine(engine: DatabaseEngine): DatabaseBackend;

--- a/ledger-core/inc/core/database/DatabaseBackend.hpp
+++ b/ledger-core/inc/core/database/DatabaseBackend.hpp
@@ -63,6 +63,8 @@ namespace ledger {
 
             bool isLoggingEnabled() override;
 
+            static bool isPostgreSQLSupported();
+
         private:
             bool _enableLogging;
         };

--- a/ledger-core/inc/core/database/PostgreSQLBackend.hpp
+++ b/ledger-core/inc/core/database/PostgreSQLBackend.hpp
@@ -1,0 +1,68 @@
+/*
+ *
+ * PostgreSQL
+ *
+ * Created by El Khalil Bellakrid on 06/12/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <soci.h>
+
+#include <core/api/PathResolver.hpp>
+#include <core/database/DatabaseBackend.hpp>
+
+namespace ledger {
+    namespace core {
+        class PostgreSQLBackend : public DatabaseBackend {
+        public:
+            PostgreSQLBackend();
+            PostgreSQLBackend(int32_t connectionPoolSize);
+
+            int32_t getConnectionPoolSize() override;
+
+            void init(const std::shared_ptr<api::PathResolver> &resolver,
+                      const std::string &dbName,
+                      const std::string &password,
+                      soci::session &session) override;
+
+            void setPassword(const std::string &password,
+                             soci::session &session) override;
+
+            void changePassword(const std::string & oldPassword,
+                                const std::string & newPassword,
+                                soci::session &session) override;
+
+        private:
+            // Resolved path to db
+            std::string _dbName;
+            int32_t _connectionPoolSize;
+        };
+    }
+}

--- a/ledger-core/lib/CMakeLists.txt
+++ b/ledger-core/lib/CMakeLists.txt
@@ -35,4 +35,6 @@ set(SOCI_SHARED OFF CACHE BOOL "USE ONLY STATIC" FORCE)
 add_subdirectory(soci)
 add_subdirectory(soci_sqlite3)
 
-#add_subdirectory(soci_mysql)
+if (PG_SUPPORT)
+    add_subdirectory(soci_postgresql)
+endif()

--- a/ledger-core/lib/soci_postgresql/CMakeLists.txt
+++ b/ledger-core/lib/soci_postgresql/CMakeLists.txt
@@ -9,43 +9,17 @@
 #
 ###############################################################################
 
-include(CMakeDependentOption)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+add_library(soci_postgresql STATIC
+        blob.cpp common.cpp common.h error.cpp factory.cpp row-id.cpp session.cpp soci-postgresql.h standard-into-type.cpp
+        standard-use-type.cpp statement.cpp vector-into-type.cpp vector-use-type.cpp)
 
-option(SOCI_POSTGRESQL_NOPARAMS
-  "Do not use input parameters. PostgreSQL 7.x portability."
-  OFF)
+# set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+find_package(PostgreSQL REQUIRED)
+target_include_directories(soci_postgresql PUBLIC ${PostgreSQL_INCLUDE_DIR})
+target_link_libraries(soci_postgresql PUBLIC ${PostgreSQL_LIBRARIES})
+target_include_directories(soci_postgresql PUBLIC 
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../soci/core>
+        $<INSTALL_INTERFACE:include/soci>
+)
 
-option(SOCI_POSTGRESQL_NOBINDBYNAME
-  "Disable query rewriting to native form. PostgreSQL 7.0 portability."
-  OFF)
-
-cmake_dependent_option(SOCI_POSTGRESQL_NOPREPARE
-  "Disable prepared statements. Set ON if SOCI_POSTGRESQL_NOBINDBYNAME is ON. PostgreSQL 7.0 portability." ON
-  SOCI_POSTGRESQL_NOBINDBYNAME OFF)
-
-if(SOCI_POSTGRESQL_NOPARAMS)
-  add_definitions(-DSOCI_POSTGRESQL_NOPARAMS=1)
-endif()
-
-if(SOCI_POSTGRESQL_NOBINDBYNAME)
-message("X")
-  add_definitions(-DSOCI_POSTGRESQL_NOBINDBYNAME=1)
-endif()
-
-if(SOCI_POSTGRESQL_NOPREPARE)
-message("Y")
-  add_definitions(-DSOCI_POSTGRESQL_NOPREPARE=1)
-endif()
-
-soci_backend(PostgreSQL
-  DEPENDS PostgreSQL
-  HEADERS soci-postgresql.h common.h
-  DESCRIPTION "SOCI backend for PostgreSQL database engine"
-  AUTHORS "Maciej Sobczak, Stephen Hutton"
-  MAINTAINERS "Mateusz Loskot")
-
-boost_report_value(SOCI_POSTGRESQL_NOPARAMS)
-boost_report_value(SOCI_POSTGRESQL_NOBINDBYNAME)
-boost_report_value(SOCI_POSTGRESQL_NOPREPARE)
-
-add_subdirectory(test)

--- a/ledger-core/src/CMakeLists.txt
+++ b/ledger-core/src/CMakeLists.txt
@@ -37,6 +37,11 @@ link_directories(${CMAKE_BINARY_DIR}/lib)
 file(GLOB_RECURSE SRC_FILES *.cpp)
 file(GLOB_RECURSE HEADERS_FILES ../inc/*.{h,hpp})
 
+if (NOT PG_SUPPORT)
+    list(REMOVE_ITEM SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/core/database/PostgreSQLBackend.cpp)
+    list(REMOVE_ITEM HEADERS_FILES ${CMAKE_CURRENT_SOURCE_DIR}/core/database/PostgreSQLBackend.hpp)
+endif()
+
 # Interface library used to hold shared properties
 add_library(ledger-core-interface INTERFACE)
 
@@ -117,6 +122,10 @@ target_link_libraries(ledger-core-interface INTERFACE soci_sqlite3)
 target_link_libraries(ledger-core-interface INTERFACE soci_core_static)
 target_link_libraries(ledger-core-interface INTERFACE leveldb)
 
+if (PG_SUPPORT)
+    target_link_libraries(ledger-core-interface INTERFACE soci_postgresql)
+endif()
+
 target_compile_definitions(ledger-core-interface INTERFACE SPDLOG_WCHAR_FILENAMES)
 target_link_libraries(ledger-core-interface INTERFACE spdlog)
 
@@ -150,6 +159,7 @@ target_include_directories(
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/ethash/src>           $<INSTALL_INTERFACE:include/ledger-core/lib/ethash/src>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/fmt/include>          $<INSTALL_INTERFACE:include/ledger-core/lib/fmt/include>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/spdlog/include>       $<INSTALL_INTERFACE:include/ledger-core/lib/spdlog/include>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/soci_postgresql>      $<INSTALL_INTERFACE:include/ledger-core/lib/soci_postgresql>
 
     # Hack: work around to find the ledger-core API header files in dependent projects
     $<INSTALL_INTERFACE:include/ledger-core/core/api>

--- a/ledger-core/src/core/database/DatabaseBackend.cpp
+++ b/ledger-core/src/core/database/DatabaseBackend.cpp
@@ -30,9 +30,14 @@
  */
 
 #include <core/api/DatabaseEngine.hpp>
+#include <core/api/Error.hpp>
 #include <core/database/DatabaseBackend.hpp>
 #include <core/database/SQLite3Backend.hpp>
 #include <core/database/ProxyBackend.hpp>
+#include <core/utils/Exception.hpp>
+#ifdef PG_SUPPORT
+#include <core/database/PostgreSQLBackend.hpp>
+#endif
 
 namespace ledger {
     namespace core {
@@ -52,6 +57,22 @@ namespace ledger {
 
         bool DatabaseBackend::isLoggingEnabled() {
             return _enableLogging;
+        }
+
+        std::shared_ptr<api::DatabaseBackend> api::DatabaseBackend::getPostgreSQLBackend(int32_t connectionPoolSize) {
+#ifdef PG_SUPPORT
+            return std::make_shared<PostgreSQLBackend>(connectionPoolSize);
+#else
+            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "Libcore should be compiled with PG_SUPPORT flag.");
+#endif
+        }
+
+        bool DatabaseBackend::isPostgreSQLSupported() {
+#ifdef PG_SUPPORT
+            return true;
+#else
+            return false;
+#endif
         }
     }
 }

--- a/ledger-core/src/core/database/Migrations.cpp
+++ b/ledger-core/src/core/database/Migrations.cpp
@@ -47,7 +47,7 @@ namespace ledger {
             sql << "DROP TABLE __database_meta__";
         }
 
-        template <> void migrate<1, CoreMigration>(soci::session& sql) {
+        template <> void migrate<1, CoreMigration>(soci::session& sql, api::DatabaseBackendType) {
             // Abstract currency table
             sql << "CREATE TABLE currencies("
                 "name VARCHAR(255) PRIMARY KEY NOT NULL,"
@@ -107,7 +107,7 @@ namespace ledger {
             ")";
         }
 
-        template <> void rollback<1, CoreMigration>(soci::session& sql) {
+        template <> void rollback<1, CoreMigration>(soci::session& sql, api::DatabaseBackendType) {
             // Abstract operation table
             sql << "DROP TABLE operations";
 
@@ -127,7 +127,7 @@ namespace ledger {
             sql << "DROP TABLE currencies";
         }
 
-        template <> void migrate<2, CoreMigration>(soci::session& sql) {
+        template <> void migrate<2, CoreMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "CREATE TABLE internal_operations("
                     "uid VARCHAR(255) PRIMARY KEY NOT NULL ,"
                     "ethereum_operation_uid VARCHAR(255) NOT NULL REFERENCES operations(uid) ON DELETE CASCADE,"
@@ -141,7 +141,7 @@ namespace ledger {
                     ")";
         }
 
-        template <> void rollback<2, CoreMigration>(soci::session& sql) {
+        template <> void rollback<2, CoreMigration>(soci::session& sql, api::DatabaseBackendType) {
             sql << "DROP TABLE internal_operations";
         }
     }

--- a/ledger-core/src/core/database/PostgreSQLBackend.cpp
+++ b/ledger-core/src/core/database/PostgreSQLBackend.cpp
@@ -1,0 +1,76 @@
+/*
+ *
+ * PostgreSQLBackend
+ *
+ * Created by El Khalil Bellakrid on 06/12/2019.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <soci-postgresql.h>
+
+#include <core/api/ConfigurationDefaults.hpp>
+#include <core/database/PostgreSQLBackend.hpp>
+#include <core/utils/Exception.hpp>
+
+using namespace soci;
+
+namespace ledger {
+    namespace core {
+        PostgreSQLBackend::PostgreSQLBackend() : DatabaseBackend(),
+                                                 _connectionPoolSize(api::ConfigurationDefaults::DEFAULT_PG_CONNECTION_POOL_SIZE)
+        {}
+
+        PostgreSQLBackend::PostgreSQLBackend(int32_t connectionPoolSize) : DatabaseBackend(),
+                                                                           _connectionPoolSize(connectionPoolSize)
+        {}
+
+        int32_t PostgreSQLBackend::getConnectionPoolSize() {
+            return _connectionPoolSize;
+        }
+
+        void PostgreSQLBackend::init(const std::shared_ptr<ledger::core::api::PathResolver> &resolver,
+                                  const std::string &dbName,
+                                  const std::string &password,
+                                  soci::session &session) {
+            _dbName = dbName;
+            setPassword(password, session);
+        }
+
+        void PostgreSQLBackend::setPassword(const std::string &password,
+                                         soci::session &session) {
+            if (_dbName.empty()) {
+                throw make_exception(api::ErrorCode::DATABASE_EXCEPTION, "Database should be initiated before setting password.");
+            }
+            session.close();
+            session.open(*soci::factory_postgresql(), _dbName);
+        }
+
+        void PostgreSQLBackend::changePassword(const std::string & oldPassword,
+                                            const std::string & newPassword,
+                                            soci::session &session) {
+            throw make_exception(api::ErrorCode::IMPLEMENTATION_IS_MISSING, "Change of password is not handled with PostgreSQL backend.");
+        }
+    }
+} 

--- a/ledger-core/test/integration/BaseFixture.cpp
+++ b/ledger-core/test/integration/BaseFixture.cpp
@@ -60,7 +60,8 @@ void BaseFixture::TearDown() {
 
 std::shared_ptr<Services> BaseFixture::newDefaultServices(
     const std::string &tenant,
-    const std::string &password
+    const std::string &password,
+    const std::shared_ptr<api::DynamicObject> &configuration
 ) {
     return Services::newInstance(
         tenant,
@@ -72,7 +73,7 @@ std::shared_ptr<Services> BaseFixture::newDefaultServices(
         dispatcher,
         rng,
         backend,
-        api::DynamicObject::newInstance()
+        configuration
     );
 }
 

--- a/ledger-core/test/integration/BaseFixture.hpp
+++ b/ledger-core/test/integration/BaseFixture.hpp
@@ -62,7 +62,8 @@ public:
 
     std::shared_ptr<Services> newDefaultServices(
         const std::string &tenant = "default_tenant",
-        const std::string &password = "test"
+        const std::string &password = "test",
+        const std::shared_ptr<api::DynamicObject> &configuration = api::DynamicObject::newInstance()
     );
 
     std::shared_ptr<WalletStore> newWalletStore(


### PR DESCRIPTION
As the title above said this PR contains the backport of PostSQL support into the segregated `lib-ledger-core` and a method to know if the main `ledger-core` library was compiled with `PG_SUPPORT` (efficient way to instance the correct database backend in coin-specific library).

## Mandatory picture of a cat 
![pink_cat](https://user-images.githubusercontent.com/6042495/74760625-fc43a200-527a-11ea-82fe-c38718fe4cac.gif)

