### PR TITLE
Add missing explorer tests

### DIFF
--- a/ledger-core-bitcoin/test/ExplorerTests.cpp
+++ b/ledger-core-bitcoin/test/ExplorerTests.cpp
@@ -1,7 +1,7 @@
 /*
  *
  * ExplorerTests
- * 
+ *
  * ledger-core-bitcoin
  *
  * Created by Alexis Le Provost on 04/02/2020.
@@ -36,35 +36,7 @@
 #include <bitcoin/api/BitcoinLikeNetworkParameters.hpp>
 #include <bitcoin/explorers/LedgerApiBitcoinLikeBlockchainExplorer.hpp>
 
-#include <integration/BaseFixture.hpp>
-
-template <typename CurrencyExplorer, typename NetworkParameters>
-class ExplorerFixture : public BaseFixture {
-public:
-    void SetUp() override {
-        BaseFixture::SetUp();
-       
-        auto worker = dispatcher->getSerialExecutionContext("worker");
-        auto client = std::make_shared<HttpClient>(explorerEndpoint, http, worker);
-        explorer = std::make_shared<CurrencyExplorer>(worker, client, params, api::DynamicObject::newInstance());
-        logger = ledger::core::logger::create("test_logs",
-                                              dispatcher->getSerialExecutionContext("logger"),
-                                              resolver,
-                                              printer,
-                                              2000000000
-        );
-    }
-
-    void TearDown() override {
-        logger.reset();
-        explorer.reset();
-    }
-
-    NetworkParameters params;
-    std::string explorerEndpoint;
-    std::shared_ptr<spdlog::logger> logger;
-    std::shared_ptr<CurrencyExplorer> explorer;
-};
+#include <integration/ExplorerFixture.hpp>
 
 class BitcoinExplorers : public ExplorerFixture<LedgerApiBitcoinLikeBlockchainExplorer, api::BitcoinLikeNetworkParameters> {
 public:
@@ -90,7 +62,7 @@ TEST_F(BitcoinExplorers, GetRawTransaction) {
 TEST_F(BitcoinExplorers, GetTransactionByHash) {
     auto transaction = wait(explorer->getTransactionByHash("9fdbe15a16fe282291426df15894ab1473e252bc31f244e4d923a17e11743eda"));
     auto &explorerTransaction = *transaction.get();
-    
+
     EXPECT_EQ(explorerTransaction.inputs.size(), 1);
     EXPECT_EQ(explorerTransaction.hash, "9fdbe15a16fe282291426df15894ab1473e252bc31f244e4d923a17e11743eda");
     EXPECT_EQ(explorerTransaction.inputs[0].value.getValue().toString(), "1634001");

--- a/ledger-core-ethereum/test/CMakeLists.txt
+++ b/ledger-core-ethereum/test/CMakeLists.txt
@@ -9,14 +9,15 @@ if (APPLE)
     add_definitions(-D__GLIBCXX__)
 endif (APPLE)
 
-add_executable(ledger-core-ethereum-tests 
-    main.cpp 
+add_executable(ledger-core-ethereum-tests
+    main.cpp
     Fixtures.cpp
     WalletTests.cpp
-    KeychainTests.cpp 
-    SynchronizationTests.cpp 
+    KeychainTests.cpp
+    SynchronizationTests.cpp
     TransactionTests.cpp
     AccountTests.cpp
+    ExplorerTests.cpp
 )
 
 target_link_libraries(ledger-core-ethereum-tests Core::ledger-core-static)
@@ -35,3 +36,4 @@ add_test(NAME Ethereum-transaction COMMAND ledger-core-ethereum-tests --gtest_fi
 add_test(NAME Ethereum-keychain COMMAND ledger-core-ethereum-tests --gtest_filter=EthereumKeychains.*)
 add_test(NAME Ethereum-synchronization COMMAND ledger-core-ethereum-tests --gtest_filter=EthereumLikeWalletSynchronization.*)
 add_test(NAME Ethereum-account COMMAND ledger-core-ethereum-tests --gtest_filter=EthereumAccounts.*)
+add_test(NAME Ethereum-explorer COMMAND ledger-core-ethereum-tests --gtest_filter=EthereumExplorers.*)

--- a/ledger-core-ethereum/test/ExplorerTests.cpp
+++ b/ledger-core-ethereum/test/ExplorerTests.cpp
@@ -1,0 +1,57 @@
+/*
+ *
+ * ExplorerTests
+ *
+ * ledger-core-ethereum
+ *
+ * Created by Alexis Le Provost on 04/02/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <ethereum/EthereumNetworks.hpp>
+#include <ethereum/api/EthereumLikeNetworkParameters.hpp>
+#include <ethereum/explorers/LedgerApiEthereumLikeBlockchainExplorer.hpp>
+
+#include <integration/ExplorerFixture.hpp>
+
+class EthereumExplorers : public ExplorerFixture<LedgerApiEthereumLikeBlockchainExplorer, api::EthereumLikeNetworkParameters> {
+public:
+    EthereumExplorers() {
+        params = networks::getEthereumLikeNetworkParameters("ethereum_ropsten");
+        explorerEndpoint = "http://eth-ropsten.explorers.dev.aws.ledger.fr";
+    }
+};
+
+TEST_F(EthereumExplorers, GetGasPrice) {
+    auto result = wait(explorer->getGasPrice());
+    EXPECT_NE(result->toUint64(), 0);
+}
+
+TEST_F(EthereumExplorers, GetEstimatedGasLimit) {
+    auto result = wait(explorer->getEstimatedGasLimit("0x57e8ba2a915285f984988282ab9346c1336a4e11"));
+    EXPECT_GE(result->toUint64(), 10000);
+}

--- a/ledger-core/test/integration/ExplorerFixture.hpp
+++ b/ledger-core/test/integration/ExplorerFixture.hpp
@@ -1,0 +1,63 @@
+/*
+ *
+ * ExplorerFixture
+ *
+ * ledger-core
+ *
+ * Created by Alexis Le Provost on 04/02/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <integration/BaseFixture.hpp>
+
+template <typename CurrencyExplorer, typename NetworkParameters>
+class ExplorerFixture : public BaseFixture {
+public:
+    void SetUp() override {
+        BaseFixture::SetUp();
+
+        auto worker = dispatcher->getSerialExecutionContext("worker");
+        auto client = std::make_shared<HttpClient>(explorerEndpoint, http, worker);
+        explorer = std::make_shared<CurrencyExplorer>(worker, client, params, api::DynamicObject::newInstance());
+        logger = ledger::core::logger::create("test_logs",
+                                              dispatcher->getSerialExecutionContext("logger"),
+                                              resolver,
+                                              printer,
+                                              2000000000
+        );
+    }
+
+    void TearDown() override {
+        logger.reset();
+        explorer.reset();
+    }
+
+    NetworkParameters params;
+    std::string explorerEndpoint;
+    std::shared_ptr<spdlog::logger> logger;
+    std::shared_ptr<CurrencyExplorer> explorer;
+};


### PR DESCRIPTION
This PR includes missing explorer tests (basically linked to ethereum) and implement a `ExplorerFixture` class which is used in bitcoin and ethereum tests.
We need to merge this PR as soon as possible to unlock the backport of the PR #429.

## Mandatory picture of a cat
![magic_cat](https://user-images.githubusercontent.com/6042495/76538005-e6db2580-647e-11ea-8379-e7ce56d2755a.gif)
