### PR TITLE
Use static MS runtime

### DIFF
--- a/.circleci/cmake-install.sh
+++ b/.circleci/cmake-install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 echo "========> Install CMake"
 cd $HOME
-wget --quiet https://github.com/Kitware/CMake/releases/download/v3.13.3/cmake-3.13.3-Linux-x86_64.tar.gz && tar -xf cmake-3.13.3-Linux-x86_64.tar.gz
-ln -s cmake-3.13.3-Linux-x86_64 cmake_folder
+wget --quiet https://github.com/Kitware/CMake/releases/download/v3.16.5/cmake-3.16.5-Linux-x86_64.tar.gz && tar -xf cmake-3.16.5-Linux-x86_64.tar.gz
+ln -s cmake-3.16.5-Linux-x86_64 cmake_folder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 general:
 dependencies:
   cache_directories:
-    - ~/cmake-3.12.3
+    - ~/cmake-3.16.5
 jobs:
   build_linux_release:
     environment:
@@ -138,7 +138,7 @@ jobs:
             command: |
                 cd ../lib-ledger-core-build
 
-                ~/cmake-3.13.3-Linux-x86_64/bin/ctest -VV -timeout 60
+                ~/cmake-3.16.5-Linux-x86_64/bin/ctest -VV -timeout 60
   build_macos_release:
     macos:
       xcode: "10.0.0"

--- a/.circleci/setup_debian.sh
+++ b/.circleci/setup_debian.sh
@@ -18,16 +18,16 @@ ls -la /usr/lib/jvm/java-8-openjdk || echo "!!!! java openjdk not found"
 
 if [ "$BUILD_CONFIG" == "Release" ]; then
     apt-get install -y awscli
-	echo "========> Install sbt"
-	curl -L -o sbt-1.2.8.deb https://dl.bintray.com/sbt/debian/sbt-1.2.8.deb
-	dpkg -i sbt-1.2.8.deb
-	rm sbt-1.2.8.deb
-	sbt sbtVersion
+    echo "========> Install sbt"
+    curl -L -o sbt-1.2.8.deb https://dl.bintray.com/sbt/debian/sbt-1.2.8.deb
+    dpkg -i sbt-1.2.8.deb
+    rm sbt-1.2.8.deb
+    sbt sbtVersion
 fi
 
 echo "========> Install C++ dependencies"
 apt-get install -y g++ make
-export PATH=$HOME/cmake-3.12.3/bin:$PATH
+export PATH=$HOME/cmake-3.16.5/bin:$PATH
 
 if [ "$BUILD_CONFIG" == "Debug" ]; then
     echo "========> Install Qt5"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
+cmake_policy(SET CMP0091 NEW) # allow MSVC_RUNTIME_LIBRARY property
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 project(ledger-core)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -7,6 +9,7 @@ option(BUILD_TESTS "Indicates wheter or not the toolchain must build the test or
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(UseBackportedModules)
+
 
 # The project version number.
 set(VERSION_MAJOR   3   CACHE STRING "Project major version number.")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ install:
 - mkdir C:\projects\deps
 - cd C:\projects\deps
 - if not exist "%CMAKE_DIR%" (
-    set CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-win64-x64.zip"
+    set CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.16.5/cmake-3.16.5-win64-x64.zip"
     appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
     7z x cmake.zip -oC:\projects\deps > nul
     move C:\projects\deps\cmake-* C:\projects\deps\cmake

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -91,6 +91,7 @@ else()
             ${SRC_FILES}
             ${HEADERS_FILES})
     target_link_libraries(ledger-core-obj PUBLIC ledger-core-interface)
+
     # shared and static libraries built from the same object files
     add_library(ledger-core SHARED)
     target_link_libraries(ledger-core PUBLIC ledger-core-obj)


### PR DESCRIPTION
Update CMake and enable https://cmake.org/cmake/help/v3.15/policy/CMP0091.html#policy:CMP0091 to compile all subprojects with static MS runtime