### PR TITLE
[cosmos] Do not include fees user didn't pay in operations

### DIFF
--- a/core/src/wallet/cosmos/CosmosLikeAccount.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.hpp
@@ -51,6 +51,7 @@
 #include <wallet/common/AbstractWallet.hpp>
 #include <wallet/cosmos/api_impl/CosmosLikeDelegation.hpp>
 #include <wallet/cosmos/api_impl/CosmosLikeOperation.hpp>
+
 #include <wallet/cosmos/api_impl/CosmosLikeRedelegation.hpp>
 #include <wallet/cosmos/api_impl/CosmosLikeReward.hpp>
 #include <wallet/cosmos/api_impl/CosmosLikeUnbonding.hpp>
@@ -103,6 +104,7 @@ class CosmosLikeAccount : public api::CosmosLikeAccount, public AbstractAccount 
 
     std::shared_ptr<CosmosLikeKeychain> getKeychain() const;
     std::shared_ptr<api::Keychain> getAccountKeychain() override;
+    std::string getAddress() const;
 
     FuturePtr<Amount> getBalance() override;
 
@@ -225,8 +227,6 @@ class CosmosLikeAccount : public api::CosmosLikeAccount, public AbstractAccount 
    private:
     std::shared_ptr<CosmosLikeAccount> getSelf();
     void updateFromDb();
-
-    std::string getAddress() const;
 
     // These helpers stay on CosmosLikeAccount *only* because they have to use their
     // knowledge of Address information in order to correctly map operation type.

--- a/core/test/cosmos/Fixtures.cpp
+++ b/core/test/cosmos/Fixtures.cpp
@@ -85,11 +85,11 @@ namespace ledger {
                                 return msg;
                         }
 
-                        Message setupFeesMessage() {
+                        Message setupFeesMessage(const std::string &payerAddress) {
                             Message msg;
                             msg.type = constants::kMsgFees;
                             MsgFees feesMsg;
-                            feesMsg.payerAddress = "cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl";
+                            feesMsg.payerAddress = payerAddress;
                             feesMsg.fees = api::CosmosLikeAmount("30", "uatom");
                             msg.content = feesMsg;
                             return msg;

--- a/core/test/cosmos/Fixtures.hpp
+++ b/core/test/cosmos/Fixtures.hpp
@@ -33,7 +33,7 @@ namespace ledger {
                         Message setupUndelegateMessage();
                         Message setupVoteMessage();
                         Message setupWithdrawDelegationRewardMessage();
-                        Message setupFeesMessage();
+                        Message setupFeesMessage(const std::string& payerAddress);
 
                         // Build a transaction to be broadcasted to the blockhain
                         Transaction setupTransactionRequest(const std::vector<Message>& msgs);


### PR DESCRIPTION
The filtering is done just before converting an incoming Transaction to
an Operation suitable for database storage.

A test is added to check that a FeeMessage is filtered out when the
payer is not the current account.