### PR TITLE
Fix BCH: construct P2PKH and P2SH output scripts even in case of cash addresses

### DIFF
--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeTransactionBuilder.cpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeTransactionBuilder.cpp
@@ -182,12 +182,10 @@ namespace ledger {
 
             // BCH has a fake P2WPKH and P2WSH
             // So for cash addresses we should still use P2PKH or P2SH
-            auto isP2PKH = a->isP2PKH() || (a->isP2WPKH() && _currency.name == currencies::BITCOIN_CASH.name);
-            auto isP2SH = a->isP2SH() || (a->isP2WSH() && _currency.name == currencies::BITCOIN_CASH.name);
-            if (isP2PKH) {
+            if (a->isP2PKH() || (a->isP2WPKH() && _currency.name == currencies::BITCOIN_CASH.name)) {
                 script << btccore::OP_DUP << btccore::OP_HASH160 << a->getHash160() << btccore::OP_EQUALVERIFY
                        << btccore::OP_CHECKSIG;
-            } else if (isP2SH) {
+            } else if (a->isP2SH() || (a->isP2WSH() && _currency.name == currencies::BITCOIN_CASH.name)) {
                 script << btccore::OP_HASH160 << a->getHash160() << btccore::OP_EQUAL;
             } else if (a->isP2WPKH() || a->isP2WSH()) {
                 script << btccore::OP_0 << a->getHash160();

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeTransactionBuilder.cpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeTransactionBuilder.cpp
@@ -37,6 +37,7 @@
 #include <wallet/bitcoin/api_impl/BitcoinLikeScriptApi.h>
 #include <wallet/bitcoin/networks.hpp>
 #include <utils/hex.h>
+#include <wallet/currencies.hpp>
 
 namespace ledger {
     namespace core {
@@ -178,10 +179,15 @@ namespace ledger {
                 throw make_exception(api::ErrorCode::RUNTIME_ERROR, "Invalid address {}", address);
             }
             BitcoinLikeScript script;
-            if (a->isP2PKH()) {
+
+            // BCH has a fake P2WPKH and P2WSH
+            // So for cash addresses we should still use P2PKH or P2SH
+            auto isP2PKH = a->isP2PKH() || (a->isP2WPKH() && _currency.name == currencies::BITCOIN_CASH.name);
+            auto isP2SH = a->isP2SH() || (a->isP2WSH() && _currency.name == currencies::BITCOIN_CASH.name);
+            if (isP2PKH) {
                 script << btccore::OP_DUP << btccore::OP_HASH160 << a->getHash160() << btccore::OP_EQUALVERIFY
                        << btccore::OP_CHECKSIG;
-            } else if (a->isP2SH()) {
+            } else if (isP2SH) {
                 script << btccore::OP_HASH160 << a->getHash160() << btccore::OP_EQUAL;
             } else if (a->isP2WPKH() || a->isP2WSH()) {
                 script << btccore::OP_0 << a->getHash160();

--- a/core/test/integration/transactions/bitcoin_P2PKH_transaction_tests.cpp
+++ b/core/test/integration/transactions/bitcoin_P2PKH_transaction_tests.cpp
@@ -208,15 +208,23 @@ struct BCHMakeP2PKHTransaction : public BitcoinMakeBaseTransaction {
 };
 
 TEST_F(BCHMakeP2PKHTransaction, CreateStandardP2SHWithOneOutput) {
-    auto builder = tx_builder();
-    builder->sendToAddress(api::Amount::fromLong(currency, 5000), "14RYdhaFU9fMH25e6CgkRrBRjZBvEvKxne");
-    builder->pickInputs(api::BitcoinLikePickingStrategy::DEEP_OUTPUTS_FIRST, 0xFFFFFFFF);
-    builder->setFeesPerByte(api::Amount::fromLong(currency, 41));
-    auto f = builder->build();
-    auto tx = ::wait(f);
-    auto parsedTx = BitcoinLikeTransactionBuilder::parseRawUnsignedTransaction(wallet->getCurrency(), tx->serialize(), 0);
-    //auto rawPrevious = ::wait(std::dynamic_pointer_cast<BitcoinLikeWritableInputApi>(tx->getInputs()[0])->getPreviousTransaction());
-    EXPECT_EQ(tx->serialize(), parsedTx->serialize());
+    auto buildBCHTxWithAddress = [=](const std::string & toAddress) -> std::string {
+        auto builder = tx_builder();
+        builder->sendToAddress(api::Amount::fromLong(currency, 5000), toAddress);
+        builder->pickInputs(api::BitcoinLikePickingStrategy::DEEP_OUTPUTS_FIRST, 0xFFFFFFFF);
+        builder->setFeesPerByte(api::Amount::fromLong(currency, 41));
+        auto f = builder->build();
+        auto tx = ::wait(f);
+        auto serializedTx = tx->serialize();
+        auto parsedTx = BitcoinLikeTransactionBuilder::parseRawUnsignedTransaction(wallet->getCurrency(), serializedTx, 0);
+        EXPECT_EQ(serializedTx, parsedTx->serialize());
+        return hex::toString(tx->serialize());
+    };
+
+    // https://explorer.bitcoin.com/bch/address/14RYdhaFU9fMH25e6CgkRrBRjZBvEvKxne
+    auto legacySerializeTx = buildBCHTxWithAddress("14RYdhaFU9fMH25e6CgkRrBRjZBvEvKxne");
+    auto cashAddressSerializeTx = buildBCHTxWithAddress("bitcoincash:qqjce3pqczzukajdqc27psjnd26lyz2d5yg2cfjtxe");
+    EXPECT_EQ(legacySerializeTx, cashAddressSerializeTx);
 }
 
 struct ZCASHMakeP2PKHTransaction : public BitcoinMakeBaseTransaction {


### PR DESCRIPTION
This is related to : 
- LVS: https://ledgerhq.atlassian.net/browse/LVS-141,
- Mirrored by LLC: https://ledgerhq.atlassian.net/browse/LLC-629