### PR TITLE
Add compiler warnings

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,0 +1,83 @@
+function(enable_warnings target_name)
+    option(ENABLE_WARNINGS "Enable compiler warnings" OFF)
+
+    if (ENABLE_WARNINGS)
+        set(MSVC_WARNINGS
+            /W4 # Baseline reasonable warnings
+            /w14242 # 'identfier': conversion from 'type1' to 'type1', possible loss of data
+            /w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss
+                    # of data
+            /w14263 # 'function': member function does not override any base class virtual member function
+            /w14265 # 'classname': class has virtual functions, but destructor is not virtual instances of
+                    # this class may not be destructed correctly
+            /w14287 # 'operator': unsigned/negative constant mismatch
+            /we4289 # nonstandard extension used: 'variable': loop control variable declared in the for-
+                    # loop is used outside the for-loop scope
+            /w14296 # 'operator': expression is always 'boolean_value'
+            /w14311 # 'variable': pointer truncation from 'type1' to 'type2'
+            /w14545 # expression before comma evaluates to a function which is missing an argument list
+            /w14546 # function call before comma missing argument list
+            /w14547 # 'operator': operator before comma has no effect; expected operator with side-effect
+            /w14549 # 'operator': operator before comma has no effect; did you intend 'operator'?
+            /w14555 # expression has no effect; expected expression with side- effect
+            /w14619 # pragma warning: there is no warning number 'number'
+            /w14640 # Enable warning on thread un-safe static member initialization
+            /w14826 # Conversion from 'type1' to 'type_2' is sign-extended. This may cause unexpected
+                    # runtime behavior.
+            /w14905 # wide string literal cast to 'LPSTR'
+            /w14906 # string literal cast to 'LPWSTR'
+            /w14928 # illegal copy-initialization; more than one user-defined conversion has been
+                    # implicitly applied
+        )
+
+        set(CLANG_WARNINGS
+            -Wall
+            -Wextra # reasonable and standard
+            -Wshadow # warn the user if a variable declaration shadows one from a parent context
+            -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual
+                                # destructor. This helps catch hard to track down memory errors
+            -Wold-style-cast # warn for c-style casts
+            -Wcast-align # warn for potential performance problem casts
+            -Wunused # warn on anything being unused
+            -Woverloaded-virtual # warn if you overload (not override) a virtual function
+            -Wpedantic # warn if non-standard C++ is used
+            -Wconversion # warn on type conversions that may lose data
+            -Wsign-conversion # warn on sign conversions
+            -Wnull-dereference # warn if a null dereference is detected
+            -Wdouble-promotion # warn if float is implicit promoted to double
+            -Wformat=2 # warn on security issues around functions that format output (ie printf)
+        )
+        
+        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+            set(CLANG_WARNINGS ${CLANG_WARNINGS} -O0 -g)
+            set(MSVC_WARNINGS ${MSVC_WARNINGS} /Od)
+        elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+            set(CLANG_WARNINGS ${CLANG_WARNINGS} -O3 -g)
+            set(MSVC_WARNINGS ${MSVC_WARNINGS} /O2d)
+        elseif(CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+            set(CLANG_WARNINGS ${CLANG_WARNINGS} -Os)
+            set(MSVC_WARNINGS ${MSVC_WARNINGS} /O1)
+        else()
+            set(CLANG_WARNINGS ${CLANG_WARNINGS} -O3)
+            set(MSVC_WARNINGS ${MSVC_WARNINGS} /O2)
+        endif()
+
+        set(GCC_WARNINGS
+            ${CLANG_WARNINGS}
+            -Wmisleading-indentation # warn if identation implies blocks where blocks do not exist
+            -Wduplicated-cond # warn if if / else chain has duplicated conditions
+            -Wduplicated-branches # warn if if / else branches have duplicated code
+            -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
+            -Wuseless-cast # warn if you perform a cast to the same type
+        )
+
+        target_compile_options(
+            ${target_name}
+            INTERFACE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
+                    ${CLANG_WARNINGS}>
+                    $<$<CXX_COMPILER_ID:MSVC>:
+                    ${MSVC_WARNINGS}>
+                    $<$<CXX_COMPILER_ID:GNU>:
+                    ${GCC_WARNINGS}>)
+    endif()
+endfunction()

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,15 +1,16 @@
-function(enable_warnings target_name)
+function(toggle_compiler_warnings target_name)
     option(ENABLE_WARNINGS "Enable compiler warnings" OFF)
+    option(WARNINGS_AS_ERRORS "Treat warnings as erros" OFF)
 
-    if (ENABLE_WARNINGS)
+    if(ENABLE_WARNINGS)
         set(MSVC_WARNINGS
             /W4 # Baseline reasonable warnings
-            /w14242 # 'identfier': conversion from 'type1' to 'type1', possible loss of data
+            /w14242 # 'identifier': conversion from 'type1' to 'type1', possible loss of data
             /w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss
                     # of data
-            /w14263 # 'function': member function does not override any base class virtual member function
-            /w14265 # 'classname': class has virtual functions, but destructor is not virtual instances of
-                    # this class may not be destructed correctly
+            /w14263 # 'function': member function does not override any virtual member function of base class
+            /w14265 # 'classname': class has virtual functions, but destructor is not a virtual instance of
+                    # this class; it may not be destructed correctly
             /w14287 # 'operator': unsigned/negative constant mismatch
             /we4289 # nonstandard extension used: 'variable': loop control variable declared in the for-
                     # loop is used outside the for-loop scope
@@ -38,16 +39,20 @@ function(enable_warnings target_name)
                                 # destructor. This helps catch hard to track down memory errors
             -Wold-style-cast # warn for c-style casts
             -Wcast-align # warn for potential performance problem casts
-            -Wunused # warn on anything being unused
             -Woverloaded-virtual # warn if you overload (not override) a virtual function
             -Wpedantic # warn if non-standard C++ is used
             -Wconversion # warn on type conversions that may lose data
-            -Wsign-conversion # warn on sign conversions
             -Wnull-dereference # warn if a null dereference is detected
             -Wdouble-promotion # warn if float is implicit promoted to double
             -Wformat=2 # warn on security issues around functions that format output (ie printf)
         )
         
+        if(WARNINGS_AS_ERRORS)
+            message("Treat compiler warnings as errors")
+            set(CLANG_WARNINGS ${CLANG_WARNINGS} -Werror)
+            set(MSVC_WARNINGS ${MSVC_WARNINGS} /WX)
+        endif()
+
         if(CMAKE_BUILD_TYPE STREQUAL "Debug")
             set(CLANG_WARNINGS ${CLANG_WARNINGS} -O0 -g)
             set(MSVC_WARNINGS ${MSVC_WARNINGS} /Od)
@@ -64,7 +69,6 @@ function(enable_warnings target_name)
 
         set(GCC_WARNINGS
             ${CLANG_WARNINGS}
-            -Wmisleading-indentation # warn if identation implies blocks where blocks do not exist
             -Wduplicated-cond # warn if if / else chain has duplicated conditions
             -Wduplicated-branches # warn if if / else branches have duplicated code
             -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
@@ -72,12 +76,18 @@ function(enable_warnings target_name)
         )
 
         target_compile_options(
-            ${target_name}
-            INTERFACE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
-                    ${CLANG_WARNINGS}>
-                    $<$<CXX_COMPILER_ID:MSVC>:
-                    ${MSVC_WARNINGS}>
-                    $<$<CXX_COMPILER_ID:GNU>:
-                    ${GCC_WARNINGS}>)
+            ${target_name} PRIVATE
+              $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>: ${CLANG_WARNINGS}>
+              $<$<CXX_COMPILER_ID:MSVC>: ${MSVC_WARNINGS}>
+              $<$<CXX_COMPILER_ID:GNU>: ${GCC_WARNINGS}>)
     endif()
