### PR TITLE
Revert "Use static MS runtime"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,4 @@
 cmake_minimum_required(VERSION 3.15)
-cmake_policy(SET CMP0091 NEW) # allow MSVC_RUNTIME_LIBRARY property
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 project(ledger-core)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
This reverts commit 97d983ccb9a7f44ee8a1415785ef204292099ad7.

Keep using newer version of CMake, but revert compilation
with static MS runtime.
With Live team we decided, to include VS redistributable inside the installer,
to make another native modules, that depends on runtime works the same way as before
Electron 6