### PR TITLE
LLC-648 + VSD-26 — Fix stack exhaustion with recursive futures in the Bitcoin UTXO picker.

### DIFF
--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeUtxoPicker.cpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeUtxoPicker.cpp
@@ -35,7 +35,6 @@
 #include <api/BitcoinLikeScriptChunk.hpp>
 #include <wallet/bitcoin/api_impl/BitcoinLikeScriptApi.h>
 #include <wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h>
-#include <utils/ImmediateExecutionContext.hpp>
 
 namespace ledger {
     namespace core {
@@ -63,13 +62,13 @@ namespace ledger {
                     auto tx = std::make_shared<BitcoinLikeTransactionApi>(self->_currency, keychain->getKeychainEngine(), currentBlockHeight);
                     auto filteredGetUtxo = createFilteredUtxoFunction(r, getUtxo);
                     return std::make_shared<Buddy>(r, filteredGetUtxo, getTransaction, explorer, keychain, logger, tx, partial);
-                }).flatMap<std::shared_ptr<api::BitcoinLikeTransaction>>(ImmediateExecutionContext::INSTANCE, [=] (const std::shared_ptr<Buddy>& buddy) -> Future<std::shared_ptr<api::BitcoinLikeTransaction>> {
+                }).flatMap<std::shared_ptr<api::BitcoinLikeTransaction>>(self->getContext(), [=] (const std::shared_ptr<Buddy>& buddy) -> Future<std::shared_ptr<api::BitcoinLikeTransaction>> {
                     buddy->logger->info("Buddy created");
-                    return self->fillInputs(buddy).flatMap<Unit>(ImmediateExecutionContext::INSTANCE, [=] (const Unit&) -> Future<Unit> {
+                    return self->fillInputs(buddy).flatMap<Unit>(self->getContext(), [=] (const Unit&) -> Future<Unit> {
                         return self->fillOutputs(buddy);
-                    }).flatMap<Unit>(ImmediateExecutionContext::INSTANCE, [=] (const Unit&) -> Future<Unit> {
+                    }).flatMap<Unit>(self->getContext(), [=] (const Unit&) -> Future<Unit> {
                         return self->fillTransactionInfo(buddy);
-                    }).mapPtr<api::BitcoinLikeTransaction>(ImmediateExecutionContext::INSTANCE, [=] (const Unit&) -> std::shared_ptr<api::BitcoinLikeTransaction> {
+                    }).mapPtr<api::BitcoinLikeTransaction>(self->getContext(), [=] (const Unit&) -> std::shared_ptr<api::BitcoinLikeTransaction> {
                         buddy->logger->info("Empty transaction built");
                         return buddy->transaction;
                     });;
@@ -145,13 +144,13 @@ namespace ledger {
                 return Future<Unit>::successful(unit);
             }
             //Set timestamp
-            buddy->explorer->getTimestamp().onComplete(ImmediateExecutionContext::INSTANCE, [=] (const Try<int64_t> &timestamp){
+            buddy->explorer->getTimestamp().onComplete(getContext(), [=] (const Try<int64_t> &timestamp){
                 if (timestamp.isSuccess()) {
                     buddy->transaction->setTimestamp(timestamp.getValue());
                 }
             });
 
-            return buddy->explorer->getCurrentBlock().map<Unit>(ImmediateExecutionContext::INSTANCE, [=] (const std::shared_ptr<BitcoinLikeBlockchainExplorer::Block>& block) -> Unit{
+            return buddy->explorer->getCurrentBlock().map<Unit>(getContext(), [=] (const std::shared_ptr<BitcoinLikeBlockchainExplorer::Block>& block) -> Unit{
                 buddy->transaction->setLockTime(static_cast<uint32_t>(block->height));
                 return unit;
             });
@@ -169,17 +168,17 @@ namespace ledger {
 
             auto inputs = std::make_shared<UTXODescriptorList>();
             static std::function<Future<Unit> (int, const std::shared_ptr<UTXODescriptorList>&, const std::shared_ptr<Buddy>&, const std::shared_ptr<BitcoinLikeUtxoPicker>&)> performFill
-            = [] (int index, const std::shared_ptr<UTXODescriptorList>& inputs, const std::shared_ptr<Buddy>& buddy, const std::shared_ptr<BitcoinLikeUtxoPicker>& self) mutable -> Future<Unit> {
+            = [=] (int index, const std::shared_ptr<UTXODescriptorList>& inputs, const std::shared_ptr<Buddy>& buddy, const std::shared_ptr<BitcoinLikeUtxoPicker>& self) mutable -> Future<Unit> {
                 if (index >= inputs->size())
                     return Future<Unit>::successful(unit);
-                return self->fillInput(buddy, (*inputs)[index]).flatMap<Unit>(ImmediateExecutionContext::INSTANCE, [=] (const Unit&) {
+                return self->fillInput(buddy, (*inputs)[index]).flatMap<Unit>(self->getContext(), [=] (const Unit&) {
                     return performFill(index + 1, inputs, buddy, self);
                 });
             };
             inputs->insert(inputs->end(), buddy->request.inputs.begin(), buddy->request.inputs.end());
-            return performFill(0, inputs, buddy, self).flatMap<UTXODescriptorList>(ImmediateExecutionContext::INSTANCE, [=] (const Unit&) mutable -> Future<UTXODescriptorList> {
+            return performFill(0, inputs, buddy, self).flatMap<UTXODescriptorList>(getContext(), [=] (const Unit&) mutable -> Future<UTXODescriptorList> {
                 return pickUtxo();
-            }).flatMap<Unit>(ImmediateExecutionContext::INSTANCE, [=] (const UTXODescriptorList& utxo) mutable -> Future<Unit> {
+            }).flatMap<Unit>(getContext(), [=] (const UTXODescriptorList& utxo) mutable -> Future<Unit> {
                 auto offset = static_cast<int>(inputs->size());
                 inputs->insert(inputs->end(), utxo.begin(), utxo.end());
                 return performFill(offset, inputs, buddy, self);
@@ -195,7 +194,7 @@ namespace ledger {
                 }
                 return buddy->explorer->getTransactionByHash(hash);
             };
-            return txGetter(hash).map<Unit>(ImmediateExecutionContext::INSTANCE, [=] (const std::shared_ptr<BitcoinLikeBlockchainExplorerTransaction>& tx) {
+            return txGetter(hash).map<Unit>(getContext(), [=] (const std::shared_ptr<BitcoinLikeBlockchainExplorerTransaction>& tx) {
                 buddy->logger->debug("Get output {} on {}", std::get<1>(desc), tx->outputs.size());
                 auto output = tx->outputs[std::get<1>(desc)];
                 std::vector<std::vector<uint8_t>> pub_keys;


### PR DESCRIPTION
# Content

The problem was due to immediate contexts being used, which stack
fillInputs calls and eventually lead to a segmentation fault. We
detected the problem in VSD-26, leading to LLC-648 after seeing first a
520+-deep callstack on the JVM / Wallet Daemon, and I reproduced locally
by limitting the size of the stack to 1MB on native tests (SIGSEGV after
a 8k+-deep callstack).

This commit doesn’t do anything more than fixing the stack problem. Slow
issues are to be solved in another PR and new issues.

# Mandatory picture of boop boop

![](https://phaazon.net/media/uploads/boop_boop.jpg)