### PR TITLE
Change explorer base URL

### DIFF
--- a/core/idl/wallet/configuration.djinni
+++ b/core/idl/wallet/configuration.djinni
@@ -1,7 +1,7 @@
 # Available API to use with Stellar wallets
 StellarConfiguration = interface +c {
     const HORIZON_EXPLORER_ENGINE: string = "HORIZON_EXPLORER_ENGINE";
-    const HORIZON_MAINNET_BLOCKCHAIN_EXPLORER_URL: string = "https://horizon.stellar.org";
+    const HORIZON_MAINNET_BLOCKCHAIN_EXPLORER_URL: string = "https://stellar.coin.ledger.com";
     const HORIZON_TESTNET_BLOCKCHAIN_EXPLORER_URL: string = "https://horizon-testnet.stellar.org";
 }
 

--- a/core/src/api/StellarConfiguration.cpp
+++ b/core/src/api/StellarConfiguration.cpp
@@ -7,7 +7,7 @@ namespace ledger { namespace core { namespace api {
 
 std::string const StellarConfiguration::HORIZON_EXPLORER_ENGINE = {"HORIZON_EXPLORER_ENGINE"};
 
-std::string const StellarConfiguration::HORIZON_MAINNET_BLOCKCHAIN_EXPLORER_URL = {"https://horizon.stellar.org"};
+std::string const StellarConfiguration::HORIZON_MAINNET_BLOCKCHAIN_EXPLORER_URL = {"https://stellar.coin.ledger.com"};
 
 std::string const StellarConfiguration::HORIZON_TESTNET_BLOCKCHAIN_EXPLORER_URL = {"https://horizon-testnet.stellar.org"};
 

--- a/core/src/wallet/stellar/explorers/horizon/HorizonFeeStatsParser.cpp
+++ b/core/src/wallet/stellar/explorers/horizon/HorizonFeeStatsParser.cpp
@@ -35,9 +35,9 @@ using namespace ledger::core;
 
 static const JsonParserPathMatcher LAST_LEDGER_MATCHER("/last_ledger");
 static const JsonParserPathMatcher BASE_FEE_MATCHER("/last_ledger_base_fee");
-static const JsonParserPathMatcher MIN_FEE_MATCHER("/min_accepted_fee");
-static const JsonParserPathMatcher MODE_FEE_MATCHER("/mode_accepted_fee");
-static const JsonParserPathMatcher MAX_FEE_MATCHER("/p99_accepted_fee");
+static const JsonParserPathMatcher MIN_FEE_MATCHER("/fee_charged/min");
+static const JsonParserPathMatcher MODE_FEE_MATCHER("/fee_charged/mode");
+static const JsonParserPathMatcher MAX_FEE_MATCHER("/fee_charged/max");
 
 namespace ledger {
     namespace core {

--- a/core/test/coin-integration/stellar/horizon_explorer_tests.cpp
+++ b/core/test/coin-integration/stellar/horizon_explorer_tests.cpp
@@ -160,19 +160,18 @@ TEST_F(StellarFixture, GetOperations) {
     }
 }
 
-// This test is disabled until our nodes can support the feature
-//TEST_F(StellarFixture, GetRecommendedFees) {
-//    auto pool = newPool();
-//    auto explorer = std::make_shared<HorizonBlockchainExplorer>(
-//            pool->getDispatcher()->getSerialExecutionContext("explorer"),
-//            pool->getHttpClient(MAINNET_URL),
-//            std::make_shared<DynamicObject>()
-//    );
-//    auto fees = wait(explorer->getRecommendedFees());
-//    auto t = fees->maxFee.toString();
-//    EXPECT_TRUE(!fees->lastLedger.empty());
-//    EXPECT_TRUE(fees->lastBaseFee >= BigInt(100));
-//    EXPECT_TRUE(fees->modeAcceptedFee >= BigInt(100));
-//    EXPECT_TRUE(fees->minAccepted >= BigInt(100));
-//    EXPECT_TRUE(fees->maxFee >= BigInt(100));
-//}
+TEST_F(StellarFixture, GetRecommendedFees) {
+    auto pool = newPool();
+    auto explorer = std::make_shared<HorizonBlockchainExplorer>(
+            pool->getDispatcher()->getSerialExecutionContext("explorer"),
+            pool->getHttpClient(MAINNET_URL),
+            std::make_shared<DynamicObject>()
+    );
+    auto fees = wait(explorer->getRecommendedFees());
+    auto t = fees->maxFee.toString();
+    EXPECT_TRUE(!fees->lastLedger.empty());
+    EXPECT_TRUE(fees->lastBaseFee >= BigInt(100));
+    EXPECT_TRUE(fees->modeAcceptedFee >= BigInt(100));
+    EXPECT_TRUE(fees->minAccepted >= BigInt(100));
+    EXPECT_TRUE(fees->maxFee >= BigInt(100));
+}


### PR DESCRIPTION
This PR changes:
 - The base url used by the Explorer in order to use our proxy
 - Change /fee_stat implementation to match last version of Horizon 