+endfunction()
+
+function(disable_compiler_warnings target_name)
+    target_compile_options(
+        ${target_name} PRIVATE
+            $<$<CXX_COMPILER_ID:MSVC>: /w>
+            $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>: -Wno-everything>
+            $<$<CXX_COMPILER_ID:GNU>: -w>
+    )
 endfunction()

--- a/ledger-core-bitcoin/src/CMakeLists.txt
+++ b/ledger-core-bitcoin/src/CMakeLists.txt
@@ -96,6 +96,11 @@ else()
     include(StaticAnalyzers)
     set_enabled_static_analyzers(ledger-core-bitcoin-obj)
 
+    # set compiler warnings
+    include(CompilerWarnings)
+    toggle_compiler_warnings(ledger-core-bitcoin-obj)
+    disable_compiler_warnings(ledger-core-bitcoin-api-obj)
+
     # shared and static libraries built from the same object files
     add_library(ledger-core-bitcoin SHARED)
     target_link_libraries(ledger-core-bitcoin PUBLIC ledger-core-bitcoin-obj ledger-core-bitcoin-api-obj)

--- a/ledger-core-ethereum/src/CMakeLists.txt
+++ b/ledger-core-ethereum/src/CMakeLists.txt
@@ -96,6 +96,11 @@ else()
     include(StaticAnalyzers)
     set_enabled_static_analyzers(ledger-core-ethereum-obj)
 
