### PR TITLE
Fix undefined reference to dl on ubuntu

### DIFF
--- a/ledger-core/lib/soci/core/CMakeLists.txt
+++ b/ledger-core/lib/soci/core/CMakeLists.txt
@@ -111,6 +111,10 @@ if (SOCI_STATIC)
 
   add_library(${SOCI_CORE_TARGET_STATIC} STATIC ${SOCI_CORE_HEADERS} ${SOCI_CORE_SOURCES})
 
+  if(UNIX)
+    target_link_libraries(${SOCI_CORE_TARGET_STATIC} ${CMAKE_DL_LIBS})
+  endif()
+
   set_target_properties(${SOCI_CORE_TARGET_STATIC}
     PROPERTIES
     OUTPUT_NAME ${SOCI_CORE_TARGET_OUTPUT_NAME}


### PR DESCRIPTION
This PR is quite simple : link `dl` library to `soci-core`.

## Mandatory picture of a cat
![black_cat](https://user-images.githubusercontent.com/6042495/77531740-b4c0bf00-6e93-11ea-8b18-e263b85aec5e.gif)
