### PR TITLE
Fix fees parsing on XLM

### DIFF
--- a/core/src/wallet/stellar/explorers/horizon/HorizonTransactionParser.cpp
+++ b/core/src/wallet/stellar/explorers/horizon/HorizonTransactionParser.cpp
@@ -84,11 +84,7 @@ namespace ledger {
 
         bool
         HorizonTransactionParser::RawNumber(const rapidjson::Reader::Ch *str, rapidjson::SizeType length, bool copy) {
-            if (_path.match(FEE_MATCHER)) {
-                _transaction->feePaid = BigInt::fromString(std::string(str, length));
-            } else if (_path.match(ACCOUNT_SEQUENCE_MATCHER)) {
-                _transaction->sourceAccountSequence = BigInt::fromString(std::string(str, length));
-            } else if (_path.match(LEDGER_MATCHER)) {
+           if (_path.match(LEDGER_MATCHER)) {
                 _transaction->ledger = BigInt::fromString(std::string(str, length)).toUint64();
             }
             return true;
@@ -114,6 +110,10 @@ namespace ledger {
                 BaseConverter::decode(std::string(str, length), BaseConverter::BASE64_RFC4648, buffer);
                 stellar::xdr::Decoder decoder(buffer);
                 decoder >> _transaction->envelope;
+            } else if (_path.match(FEE_MATCHER)) {
+                _transaction->feePaid = BigInt::fromString(std::string(str, length));
+            } else if (_path.match(ACCOUNT_SEQUENCE_MATCHER)) {
+                _transaction->sourceAccountSequence = BigInt::fromString(std::string(str, length));
             }
             return true;
         }

--- a/core/test/coin-integration/stellar/synchronization_tests.cpp
+++ b/core/test/coin-integration/stellar/synchronization_tests.cpp
@@ -63,6 +63,9 @@ TEST_F(StellarFixture, SynchronizeStellarAccount) {
     for (const auto& op : operations) {
         auto record = op->asStellarLikeOperation()->getRecord();
         fmt::print("{} {} {} {}\n",   api::to_string(op->getOperationType()), op->getAmount()->toString(), op->getFees()->toString(), api::to_string(record.operationType));
+        if (op->getOperationType() == api::OperationType::SEND) {
+            EXPECT_TRUE(op->getFees()->toLong() >= 100);
+        }
     }
 
     const auto& first = operations.front();


### PR DESCRIPTION
Horizon 1.3.0 update changed the way fees are serialized from int64 to string.
Also source_sequence_account was not fetched properly (unused value in live).

https://github.com/stellar/go/releases/tag/horizon-v1.3.0