### PR TITLE
Add support for failover behavior in soci connection pools.

### DIFF
--- a/core/idl/database/database.djinni
+++ b/core/idl/database/database.djinni
@@ -205,6 +205,9 @@ DatabaseConnection = interface +j +n +o {
     # Create a new empty blob.
     # @return An empty blob
     newBlob(): DatabaseBlob;
+
+    # Check whether the connection is still alive.
+    is_alive(): bool;
 }
 
 # A pool of connections to a single database.

--- a/core/idl/database/database.djinni
+++ b/core/idl/database/database.djinni
@@ -207,7 +207,7 @@ DatabaseConnection = interface +j +n +o {
     newBlob(): DatabaseBlob;
 
     # Check whether the connection is still alive.
-    is_alive(): bool;
+    isAlive(): bool;
 }
 
 # A pool of connections to a single database.

--- a/core/lib/soci/core/session.cpp
+++ b/core/lib/soci/core/session.cpp
@@ -84,7 +84,7 @@ session::session(connection_pool & pool)
         poolPosition_ = pool.lease();
         session & pooledSession = pool.at(poolPosition_);
 
-        if (pooledSession.is_alive()) {
+        if (pooledSession.isAlive()) {
             once.set_session(&pooledSession);
             prepare.set_session(&pooledSession);
             backEnd_ = pooledSession.get_backend();
@@ -229,7 +229,7 @@ std::string session::get_query() const
     else
     {
         // preserve logical constness of get_query,
-        // stream used as read-only here, 
+        // stream used as read-only here,
         session* pthis = const_cast<session*>(this);
 
         // sole place where any user-defined query transformation is applied
@@ -397,9 +397,9 @@ blob_backend * session::make_blob_backend()
     return backEnd_->make_blob_backend();
 }
 
-bool session::is_alive() const
+bool session::isAlive() const
 {
     ensureConnected(backEnd_);
 
-    return backEnd_->is_alive();
+    return backEnd_->isAlive();
 }

--- a/core/lib/soci/core/session.cpp
+++ b/core/lib/soci/core/session.cpp
@@ -80,7 +80,8 @@ session::session(std::string const & connectString)
 session::session(connection_pool & pool)
     : logStream_(NULL), isFromPool_(true), pool_(&pool)
 {
-    while (true) {
+    // this is just a safe guard hack, in case we cannot join the database
+    for (uint32_t failoverRetries = 100u; failoverRetries > 0; --failoverRetries) {
         poolPosition_ = pool.lease();
         session & pooledSession = pool.at(poolPosition_);
 

--- a/core/lib/soci/core/session.h
+++ b/core/lib/soci/core/session.h
@@ -122,6 +122,12 @@ public:
     details::rowid_backend * make_rowid_backend();
     details::blob_backend * make_blob_backend();
 
+    // check the status of a session; some backends might drop idleing connections,
+    // resulting in invalidated connection_pool; when that occurs, this function
+    // should return false to indicate the connection_pool to discard the session
+    // and try again; the default implementation assumes no timeout
+    bool is_alive() const;
+
 private:
     session(session const &);
     session& operator=(session const &);

--- a/core/lib/soci/core/session.h
+++ b/core/lib/soci/core/session.h
@@ -126,7 +126,7 @@ public:
     // resulting in invalidated connection_pool; when that occurs, this function
     // should return false to indicate the connection_pool to discard the session
     // and try again; the default implementation assumes no timeout
-    bool is_alive() const;
+    bool isAlive() const;
 
 private:
     session(session const &);

--- a/core/lib/soci/core/soci-backend.h
+++ b/core/lib/soci/core/soci-backend.h
@@ -250,6 +250,8 @@ public:
     virtual rowid_backend* make_rowid_backend() = 0;
     virtual blob_backend* make_blob_backend() = 0;
 
+    virtual bool is_alive() const = 0;
+
 private:
     // noncopyable
     session_backend(session_backend const&);

--- a/core/lib/soci/core/soci-backend.h
+++ b/core/lib/soci/core/soci-backend.h
@@ -250,7 +250,7 @@ public:
     virtual rowid_backend* make_rowid_backend() = 0;
     virtual blob_backend* make_blob_backend() = 0;
 
-    virtual bool is_alive() const = 0;
+    virtual bool isAlive() const = 0;
 
 private:
     // noncopyable

--- a/core/lib/soci_postgresql/session.cpp
+++ b/core/lib/soci_postgresql/session.cpp
@@ -130,5 +130,12 @@ postgresql_blob_backend * postgresql_session_backend::make_blob_backend()
 }
 
 bool postgresql_session_backend::is_alive() const {
+    auto res = PQexec(conn_, "SELECT 1");
+    if (PQresultStatus(res) != PGRES_COMMAND_OK) {
+        // reset the connection; we do it here because the current interface
+        // of soci doesn’t allow us to to recreate it correctly
+        PQreset(conn_);
+    }
+
     return conn_ != nullptr && PQstatus(conn_) == CONNECTION_OK;
 }

--- a/core/lib/soci_postgresql/session.cpp
+++ b/core/lib/soci_postgresql/session.cpp
@@ -129,7 +129,7 @@ postgresql_blob_backend * postgresql_session_backend::make_blob_backend()
     return new postgresql_blob_backend(*this);
 }
 
-bool postgresql_session_backend::is_alive() const {
+bool postgresql_session_backend::isAlive() const {
     auto res = PQexec(conn_, "SELECT 1");
     if (PQresultStatus(res) != PGRES_COMMAND_OK) {
         // reset the connection; we do it here because the current interface

--- a/core/lib/soci_postgresql/session.cpp
+++ b/core/lib/soci_postgresql/session.cpp
@@ -128,3 +128,7 @@ postgresql_blob_backend * postgresql_session_backend::make_blob_backend()
 {
     return new postgresql_blob_backend(*this);
 }
+
+bool postgresql_session_backend::is_alive() const {
+    return conn_ != nullptr && PQstatus(conn_) == CONNECTION_OK;
+}

--- a/core/lib/soci_postgresql/soci-postgresql.h
+++ b/core/lib/soci_postgresql/soci-postgresql.h
@@ -330,7 +330,7 @@ struct postgresql_session_backend : details::session_backend
     virtual postgresql_rowid_backend * make_rowid_backend() override;
     virtual postgresql_blob_backend * make_blob_backend() override;
 
-    bool is_alive() const override;
+    bool isAlive() const override;
 
     std::string get_next_statement_name();
 

--- a/core/lib/soci_postgresql/soci-postgresql.h
+++ b/core/lib/soci_postgresql/soci-postgresql.h
@@ -310,22 +310,27 @@ struct postgresql_session_backend : details::session_backend
 
     ~postgresql_session_backend();
 
-    virtual void begin();
-    virtual void commit();
-    virtual void rollback();
+    virtual void begin() override;
+    virtual void commit() override;
+    virtual void rollback() override;
 
     void deallocate_prepared_statement(const std::string & statementName);
 
-    virtual bool get_next_sequence_value(session & s,
-        std::string const & sequence, long & value);
+    virtual bool get_next_sequence_value(
+        session & s,
+        std::string const & sequence,
+        long & value
+    ) override;
 
-    virtual std::string get_backend_name() const { return "postgresql"; }
+    virtual std::string get_backend_name() const override { return "postgresql"; }
 
     void clean_up();
 
-    virtual postgresql_statement_backend * make_statement_backend();
-    virtual postgresql_rowid_backend * make_rowid_backend();
-    virtual postgresql_blob_backend * make_blob_backend();
+    virtual postgresql_statement_backend * make_statement_backend() override;
+    virtual postgresql_rowid_backend * make_rowid_backend() override;
+    virtual postgresql_blob_backend * make_blob_backend() override;
+
+    bool is_alive() const override;
 
     std::string get_next_statement_name();
 

--- a/core/lib/soci_sqlite3/session.cpp
+++ b/core/lib/soci_sqlite3/session.cpp
@@ -65,7 +65,7 @@ namespace // anonymous
         res = sqlite3_busy_timeout(conn, timeout * 1000);
         check_sqlite_err(conn, res, "Failed to set busy timeout for connection. ");
     }
-    
+
     void sqlcipher_export(sqlite_api::sqlite3* conn,
                           int flags,
                           int timeout,
@@ -264,4 +264,8 @@ sqlite3_rowid_backend * sqlite3_session_backend::make_rowid_backend()
 sqlite3_blob_backend * sqlite3_session_backend::make_blob_backend()
 {
     return new sqlite3_blob_backend(*this);
+}
+
+bool sqlite3_session_backend::is_alive() const {
+    return true;
 }

--- a/core/lib/soci_sqlite3/session.cpp
+++ b/core/lib/soci_sqlite3/session.cpp
@@ -266,6 +266,6 @@ sqlite3_blob_backend * sqlite3_session_backend::make_blob_backend()
     return new sqlite3_blob_backend(*this);
 }
 
-bool sqlite3_session_backend::is_alive() const {
+bool sqlite3_session_backend::isAlive() const {
     return true;
 }

--- a/core/lib/soci_sqlite3/soci-sqlite3.h
+++ b/core/lib/soci_sqlite3/soci-sqlite3.h
@@ -266,6 +266,8 @@ struct sqlite3_session_backend : details::session_backend
     virtual sqlite3_rowid_backend * make_rowid_backend();
     virtual sqlite3_blob_backend * make_blob_backend();
 
+    virtual bool is_alive() const override;
+
     sqlite_api::sqlite3 *conn_;
 };
 

--- a/core/lib/soci_sqlite3/soci-sqlite3.h
+++ b/core/lib/soci_sqlite3/soci-sqlite3.h
@@ -253,20 +253,20 @@ struct sqlite3_session_backend : details::session_backend
 
     ~sqlite3_session_backend();
 
-    virtual void begin();
-    virtual void commit();
-    virtual void rollback();
+    virtual void begin() override;
+    virtual void commit() override;
+    virtual void rollback() override;
 
-    virtual std::string get_backend_name() const { return "sqlite3"; }
+    virtual std::string get_backend_name() const override { return "sqlite3"; }
 
     void post_connection(std::string const& dbname, int connection_flags, int timeout, std::string const& synchronous);
     void clean_up();
 
-    virtual sqlite3_statement_backend * make_statement_backend();
-    virtual sqlite3_rowid_backend * make_rowid_backend();
-    virtual sqlite3_blob_backend * make_blob_backend();
+    virtual sqlite3_statement_backend * make_statement_backend() override;
+    virtual sqlite3_rowid_backend * make_rowid_backend() override;
+    virtual sqlite3_blob_backend * make_blob_backend() override;
 
-    virtual bool is_alive() const override;
+    virtual bool isAlive() const override;
 
     sqlite_api::sqlite3 *conn_;
 };

--- a/core/src/api/DatabaseConnection.hpp
+++ b/core/src/api/DatabaseConnection.hpp
@@ -55,7 +55,7 @@ public:
     virtual std::shared_ptr<DatabaseBlob> newBlob() = 0;
 
     /** Check whether the connection is still alive. */
-    virtual bool is_alive() = 0;
+    virtual bool isAlive() = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/DatabaseConnection.hpp
+++ b/core/src/api/DatabaseConnection.hpp
@@ -53,6 +53,9 @@ public:
      * @return An empty blob
      */
     virtual std::shared_ptr<DatabaseBlob> newBlob() = 0;
+
+    /** Check whether the connection is still alive. */
+    virtual bool is_alive() = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/database/proxy_backend/session.cpp
+++ b/core/src/database/proxy_backend/session.cpp
@@ -72,3 +72,7 @@ proxy_rowid_backend *proxy_session_backend::make_rowid_backend() {
 proxy_blob_backend *proxy_session_backend::make_blob_backend() {
     return new proxy_blob_backend(_conn->newBlob());
 }
+
+bool proxy_session_backend::is_alive() const {
+    return _conn->is_alive();
+}

--- a/core/src/database/proxy_backend/session.cpp
+++ b/core/src/database/proxy_backend/session.cpp
@@ -73,6 +73,6 @@ proxy_blob_backend *proxy_session_backend::make_blob_backend() {
     return new proxy_blob_backend(_conn->newBlob());
 }
 
-bool proxy_session_backend::is_alive() const {
-    return _conn->is_alive();
+bool proxy_session_backend::isAlive() const {
+    return _conn->isAlive();
 }

--- a/core/src/database/proxy_backend/soci-proxy.h
+++ b/core/src/database/proxy_backend/soci-proxy.h
@@ -199,7 +199,7 @@ namespace soci
         proxy_rowid_backend* make_rowid_backend() SOCI_OVERRIDE;
         proxy_blob_backend* make_blob_backend() SOCI_OVERRIDE;
 
-        bool is_alive() const SOCI_OVERRIDE;
+        bool isAlive() const SOCI_OVERRIDE;
 
     private:
         std::shared_ptr<ledger::core::api::DatabaseConnection> _conn;

--- a/core/src/database/proxy_backend/soci-proxy.h
+++ b/core/src/database/proxy_backend/soci-proxy.h
@@ -199,6 +199,8 @@ namespace soci
         proxy_rowid_backend* make_rowid_backend() SOCI_OVERRIDE;
         proxy_blob_backend* make_blob_backend() SOCI_OVERRIDE;
 
+        bool is_alive() const SOCI_OVERRIDE;
+
     private:
         std::shared_ptr<ledger::core::api::DatabaseConnection> _conn;
     };

--- a/core/src/jni/jni/DatabaseConnection.cpp
+++ b/core/src/jni/jni/DatabaseConnection.cpp
@@ -62,5 +62,13 @@ std::shared_ptr<::ledger::core::api::DatabaseBlob> DatabaseConnection::JavaProxy
     ::djinni::jniExceptionCheck(jniEnv);
     return ::djinni_generated::DatabaseBlob::toCpp(jniEnv, jret);
 }
+bool DatabaseConnection::JavaProxy::is_alive() {
+    auto jniEnv = ::djinni::jniGetThreadEnv();
+    ::djinni::JniLocalScope jscope(jniEnv, 10);
+    const auto& data = ::djinni::JniClass<::djinni_generated::DatabaseConnection>::get();
+    auto jret = jniEnv->CallBooleanMethod(Handle::get().get(), data.method_isAlive);
+    ::djinni::jniExceptionCheck(jniEnv);
+    return ::djinni::Bool::toCpp(jniEnv, jret);
+}
 
 }  // namespace djinni_generated

--- a/core/src/jni/jni/DatabaseConnection.cpp
+++ b/core/src/jni/jni/DatabaseConnection.cpp
@@ -62,7 +62,7 @@ std::shared_ptr<::ledger::core::api::DatabaseBlob> DatabaseConnection::JavaProxy
     ::djinni::jniExceptionCheck(jniEnv);
     return ::djinni_generated::DatabaseBlob::toCpp(jniEnv, jret);
 }
-bool DatabaseConnection::JavaProxy::is_alive() {
+bool DatabaseConnection::JavaProxy::isAlive() {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::DatabaseConnection>::get();

--- a/core/src/jni/jni/DatabaseConnection.hpp
+++ b/core/src/jni/jni/DatabaseConnection.hpp
@@ -40,7 +40,7 @@ private:
         void commit() override;
         void close() override;
         std::shared_ptr<::ledger::core::api::DatabaseBlob> newBlob() override;
-        bool is_alive() override;
+        bool isAlive() override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::DatabaseConnection, ::djinni_generated::DatabaseConnection>;

--- a/core/src/jni/jni/DatabaseConnection.hpp
+++ b/core/src/jni/jni/DatabaseConnection.hpp
@@ -40,6 +40,7 @@ private:
         void commit() override;
         void close() override;
         std::shared_ptr<::ledger::core::api::DatabaseBlob> newBlob() override;
+        bool is_alive() override;
 
     private:
         friend ::djinni::JniInterface<::ledger::core::api::DatabaseConnection, ::djinni_generated::DatabaseConnection>;
@@ -52,6 +53,7 @@ private:
     const jmethodID method_commit { ::djinni::jniGetMethodID(clazz.get(), "commit", "()V") };
     const jmethodID method_close { ::djinni::jniGetMethodID(clazz.get(), "close", "()V") };
     const jmethodID method_newBlob { ::djinni::jniGetMethodID(clazz.get(), "newBlob", "()Lco/ledger/core/DatabaseBlob;") };
+    const jmethodID method_isAlive { ::djinni::jniGetMethodID(clazz.get(), "isAlive", "()Z") };
 };
 
 }  // namespace djinni_generated

--- a/core/test/database/MemoryDatabaseProxy.cpp
+++ b/core/test/database/MemoryDatabaseProxy.cpp
@@ -334,7 +334,7 @@ private:
 class Connection : public api::DatabaseConnection {
 public:
     Connection(sqlite3* db, const std::string &dbName) : _db(db), _dbName(dbName) {};
-    
+
     std::shared_ptr<api::DatabaseStatement> prepareStatement(const std::string &query, bool repeatable) override {
         return std::make_shared<Statement>(_db, query);
     };
@@ -383,6 +383,10 @@ public:
             check_sqlite_err(_db, res, "Failed to encrypt database. ");
         }
     };
+
+    bool isAlive() override {
+        return true;
+    }
 
 private:
     sqlite3* _db;

--- a/core/test/database/MemoryDatabaseProxy.h
+++ b/core/test/database/MemoryDatabaseProxy.h
@@ -45,5 +45,4 @@ private:
     std::shared_ptr<ConnectionPool> _pool;
 };
 
-
 #endif //LEDGER_CORE_MEMORYDATABASEPROXY_H


### PR DESCRIPTION
With the current version of soci, when a `connection_pool` is created, a
buffer is allocated with, for each element in the buffer, a pair `(bool,
session*)`. The boolean value indicates whether the session is free or
not (this is pretty bad way to encode a pool, but whatever). When a
session is freed, the boolean gets changed and then opening a new
session will reuse that slot.

However, when a session has been idleing for a while, it’s possible that
the database backend (e.g. PostgreSQL) kills the connection held in the
session for timeout. The `soci` library doesn’t see that and assumes the
session is still valid -> we hit errors, which get propagated as
`std::runtime_error` in our codebase.

This commit fixes the problem by introducing a `is_alive()` function on
the session that allows a database backend to execute some logic to
check the status of the session before using it. SQLite3 doesn’t drop
sessions (no timeout) but PostgreSQL does), so we can implement that
logic in the PostgreSQL backend.

It should be fix LVS-92.