### PR TITLE
[cosmos] Handle fees properly in balanceHistory

### DIFF
--- a/core/src/wallet/cosmos/CosmosLikeAccount.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.cpp
@@ -322,7 +322,7 @@ uint32_t CosmosLikeAccount::computeFeesForTransaction(const cosmos::Transaction 
         }
         auto const feeConsumptionRatio = static_cast<float>(tx.gasUsed.getValue().toInt()) /
                                          static_cast<float>(tx.fee.gas.toInt());
-        fees = std::lround(feeConsumptionRatio * fees);
+        fees = std::lround(feeConsumptionRatio * static_cast<float>(fees));
     }
 
     return fees;
@@ -359,7 +359,7 @@ void CosmosLikeAccount::inflateOperation(
     // Fees are added only on the MSGFEES Message Type.
     auto fees = computeFeesForTransaction(tx);
     if (cosmos::stringToMsgType(msg.type.c_str()) == api::CosmosLikeMsgType::MSGFEES) {
-        out.amount = BigInt(fees);
+        out.amount = BigInt::ZERO;
         out.fees = BigInt(fees);
     }
     else {

--- a/core/src/wallet/cosmos/CosmosLikeAccount.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.cpp
@@ -356,15 +356,12 @@ void CosmosLikeAccount::inflateOperation(
     out.currencyName = getWallet()->getCurrency().name;
     out.date = tx.timestamp;
     out.trust = std::make_shared<TrustIndicator>();
-    // Fees are added only on the MSGFEES Message Type.
-    auto fees = computeFeesForTransaction(tx);
+    // Fees are computed as the amount only on the MSGFEES Message Type.
     if (cosmos::stringToMsgType(msg.type.c_str()) == api::CosmosLikeMsgType::MSGFEES) {
-        out.amount = BigInt::ZERO;
-        out.fees = BigInt(fees);
+        auto txFees = computeFeesForTransaction(tx);
+        out.amount = BigInt(txFees);
     }
-    else {
-        out.fees = BigInt::ZERO;
-    }
+    out.fees = BigInt::ZERO;
     out.walletUid = wallet->getWalletUid();
 }
 
@@ -513,7 +510,7 @@ Future<std::vector<std::shared_ptr<api::Amount>>> CosmosLikeAccount::getBalanceH
                         break;
                     }
                     case api::OperationType::SEND: {
-                        // NOTE : in Cosmos, FEES is a SEND operation with 0 amount and the correct fees
+                        // NOTE : in Cosmos, FEES is a SEND operation with fees as amount and 0 fees
                         sum = sum - operation.amount - operation.fees.getValueOr(BigInt::ZERO);
                         break;
                     }

--- a/core/src/wallet/cosmos/CosmosLikeAccount.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.cpp
@@ -330,7 +330,7 @@ void CosmosLikeAccount::inflateOperation(
     }
     // The value is updated to the fees actually paid if the transaction has a GasUsed value to use.
     if (fees != 0 && tx.gasUsed) {
-        auto feeConsumptionRatio = static_cast<float>(tx.gasUsed.getValue().toInt()) /
+        auto const feeConsumptionRatio = static_cast<float>(tx.gasUsed.getValue().toInt()) /
                                    static_cast<float>(tx.fee.gas.toInt());
         fees = std::lround(feeConsumptionRatio * fees);
     }

--- a/core/src/wallet/cosmos/CosmosLikeAccount.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.hpp
@@ -258,7 +258,9 @@ class CosmosLikeAccount : public api::CosmosLikeAccount, public AbstractAccount 
     void fillOperationTypeAmountFromUndelegate(
         CosmosLikeOperation &out, const cosmos::MsgUndelegate &innerUndelegateMsg) const;
     /// Set the type and the amount of an Operation from an unwrapped cosmos BeginRedelegate
-    /// Message. \param [out] out the Operation to fill \param [in] innerBeginRedelegateMsg the
+    /// Message.
+    /// \param [out] out the Operation to fill
+    /// \param [in] innerBeginRedelegateMsg the
     /// cosmos beginRedelegate message to use, unwrapped.
     void fillOperationTypeAmountFromBeginRedelegate(
         CosmosLikeOperation &out, const cosmos::MsgBeginRedelegate &innerBeginRedelegateMsg) const;
@@ -277,6 +279,11 @@ class CosmosLikeAccount : public api::CosmosLikeAccount, public AbstractAccount 
     /// \param [in] innerFeesMsg the cosmos fees message to use, unwrapped.
     void fillOperationTypeAmountFromFees(
         CosmosLikeOperation &out, const cosmos::MsgFees &innerFeesMsg) const;
+
+    /// Compute the exact fees paid for the Transaction, applying the consumed gas ratio if available.
+    /// \param [in] tx A Cosmos Transaction to compute the fees from
+    /// \return the amount of fees paid for this transaction in uatom
+        static uint32_t computeFeesForTransaction(const cosmos::Transaction& tx);
 
     std::shared_ptr<cosmos::Account> _accountData;
     std::shared_ptr<CosmosLikeKeychain> _keychain;

--- a/core/src/wallet/cosmos/CosmosLikeAccount.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.hpp
@@ -233,8 +233,9 @@ class CosmosLikeAccount : public api::CosmosLikeAccount, public AbstractAccount 
     // An operation type is always seen from the account point of view.
 
     /// Set the type and the amount of an Operation from a cosmos Message in the context of the
-    /// account. \param [out] out the Operation to fill \param [in] msg the cosmos Message to use as
-    /// source of information
+    /// account.
+    /// \param [out] out the Operation to fill
+    /// \param [in] msg the cosmos Message to use as source of information
     void setOperationTypeAndAmount(CosmosLikeOperation &out, const cosmos::Message &msg) const;
     /// Set the type and the amount of an Operation from an unwrapped cosmos Send Message.
     /// \param [out] out the Operation to fill


### PR DESCRIPTION
- The fees need to be properly computed on inflation if we have the
actual gasUsed in the transaction.
- The fees are always included as an operation.amount so the
balanceHistory from CosmosLikeAccount should never care about
operation.fees from the received operationQuery