### PR TITLE
Bump libcore version in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 1.0.{build}
 image:
 - Visual Studio 2017
 environment:
-  LIB_VERSION: 3.3.0 # Hardcode the LIB_VERSION : should be retrieved by building libcore node module and run tests/lib_version.js
+  LIB_VERSION: 3.4.0 # Hardcode the LIB_VERSION : should be retrieved by building libcore node module and run tests/lib_version.js
   nodejs_version: "9"
   appveyor_rdp_password:
     secure: jb1LsDmcxCww7tA38S3xSw==


### PR DESCRIPTION
AppVeyor was releasing new artifacts on 3.3.0 instead of 3.4.0