### PR TITLE
LLC-572 — Fix missing internal transactions for Ethereum.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ compile_commands.json
 install_manifest.txt
 tags
 *.a
+/.clangd/

--- a/core/src/wallet/ethereum/EthereumLikeAccount.cpp
+++ b/core/src/wallet/ethereum/EthereumLikeAccount.cpp
@@ -107,9 +107,9 @@ namespace ledger {
                 throw Exception(api::ErrorCode::RUNTIME_ERROR, "Wallet reference is dead.");
             }
 
-            if (transaction.block.nonEmpty())
+            if (transaction.block.nonEmpty()) {
                 putBlock(sql, transaction.block.getValue());
-
+            }
 
             int result = 0x00;
 

--- a/core/src/wallet/ethereum/EthereumLikeAccount.cpp
+++ b/core/src/wallet/ethereum/EthereumLikeAccount.cpp
@@ -225,7 +225,12 @@ namespace ledger {
         void EthereumLikeAccount::updateInternalTransactions(soci::session &sql,
                                                              const Operation &operation) {
             auto transaction = operation.ethereumTransaction.getValue();
+            uint64_t index = 0;
             for (auto &internalTx : transaction.internalTransactions) {
+                // pre-increment so that we always increment the index, even when discarding
+                // internal transactions (that means we never use index = 0, but it’s okay)
+                index += 1;
+
                 // Since explorer is considering also wrapping tx as an internal action,
                 // we must filter it by considering that only internal action with same data,
                 // sender and receiver, is the one representing/corresponding to wrapping tx
@@ -235,7 +240,7 @@ namespace ledger {
                                 internalTx.to == _accountAddress ? api::OperationType::RECEIVE :
                                 api::OperationType::NONE;
 
-                    auto internalTxUid = OperationDatabaseHelper::createUid(operation.uid, fmt::format("{}-{}", internalTx.from, hex::toString(internalTx.inputData)), type);
+                    auto internalTxUid = OperationDatabaseHelper::createUid(operation.uid, fmt::format("{}-{}-{}", internalTx.from, hex::toString(internalTx.inputData), index), type);
                     auto actionCount = 0;
                     sql << "SELECT COUNT(*) FROM internal_operations WHERE uid = :uid", soci::use(internalTxUid), soci::into(actionCount);
                     if (actionCount == 0) {


### PR DESCRIPTION
# Content

Those were missing because of two issues:

- We didn’t create internal transactions UUID correctly. We initially
  assumed that we have only one internal transaction (uuid =
  transaction_uuid + hash_data, for short). This fix adds the index of
  the internal transaction to generate different UUIDs and then get them
  all.
- We didn’t filter correctly transactions that don’t concern us. We then
  end up (at least on the core side) with several `NONE` transactions.
  The filtering here basically requires to discard internal transactions
  which type is set to `NONE`, since they don’t concern us — the
  explorers seem to still send us those transactions as they don’t
  filter them from the parent transaction.

# Mandatory picture of celestial animal

![](https://lemagduchien.ouest-france.fr/images/dossiers/2018-04/samoyede-3-105538.jpg)