### PR TITLE
Release version 3.4.1

### DIFF
--- a/.circleci/setup_debian.sh
+++ b/.circleci/setup_debian.sh
@@ -19,9 +19,10 @@ ls -la /usr/lib/jvm/java-8-openjdk || echo "!!!! java openjdk not found"
 if [ "$BUILD_CONFIG" == "Release" ]; then
     apt-get install -y awscli
     echo "========> Install sbt"
-    curl -L -o sbt-1.2.8.deb https://dl.bintray.com/sbt/debian/sbt-1.2.8.deb
-    dpkg -i sbt-1.2.8.deb
-    rm sbt-1.2.8.deb
+    SBT_DEB="sbt-1.3.10.deb"
+    curl -L -o $SBT_DEB https://dl.bintray.com/sbt/debian/$SBT_DEB
+    dpkg -i $SBT_DEB
+    rm $SBT_DEB
     sbt sbtVersion
 fi
 

--- a/.circleci/setup_macos.sh
+++ b/.circleci/setup_macos.sh
@@ -22,7 +22,6 @@ if [ "$BUILD_CONFIG" == "Release" ]; then
 	brew install awscli
 	echo "========> Install sbt"
 	brew install sbt
-	sbt sbtVersion
 fi
 
 echo "========> Install C++ dependencies"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.4.1
+> 2020/06/10
+
+- Fix SBT download failures on the CI (for Debian and MacOS)
+- Fix a BTC test using a deprecated URL
+- Fix Stellar fee parsing for Horizon 1.3.0
+
 ## 3.4.0
 
 > 2020/06/01

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(UseBackportedModules)
 # The project version number.
 set(VERSION_MAJOR   3   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   4   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   1   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 1.0.{build}
 image:
 - Visual Studio 2017
 environment:
-  LIB_VERSION: 3.3.0 # Hardcode the LIB_VERSION : should be retrieved by building libcore node module and run tests/lib_version.js
+  LIB_VERSION: 3.4.0 # Hardcode the LIB_VERSION : should be retrieved by building libcore node module and run tests/lib_version.js
   nodejs_version: "9"
   appveyor_rdp_password:
     secure: jb1LsDmcxCww7tA38S3xSw==

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 1.0.{build}
 image:
 - Visual Studio 2017
 environment:
-  LIB_VERSION: 3.4.0 # Hardcode the LIB_VERSION : should be retrieved by building libcore node module and run tests/lib_version.js
+  LIB_VERSION: 3.4.1 # Hardcode the LIB_VERSION : should be retrieved by building libcore node module and run tests/lib_version.js
   nodejs_version: "9"
   appveyor_rdp_password:
     secure: jb1LsDmcxCww7tA38S3xSw==

--- a/core/src/wallet/stellar/explorers/horizon/HorizonTransactionParser.cpp
+++ b/core/src/wallet/stellar/explorers/horizon/HorizonTransactionParser.cpp
@@ -84,11 +84,7 @@ namespace ledger {
 
         bool
         HorizonTransactionParser::RawNumber(const rapidjson::Reader::Ch *str, rapidjson::SizeType length, bool copy) {
-            if (_path.match(FEE_MATCHER)) {
-                _transaction->feePaid = BigInt::fromString(std::string(str, length));
-            } else if (_path.match(ACCOUNT_SEQUENCE_MATCHER)) {
-                _transaction->sourceAccountSequence = BigInt::fromString(std::string(str, length));
-            } else if (_path.match(LEDGER_MATCHER)) {
+           if (_path.match(LEDGER_MATCHER)) {
                 _transaction->ledger = BigInt::fromString(std::string(str, length)).toUint64();
             }
             return true;
@@ -114,6 +110,10 @@ namespace ledger {
                 BaseConverter::decode(std::string(str, length), BaseConverter::BASE64_RFC4648, buffer);
                 stellar::xdr::Decoder decoder(buffer);
                 decoder >> _transaction->envelope;
+            } else if (_path.match(FEE_MATCHER)) {
+                _transaction->feePaid = BigInt::fromString(std::string(str, length));
+            } else if (_path.match(ACCOUNT_SEQUENCE_MATCHER)) {
+                _transaction->sourceAccountSequence = BigInt::fromString(std::string(str, length));
             }
             return true;
         }

--- a/core/test/coin-integration/stellar/synchronization_tests.cpp
+++ b/core/test/coin-integration/stellar/synchronization_tests.cpp
@@ -63,6 +63,9 @@ TEST_F(StellarFixture, SynchronizeStellarAccount) {
     for (const auto& op : operations) {
         auto record = op->asStellarLikeOperation()->getRecord();
         fmt::print("{} {} {} {}\n",   api::to_string(op->getOperationType()), op->getAmount()->toString(), op->getFees()->toString(), api::to_string(record.operationType));
+        if (op->getOperationType() == api::OperationType::SEND) {
+            EXPECT_TRUE(op->getFees()->toLong() >= 100);
+        }
     }
 
     const auto& first = operations.front();

--- a/core/test/integration/synchronization/synchronization_tests.cpp
+++ b/core/test/integration/synchronization/synchronization_tests.cpp
@@ -51,7 +51,7 @@ TEST_F(BitcoinLikeWalletSynchronization, MediumXpubSynchronization) {
 
     {
         configuration->putString(api::Configuration::KEYCHAIN_ENGINE,api::KeychainEngines::BIP173_P2WPKH);
-        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT,"https://bitcoin-mainnet.explorers.dev.aws.ledger.fr:443");
+        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT,"https://explorers.api.live.ledger.com");
         configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_VERSION, "v3");
         auto wallet = wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "bitcoin",
                                               configuration));


### PR DESCRIPTION
This PR:
- Bump libcore version to 3.4.1
- Rebase develop on master

Changelog:
- Fix SBT download failures on the CI (for Debian and MacOS)
- Fix a BTC test using a deprecated URL
- Fix Stellar fee parsing for Horizon 1.3.0