### PR TITLE
Fix BigInt assign scalar

### DIFF
--- a/core/src/math/BigInt.h
+++ b/core/src/math/BigInt.h
@@ -43,6 +43,7 @@
 #include <vector>
 #include <bigd.h>
 #include <memory>
+#include <traits/arithmetic.hpp>
 #include "../utils/endian.h"
 
 namespace ledger {
@@ -223,7 +224,15 @@ namespace ledger {
 
             BigInt& assignI64(int64_t value);
 
-            template <typename T>
+            template <typename T, isUnsigned<T> = true>
+            BigInt& assignScalar(T value) {
+                auto bytes = endianness::scalar_type_to_array<T>(value, endianness::Endianness::BIG);
+                bdConvFromOctets(_bigd, reinterpret_cast<const unsigned char *>(bytes), sizeof(value));
+                std::free(bytes);
+                return *this;
+            }
+
+            template <typename T, isSigned<T> = true>
             BigInt& assignScalar(T value) {
                 auto bytes = endianness::scalar_type_to_array<T>(std::abs(value), endianness::Endianness::BIG);
                 bdConvFromOctets(_bigd, reinterpret_cast<const unsigned char *>(bytes), sizeof(value));

--- a/core/src/traits/arithmetic.hpp
+++ b/core/src/traits/arithmetic.hpp
@@ -1,0 +1,49 @@
+/*
+ *
+ * arithmetic.hpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 07/05/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#ifndef LEDGER_CORE_ARITHMETIC_HPP
+#define LEDGER_CORE_ARITHMETIC_HPP
+
+#include <type_traits>
+
+namespace ledger {
+    namespace core {
+
+        template <typename T>
+        using isSigned = std::enable_if_t<std::is_signed<T>::value, bool>;
+
+        template <typename T>
+        using isUnsigned = std::enable_if_t<std::is_unsigned<T>::value, bool>;
+
+    }
+}
+
+#endif //LEDGER_CORE_ARITHMETIC_HPP

--- a/core/test/math/bigint_tests.cpp
+++ b/core/test/math/bigint_tests.cpp
@@ -31,6 +31,7 @@
 
 #include "gtest/gtest.h"
 #include "math/BigInt.h"
+#include <limits>
 
 using namespace ledger::core;
 
@@ -176,4 +177,18 @@ TEST(BigInt, FromFloatString) {
     auto t = witness.toByteArray();
     auto tt = subject.toByteArray();
     EXPECT_TRUE(witness.compare(subject) == 0);
+}
+
+TEST(BigInt, AssignFromUnsigned64bitScalar) {
+    auto value = std::numeric_limits<uint64_t>::max();
+    BigInt bigInt;
+    bigInt.assignScalar(value);
+    EXPECT_EQ(value, bigInt.toUint64());
+}
+
+TEST(BigInt, AssignFromSigned64bitScalar) {
+    uint64_t value = std::numeric_limits<uint64_t>::min();
+    BigInt bigInt;
+    bigInt.assignScalar(value);
+    EXPECT_EQ(value, bigInt.toUint64());
 }


### PR DESCRIPTION
Current implementation of BigInt::assignScalar doesn't build when passing an unsigned integer because std::abs is not defined for unsigned type (and doesn't make much sense).

This PR add 2 different implementation of BigInt::assignScalar<T> for signed and unsigned type and a test to create BigInt from unsigned scalar types.