### PR TITLE
[iOS] Add x86_64 to fat framework

### DIFF
--- a/.circleci/deploy_fat_lib.sh
+++ b/.circleci/deploy_fat_lib.sh
@@ -6,8 +6,7 @@ if [ -n "$CIRCLE_TAG" ] || [ "$CIRCLE_BRANCH" == "master" -o "$CIRCLE_BRANCH" ==
 	echo "======> Build Fat Library"
 	pwd
 
-	#We don't put x86_64/ledger-core.framework/ledger-core otherwise we have a problem when pushing to AppStore
-	lipo -create armv7/ledger-core.framework/ledger-core arm64/ledger-core.framework/ledger-core -o ledger-core
+	lipo -create armv7/ledger-core.framework/ledger-core arm64/ledger-core.framework/ledger-core x86_64/ledger-core.framework/ledger-core -o ledger-core
 	mkdir ledger-core.framework
 	mv ledger-core ledger-core.framework/
 	cp armv7/ledger-core.framework/Info.plist ledger-core.framework/


### PR DESCRIPTION
XCode had a recent change of heart regarding embedded library architectures allowed in a build so, long story short, we have to change the way we embed `ledger-core.framework` in Ledger Live mobile, meaning we don't use _thin_ frameworks anymore but only the _fat_ one, in which we need _all_ the architectures, including `x86_64`.