### PR TITLE
Use Production url for cosmos

### DIFF
--- a/core/idl/wallet/cosmos/wallet.djinni
+++ b/core/idl/wallet/cosmos/wallet.djinni
@@ -223,7 +223,7 @@ CosmosLikeRedelegationEntry = interface +c {
 }
 
 CosmosConfigurationDefaults = interface +c {
-        const COSMOS_DEFAULT_API_ENDPOINT: string = "http://lite-client-0e27eefb-4031-4859-a88e-249fd241989d.cosmos.bison.run:1317";
+        const COSMOS_DEFAULT_API_ENDPOINT: string = "https://cosmos.coin.ledger.com";
         const COSMOS_OBSERVER_WS_ENDPOINT: string = "";
 }
 


### PR DESCRIPTION
The shift for production URL will be done once the proxy is setup. This
change is still necessary because the old node will be decommissioned
soon.