### PR TITLE
Use public key as restore key for XLM integration

### DIFF
--- a/core/src/wallet/stellar/keychains/DefaultStellarLikeKeychain.cpp
+++ b/core/src/wallet/stellar/keychains/DefaultStellarLikeKeychain.cpp
@@ -52,7 +52,7 @@ namespace ledger {
         }
 
         std::string DefaultStellarLikeKeychain::getRestoreKey() const {
-            return _address->toString();
+            return hex::toString(_address->toPublicKey());
         }
     }
 }


### PR DESCRIPTION
- Use hex public as restore key for XLM because the live uses it to restore accounts.