### PR TITLE
Undefined symbols related to dl library

### DIFF
--- a/core/lib/CMakeLists.txt
+++ b/core/lib/CMakeLists.txt
@@ -38,6 +38,9 @@ set(SOCI_STATIC ON)
 set(SOCI_SHARED OFF CACHE BOOL "USE ONLY STATIC" FORCE)
 
 add_subdirectory(soci)
+# Fix undefined symbol related to dl library on Unix system
+# The dl library is linked here to avoid to modify vendor cmake files
+target_link_libraries(soci_core_static ${CMAKE_DL_LIBS})
 add_subdirectory(soci_sqlite3)
 
 if (PG_SUPPORT)


### PR DESCRIPTION
The PR aims to fix the undefined symbols related to `dl` library on Unix systems.

## Mandatory picture of a cat
![slice_cat](https://user-images.githubusercontent.com/6042495/79325744-ff24e100-7f11-11ea-8a6b-0d5678fc7010.gif)
