### PR TITLE
Fix compilation of Hex.cpp.

### DIFF
--- a/ledger-core/src/core/utils/Hex.cpp
+++ b/ledger-core/src/core/utils/Hex.cpp
@@ -30,6 +30,7 @@
  */
 
 #include <core/utils/Hex.hpp>
+#include <stdexcept>
 
 namespace ledger {
     namespace core {


### PR DESCRIPTION
- Rename `hex.cpp` -> `Hex.cpp`. That issue wasn’t visible on macOS
  because LOL FILESYSTEMS.
- Add inclusion of stdexcept. I don’t know why it hasn’t failed already.
  I guess even Stroustrup doesn’t know that.