### PR TITLE
Fix XRP: marker to be set to Uint64 instead of string

### DIFF
--- a/core/src/wallet/ripple/explorers/NodeRippleLikeBlockchainExplorer.h
+++ b/core/src/wallet/ripple/explorers/NodeRippleLikeBlockchainExplorer.h
@@ -107,12 +107,12 @@ namespace ledger {
                 rapidjson::Value ledgerKey(rapidjson::kStringType);
                 ledgerKey.SetString(ledgerKeyStr.c_str(), static_cast<rapidjson::SizeType>(ledgerKeyStr.length()), allocator);
                 rapidjson::Value ledgerParam(rapidjson::kNumberType);
-                ledgerParam.SetString(ledger.c_str(), static_cast<rapidjson::SizeType>(ledger.length()), allocator);
+                ledgerParam.SetUint64(BigInt(ledger).toUint64());
 
                 rapidjson::Value seqKey(rapidjson::kStringType);
                 seqKey.SetString(seqKeyStr.c_str(), static_cast<rapidjson::SizeType>(seqKeyStr.length()), allocator);
                 rapidjson::Value seqParam(rapidjson::kNumberType);
-                seqParam.SetString(seq.c_str(), static_cast<rapidjson::SizeType>(seq.length()), allocator);
+                seqParam.SetUint64(BigInt(seq).toUint64());
 
                 object.AddMember(ledgerKey, ledgerParam, allocator);
                 object.AddMember(seqKey, seqParam, allocator);


### PR DESCRIPTION
@RomanWlm could you please complete with right ticket (could not find it).

**NOTE**: it seems that `The format of the marker field is intentionally undefined.` (from: https://xrpl.org/markers-and-pagination.html), so this is valid at least for `s3` and `s2`.