### PR TITLE
Fix LedgerApiEthereumLikeBlockchainExplorerTests::PostEstimatedGasLimit.

### DIFF
--- a/core/test/integration/ledger_api_blockchain_explorer_tests.cpp
+++ b/core/test/integration/ledger_api_blockchain_explorer_tests.cpp
@@ -174,11 +174,13 @@ TEST_F(LedgerApiEthereumLikeBlockchainExplorerTests, GetEstimatedGasLimit) {
 
 TEST_F(LedgerApiEthereumLikeBlockchainExplorerTests, PostEstimatedGasLimit) {
   auto request = api::EthereumGasLimitRequest(
-      optional<std::string>(), optional<std::string>(), optional<std::string>(),
-      "0xa9059cbb00000000000000000000000013C5d95f25688f8A"
-      "7544582D9e311f201A56de6300000000000000000000000000"
-      "00000000000000000000000000000000000000",
-      optional<std::string>(), optional<std::string>(), 1.5);
+      optional<std::string>(),
+      optional<std::string>(),
+      optional<std::string>(),
+      std::string("0xa9059cbb00000000000000000000000013C5d95f25688f8A7544582D9e311f201A56de630000000000000000000000000000000000000000000000000000000000000000"),
+      optional<std::string>(),
+      optional<std::string>(),
+      1.5);
   auto result = wait(explorer->getDryRunGasLimit(
       "0x57e8ba2a915285f984988282ab9346c1336a4e11", request));
   EXPECT_GE(result->toUint64(), 10000);


### PR DESCRIPTION
`std::optional<T>` has a non-explicit constructor that authorizes to build
the optional with a `T const &`, but it cannot be transitive (i.e. the
original code tried to do `char const * -> std::string const & ->
optional`.