### PR TITLE
Add ccache support and project settings

### DIFF
--- a/cmake/ProjectSettings.cmake
+++ b/cmake/ProjectSettings.cmake
@@ -1,0 +1,44 @@
+
+macro(set_project_settings version)
+
+# Set a default build type if none was specified
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to 'RelWithDebInfo' as none was specified.")
+
+  set(CMAKE_BUILD_TYPE
+      RelWithDebInfo
+      CACHE STRING "Select build type" FORCE)
+
+  # Set the possible values of build type for cmake-gui and cmake
+  set_property(
+    CACHE CMAKE_BUILD_TYPE
+    PROPERTY STRINGS
+             "Debug"
+             "Release"
+             "MinSizeRel"
+             "RelWithDebInfo")
+endif()
+
+string(REPLACE "." ";" VERSION ${version})
+list(GET VERSION 0 VERSION_MAJOR)
+list(GET VERSION 1 VERSION_MINOR)
+list(GET VERSION 2 VERSION_PATCH)
+
+# the project version number.
+set(VERSION_MAJOR ${VERSION_MAJOR} CACHE STRING "Project major version number.")
+set(VERSION_MINOR ${VERSION_MINOR} CACHE STRING "Project minor version number.")
+set(VERSION_PATCH ${VERSION_PATCH} CACHE STRING "Project patch version number.")
+mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
+
+# C++ version and standard
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_program(CCACHE ccache)
+if(CCACHE)
+  message(STATUS "Using ccache")
+  set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE})
+else()
+  message(STATUS "ccache not found")
+endif() 
+endmacro()

--- a/ledger-core-bitcoin/CMakeLists.txt
+++ b/ledger-core-bitcoin/CMakeLists.txt
@@ -8,15 +8,8 @@ option(BUILD_TESTS "Indicates whether or not the toolchain must build the test o
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(UseBackportedModules)
 
-# The project version number.
-set(VERSION_MAJOR   0   CACHE STRING "Project major version number.")
-set(VERSION_MINOR   1   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
-mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
-
-# C++ version and standard
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+include(ProjectSettings)
+set_project_settings(0.1.0)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)
 

--- a/ledger-core-ethereum/CMakeLists.txt
+++ b/ledger-core-ethereum/CMakeLists.txt
@@ -8,15 +8,8 @@ option(BUILD_TESTS "Indicates whether or not the toolchain must build the test o
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(UseBackportedModules)
 
-# The project version number.
-set(VERSION_MAJOR   0   CACHE STRING "Project major version number.")
-set(VERSION_MINOR   1   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
-mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
-
-# C++ version and standard
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+include(ProjectSettings)
+set_project_settings(0.1.0)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)
 

--- a/ledger-core-ripple/CMakeLists.txt
+++ b/ledger-core-ripple/CMakeLists.txt
@@ -8,15 +8,8 @@ option(BUILD_TESTS "Indicates whether or not the toolchain must build the test o
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(UseBackportedModules)
 
-# The project version number.
-set(VERSION_MAJOR   0   CACHE STRING "Project major version number.")
-set(VERSION_MINOR   1   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
-mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
-
-# C++ version and standard
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+include(ProjectSettings)
+set_project_settings(0.1.0)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)
 

--- a/ledger-core-tezos/CMakeLists.txt
+++ b/ledger-core-tezos/CMakeLists.txt
@@ -8,15 +8,8 @@ option(BUILD_TESTS "Indicates whether or not the toolchain must build the test o
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(UseBackportedModules)
 
-# The project version number.
-set(VERSION_MAJOR   0   CACHE STRING "Project major version number.")
-set(VERSION_MINOR   1   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
-mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
-
-# C++ version and standard
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+include(ProjectSettings)
+set_project_settings(0.1.0)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)
 

--- a/ledger-core/CMakeLists.txt
+++ b/ledger-core/CMakeLists.txt
@@ -8,15 +8,8 @@ option(BUILD_TESTS "Indicates whether or not the toolchain must build the test o
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(UseBackportedModules)
 
-# The project version number.
-set(VERSION_MAJOR   0   CACHE STRING "Project major version number.")
-set(VERSION_MINOR   1   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
-mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
-
-# C++ version and standard
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+include(ProjectSettings)
+set_project_settings(0.1.0)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)
 


### PR DESCRIPTION
This PR aims to add `ccache` support and abstract some project settings.

`ccache` is used by default if the executable is found.

## Mandatory picture of an animal
![chaplin_cat](https://user-images.githubusercontent.com/6042495/77920325-a234f400-729e-11ea-9bd4-7219788f5593.gif)
