### PR TITLE
Port support of both OpenSSL 1.0.0 & 1.1.0 for HMAC from libcore v1 to v2

### DIFF
--- a/ledger-core/src/core/crypto/HMAC.cpp
+++ b/ledger-core/src/core/crypto/HMAC.cpp
@@ -35,15 +35,24 @@
 #include <core/crypto/HMAC.hpp>
 
 std::vector<uint8_t> ledger::core::HMAC::sha256(const std::vector<uint8_t>& key,
-                                                    const std::vector<uint8_t>& data) {
+                                                const std::vector<uint8_t>& data) {
     auto len = SHA256_DIGEST_LENGTH;
     std::vector<uint8_t> hash(len);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX hmac;
     HMAC_CTX_init(&hmac);
     HMAC_Init_ex(&hmac, key.data(), key.size(), EVP_sha256(), NULL);
     HMAC_Update(&hmac, data.data(), data.size());
     HMAC_Final(&hmac, hash.data(), (unsigned int *)(&len));
     HMAC_cleanup(&hmac);
+#else
+    HMAC_CTX * hmac = HMAC_CTX_new();
+    HMAC_CTX_reset(hmac);
+    HMAC_Init_ex(hmac, key.data(), key.size(), EVP_sha256(), NULL);
+    HMAC_Update(hmac, data.data(), data.size());
+    HMAC_Final(hmac, hash.data(), (unsigned int *)(&len));
+    HMAC_CTX_free(hmac);
+#endif
     return hash;
 }
 
@@ -51,11 +60,20 @@ std::vector<uint8_t> ledger::core::HMAC::sha512(const std::vector<uint8_t>& key,
                                                     const std::vector<uint8_t>& data) {
     auto len = SHA512_DIGEST_LENGTH;
     std::vector<uint8_t> hash(len);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX hmac;
     HMAC_CTX_init(&hmac);
     HMAC_Init_ex(&hmac, key.data(), key.size(), EVP_sha512(), NULL);
     HMAC_Update(&hmac, data.data(), data.size());
     HMAC_Final(&hmac, hash.data(), (unsigned int *)(&len));
     HMAC_cleanup(&hmac);
+#else
+    HMAC_CTX * hmac = HMAC_CTX_new();
+    HMAC_CTX_reset(hmac);
+    HMAC_Init_ex(hmac, key.data(), key.size(), EVP_sha512(), NULL);
+    HMAC_Update(hmac, data.data(), data.size());
+    HMAC_Final(hmac, hash.data(), (unsigned int *)(&len));
+    HMAC_CTX_free(hmac);
+#endif
     return hash;
 }


### PR DESCRIPTION
Port to libcore v2 the support of both OpenSSL 1.0.0 & 1.1.0 for HMAC.

This should be the same changes in `HMAC.cpp` as in https://github.com/LedgerHQ/lib-ledger-core/commit/64247e992fcc2447565628b6469ae4acb1d86fb1