+    # set compiler warnings
+    include(CompilerWarnings)
+    toggle_compiler_warnings(ledger-core-ethereum-obj)
+    disable_compiler_warnings(ledger-core-ethereum-api-obj)
+
     # shared and static libraries built from the same object files
     add_library(ledger-core-ethereum SHARED)
     target_link_libraries(ledger-core-ethereum PUBLIC ledger-core-ethereum-obj ledger-core-ethereum-api-obj)

--- a/ledger-core-ripple/src/CMakeLists.txt
+++ b/ledger-core-ripple/src/CMakeLists.txt
@@ -96,6 +96,11 @@ else()
     include(StaticAnalyzers)
     set_enabled_static_analyzers(ledger-core-ripple-obj)
 
+    # set compiler warnings
+    include(CompilerWarnings)
+    toggle_compiler_warnings(ledger-core-ripple-obj)
+    disable_compiler_warnings(ledger-core-ripple-api-obj)
+
     # shared and static libraries built from the same object files
     add_library(ledger-core-ripple SHARED)
     target_link_libraries(ledger-core-ripple PUBLIC ledger-core-ripple-obj ledger-core-ripple-api-obj)

--- a/ledger-core-tezos/src/CMakeLists.txt
+++ b/ledger-core-tezos/src/CMakeLists.txt
@@ -97,6 +97,11 @@ else()
     include(StaticAnalyzers)
     set_enabled_static_analyzers(ledger-core-tezos-obj)
 
+    # set compiler warnings
+    include(CompilerWarnings)
+    toggle_compiler_warnings(ledger-core-tezos-obj)
+    disable_compiler_warnings(ledger-core-tezos-api-obj)
+
     # shared and static libraries built from the same object files
     add_library(ledger-core-tezos SHARED)
     target_link_libraries(ledger-core-tezos PUBLIC ledger-core-tezos-obj ledger-core-tezos-api-obj)

--- a/ledger-core/src/CMakeLists.txt
+++ b/ledger-core/src/CMakeLists.txt
@@ -31,8 +31,6 @@ if (TARGET_JNI)
     add_definitions(-DTARGET_JNI=1)
 endif ()
 
-link_directories(${CMAKE_BINARY_DIR}/lib)
-
 # Add files to compile to the project
 file(GLOB_RECURSE SRC_FILES *.cpp)
 file(GLOB_RECURSE HEADERS_FILES ../inc/*.hpp)
@@ -102,6 +100,11 @@ else()
     include(StaticAnalyzers)
     set_enabled_static_analyzers(ledger-core-obj)
 
+    # set compiler warnings
+    include(CompilerWarnings)
+    toggle_compiler_warnings(ledger-core-obj)
+    disable_compiler_warnings(ledger-core-api-obj)
+
     # shared and static libraries built from the same object files
     add_library(ledger-core SHARED)
     target_link_libraries(ledger-core PUBLIC ledger-core-obj ledger-core-api-obj)
@@ -163,7 +166,7 @@ target_link_libraries(ledger-core-interface INTERFACE ethash)
 target_link_libraries(ledger-core-interface INTERFACE ${SQLITE_LIB})
 
 target_include_directories(
-    ledger-core-interface INTERFACE
+    ledger-core-interface SYSTEM INTERFACE
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/inc>                      $<INSTALL_INTERFACE:include/ledger-core>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/bigd>                 $<INSTALL_INTERFACE:include/ledger-core/lib/bigd>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/rapidjson/include>    $<INSTALL_INTERFACE:include/ledger-core/lib/rapidjson/include>


### PR DESCRIPTION
The PR aims to enable a bunch of compiler warnings for `MSVC`, `Clang`, `AppleClang` and `Gcc`.

The compilation of `lib-ledger-core` - more precisely `ledger-core` and all the coins - triggers a lot of warnings so the compiler warnings feature is optional  and disable by default.

Compiler warnings can be enabled such as :
```
cmake -DENABLE_WARNINGS=ON -DWARNINGS_AS_ERRORS=ON ...
```

## Mandatory picture of an animal
![hole_cat](https://user-images.githubusercontent.com/6042495/77652366-63d1c900-6f6e-11ea-9237-3adbde50dc3c.gif)