### PR TITLE
Fix CMake exports so that we don’t export non-existing targets.

### DIFF
--- a/ledger-core/CMakeLists.txt
+++ b/ledger-core/CMakeLists.txt
@@ -91,7 +91,6 @@ install(
         ledger-core-interface
         bigd
         fmt
-        crypto
         blake
         soci_sqlite3
         soci_core_static
@@ -99,18 +98,49 @@ install(
         spdlog
         sqlcipher
         ethash
-        ledger-test
-        ledger-qt-host
-        ledger-core-integration-test
-        mongoose
-        ssl
-        gtest
-        gtest_main
     EXPORT ledger-core
     ARCHIVE       DESTINATION lib/ledger-core
     LIBRARY       DESTINATION lib/ledger-core
     FRAMEWORK     DESTINATION lib/ledger-core
 )
+
+if(BUILD_TESTS)
+    install(
+        TARGETS
+            ledger-test
+            ledger-qt-host
+            ledger-core-integration-test
+            mongoose
+            gtest
+            gtest_main
+        EXPORT ledger-core
+        ARCHIVE       DESTINATION lib/ledger-core
+        LIBRARY       DESTINATION lib/ledger-core
+        FRAMEWORK     DESTINATION lib/ledger-core
+    )
+endif()
+
+if(NOT SYS_OPENSSL)
+    install(
+        TARGETS
+            crypto
+        EXPORT ledger-core
+        ARCHIVE       DESTINATION lib/ledger-core
+        LIBRARY       DESTINATION lib/ledger-core
+        FRAMEWORK     DESTINATION lib/ledger-core
+    )
+
+    if (SSL_SUPPORT)
+        install(
+            TARGETS
+                ssl
+            EXPORT ledger-core
+            ARCHIVE       DESTINATION lib/ledger-core
+            LIBRARY       DESTINATION lib/ledger-core
+            FRAMEWORK     DESTINATION lib/ledger-core
+        )
+    endif()
+endif()
 
 if(PG_SUPPORT)
     install(

--- a/ledger-core/ledger-core-config.cmake
+++ b/ledger-core/ledger-core-config.cmake
@@ -1,6 +1,13 @@
 include(CMakeFindDependencyMacro)
-find_dependency(Qt5 COMPONENTS Core Widgets Network Gui Concurrent WebSockets)
+
+if (BUILD_TESTS)
+    find_dependency(Qt5 COMPONENTS Core Widgets Network Gui Concurrent WebSockets)
+endif()
 find_dependency(Threads)
+
+if (SYS_OPENSSL)
+    find_dependency(OpenSSL)
+endif()
 
 get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
 include(${SELF_DIR}/ledger-core.cmake)


### PR DESCRIPTION
# Content

This PR moves _targets_ around so that we don’t include them if we’re not making them in the first place.

# Mandatory picture of an animal

![](https://phaazon.net/media/uploads/clapotter.gif)