### PR TITLE
Parallelize ctest in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
             command: |
                 cd ../lib-ledger-core-build
 
-                ~/cmake-3.16.5-Linux-x86_64/bin/ctest -VV -timeout 60
+                ~/cmake-3.16.5-Linux-x86_64/bin/ctest -j 5 --output-on-failure -timeout 60
   build_macos_release:
     macos:
       xcode: "10.0.0"
@@ -232,7 +232,7 @@ jobs:
           name: Run_Tests
           command: |
               cd ../lib-ledger-core-build
-              ctest -VV -timeout 60
+              ctest -j 5 --output-on-failure -timeout 60
   publish_jar:
     macos:
       xcode: "10.0.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -129,7 +129,7 @@ build_script:
 - if %TOOL_CONFIG% == vs2017  if %BUILD_CONFIG% == Release cp "..\lib-ledger-core-build\%CRYPTO_DLL_PATH%" ".\%LIB_VERSION%\win\%TOOL_CONFIG%" || echo "FAIL TO COPY CRYPTO DLL"
 
 #Launch tests
-- if %BUILD_CONFIG% == Debug ctest --output-on-failure -VV
+- if %BUILD_CONFIG% == Debug ctest -j 4 --output-on-failure
 
 #Build is failing because of configuration
 ##Create node module

--- a/core/idl/wallet/cosmos/wallet.djinni
+++ b/core/idl/wallet/cosmos/wallet.djinni
@@ -223,7 +223,7 @@ CosmosLikeRedelegationEntry = interface +c {
 }
 
 CosmosConfigurationDefaults = interface +c {
-        const COSMOS_DEFAULT_API_ENDPOINT: string = "https://cosmos.coin.ledger.com";
+        const COSMOS_DEFAULT_API_ENDPOINT: string = "https://cosmos.coin.staging.aws.ledger.com";
         const COSMOS_OBSERVER_WS_ENDPOINT: string = "";
 }
 

--- a/core/src/database/SQLite3Backend.cpp
+++ b/core/src/database/SQLite3Backend.cpp
@@ -49,6 +49,13 @@ namespace ledger {
             _dbResolvedPath = resolver->resolveDatabasePath(dbName);
             setPassword(password, session);
             session << "PRAGMA foreign_keys = ON";
+            // All settings below can only be active during tests, the goal is to lighten the
+            // I/O load on the machine because it might end up in corrupting tests
+            //
+            // DELETE or WAL here will throw a lot of I/O errors during parallel tests
+            session << "PRAGMA journal_mode = MEMORY";
+            session << "PRAGMA synchronous = NORMAL";
+            session << "PRAGMA temp_store = MEMORY";
         }
 
         void SQLite3Backend::setPassword(const std::string &password,

--- a/core/test/cosmos/AccountTests.cpp
+++ b/core/test/cosmos/AccountTests.cpp
@@ -36,6 +36,7 @@
 #include <wallet/cosmos/CosmosLikeWallet.hpp>
 #include <wallet/cosmos/CosmosLikeCurrencies.hpp>
 #include <wallet/cosmos/factories/CosmosLikeWalletFactory.hpp>
+#include <Uuid.hpp>
 
 struct CosmosAccounts : public BaseFixture {
 
@@ -43,7 +44,7 @@ struct CosmosAccounts : public BaseFixture {
 
 TEST_F(CosmosAccounts, FirstATOMAccountInfo) {
     auto const currency = currencies::ATOM;
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     backend->enableQueryLogging(true);
 
     auto wallet = wait(pool->createWallet("my_wallet", currency.name, api::DynamicObject::newInstance()));

--- a/core/test/cosmos/Fixtures.cpp
+++ b/core/test/cosmos/Fixtures.cpp
@@ -2,6 +2,7 @@
 
 #include <wallet/cosmos/CosmosLikeConstants.hpp>
 #include <api/CosmosLikeVoteOption.hpp>
+#include <Uuid.hpp>
 
 namespace ledger {
         namespace testing {
@@ -110,9 +111,9 @@ namespace ledger {
 
                         Transaction setupTransactionResponse(const std::vector<Message>& msgs, const std::chrono::system_clock::time_point& timeRef) {
                                 Transaction tx;
-                                tx.hash = "A1E44688B429AF17322EC33CE62876FA415EFC8D9244A2F51454BD025F416594";
+                                tx.hash = uuid::generate_uuid_v4();
                                 ledger::core::Block block;
-                                block.hash = "52B39D45B438C6995CD448B09963954883B0F7A57E9EFC7A95E0A6C5BAC09C00";
+                                block.hash = uuid::generate_uuid_v4();
                                 block.currencyName = "atom";
                                 block.height = 744795;
                                 block.time = timeRef;
@@ -122,10 +123,12 @@ namespace ledger {
                                 tx.gasUsed = BigInt(26826);
                                 tx.timestamp = timeRef;
                                 tx.memo = "Sent by Ledger";
+                                auto current_index = 0;
                                 for (const auto& msg : msgs) {
                                         tx.messages.push_back(msg);
                                         MessageLog log;
-                                        log.messageIndex = 0;
+                                        log.messageIndex = current_index;
+                                        current_index++;
                                         log.success = true;
                                         log.log = "Success";
                                         tx.logs.push_back(log);

--- a/core/test/database/BaseFixture.h
+++ b/core/test/database/BaseFixture.h
@@ -60,6 +60,7 @@
 #include <soci.h>
 #include <api/Account.hpp>
 #include <api/BitcoinLikeAccount.hpp>
+#include <Uuid.hpp>
 
 using namespace ledger::core; // Only do that for testing
 using namespace ledger::qt; // Djeez
@@ -77,7 +78,7 @@ class BaseFixture : public ::testing::Test {
 public:
     void SetUp() override;
     void TearDown() override;
-    std::shared_ptr<WalletPool> newDefaultPool(std::string poolName = "my_ppol");
+    std::shared_ptr<WalletPool> newDefaultPool(std::string poolName = "my_pool");
     void createWallet(const std::shared_ptr<WalletPool>& pool,
                       const std::string& walletName,
                       const std::string& currencyName,

--- a/core/test/database/query_builder_tests.cpp
+++ b/core/test/database/query_builder_tests.cpp
@@ -51,15 +51,16 @@
 #include <api/QueryFilter.hpp>
 
 #include "BaseFixture.h"
+#include <Uuid.hpp>
 
 class QueryBuilderTest : public BaseFixture {
 
 };
 
 TEST_F(QueryBuilderTest, SimpleOperationQuery) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     {
-        auto wallet = wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+        auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "bitcoin", api::DynamicObject::newInstance()));
         auto nextIndex = wait(wallet->getNextAccountIndex());
         EXPECT_EQ(nextIndex, 0);
         auto account = createBitcoinLikeAccount(wallet, 0, P2PKH_MEDIUM_XPUB_INFO);

--- a/core/test/database/sqlcipher_tests.cpp
+++ b/core/test/database/sqlcipher_tests.cpp
@@ -31,19 +31,17 @@
 #include <gtest/gtest.h>
 #include "BaseFixture.h"
 #include <utils/FilesystemUtils.h>
+#include <Uuid.hpp>
 #include <soci.h>
 #include <soci-sqlite3.h>
 #include <chrono>
 using namespace ledger::core;
 
-
 class SQLCipherTest : public BaseFixture {
 };
 
 TEST(SQLCipherTest, SanityCheck) {
-    auto date = DateUtils::toJSON(std::chrono::system_clock::now());
-    std::remove(date.begin(), date.end(), ':');
-    auto dbName = "test_db_" + date;
+    auto dbName = "test_db_" + uuid::generate_uuid_v4();
     auto password = "test_key";
     auto newPassword = "test_key_new";
     {
@@ -101,9 +99,7 @@ TEST(SQLCipherTest, SanityCheck) {
 // https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
 #if __cplusplus >= 201103L
 TEST(SQLCipherTest, ThrowIfWrongPassword) {
-    auto date = DateUtils::toJSON(std::chrono::system_clock::now());
-    std::remove(date.begin(), date.end(), ':');
-    auto dbName = "test_db2_" + date;
+    auto dbName = "test_db2_" + uuid::generate_uuid_v4();
     auto password = "test_key";
     auto newPassword = "test_key_new";
     {
@@ -135,9 +131,7 @@ TEST(SQLCipherTest, ThrowIfWrongPassword) {
 #endif
 
 TEST(SQLCipherTest, DisableEncryption) {
-    auto date = DateUtils::toJSON(std::chrono::system_clock::now());
-    std::remove(date.begin(), date.end(), ':');
-    auto dbName = "test_db_" + date;
+    auto dbName = "test_db_" + uuid::generate_uuid_v4();
     auto password = "test_key";
     auto newPassword = "test_key_new";
     {

--- a/core/test/integration/BaseFixture.cpp
+++ b/core/test/integration/BaseFixture.cpp
@@ -140,7 +140,6 @@ const std::string TX_4 = "{\"hash\":\"4450e70656888bd7f5240a9b532eac54db7d72f3b4
 
 void BaseFixture::SetUp() {
     ::testing::Test::SetUp();
-    ledger::qt::FilesystemUtils::clearFs(IntegrationEnvironment::getInstance()->getApplicationDirPath());
     dispatcher = std::make_shared<QtThreadDispatcher>(IntegrationEnvironment::getInstance()->getApp());
     resolver = std::make_shared<NativePathResolver>(IntegrationEnvironment::getInstance()->getApplicationDirPath());
     printer = std::make_shared<CoutLogPrinter>(dispatcher->getMainExecutionContext());

--- a/core/test/integration/BaseFixture.cpp
+++ b/core/test/integration/BaseFixture.cpp
@@ -141,7 +141,7 @@ const std::string TX_4 = "{\"hash\":\"4450e70656888bd7f5240a9b532eac54db7d72f3b4
 void BaseFixture::SetUp() {
     ::testing::Test::SetUp();
     ledger::qt::FilesystemUtils::clearFs(IntegrationEnvironment::getInstance()->getApplicationDirPath());
-    dispatcher = std::make_shared<QtThreadDispatcher>();
+    dispatcher = std::make_shared<QtThreadDispatcher>(IntegrationEnvironment::getInstance()->getApp());
     resolver = std::make_shared<NativePathResolver>(IntegrationEnvironment::getInstance()->getApplicationDirPath());
     printer = std::make_shared<CoutLogPrinter>(dispatcher->getMainExecutionContext());
     http = std::make_shared<QtHttpClient>(dispatcher->getMainExecutionContext());

--- a/core/test/integration/BaseFixture.h
+++ b/core/test/integration/BaseFixture.h
@@ -97,7 +97,7 @@ class BaseFixture : public ::testing::Test {
 public:
     virtual void SetUp() override;
     virtual void TearDown() override;
-    std::shared_ptr<WalletPool> newDefaultPool(const std::string &poolName = "my_ppol",
+    std::shared_ptr<WalletPool> newDefaultPool(const std::string &poolName = "my_pool",
                                                const std::string &password = "test",
                                                const std::shared_ptr<api::DynamicObject> &configuration = api::DynamicObject::newInstance(),
                                                bool usePostgreSQL = false);

--- a/core/test/integration/IntegrationEnvironment.cpp
+++ b/core/test/integration/IntegrationEnvironment.cpp
@@ -33,13 +33,17 @@
 
 IntegrationEnvironment* IntegrationEnvironment::_instance = nullptr;
 
-IntegrationEnvironment::IntegrationEnvironment(int argc, char **argv) {
-    QCoreApplication app(argc, argv);
-    _appDir = app.applicationDirPath().toStdString();
+IntegrationEnvironment::IntegrationEnvironment(int argc, char **argv): _app(std::make_shared<QCoreApplication>(argc, argv)) {
+    // QCoreApplication app(argc, argv);
+    _appDir = _app->applicationDirPath().toStdString();
 }
 
 std::string IntegrationEnvironment::getApplicationDirPath() const {
     return _appDir;
+}
+
+std::shared_ptr<QCoreApplication> IntegrationEnvironment::getApp() const {
+    return _app;
 }
 
 IntegrationEnvironment *IntegrationEnvironment::initInstance(int argc, char **argv) {

--- a/core/test/integration/IntegrationEnvironment.h
+++ b/core/test/integration/IntegrationEnvironment.h
@@ -39,11 +39,13 @@ class IntegrationEnvironment {
 public:
     static IntegrationEnvironment* initInstance(int argc, char** argv);
     static IntegrationEnvironment* getInstance();
+    std::shared_ptr<QCoreApplication> getApp() const;
     std::string getApplicationDirPath() const;
 private:
     IntegrationEnvironment(int argc, char** argv);
 
     std::string _appDir;
+    std::shared_ptr<QCoreApplication> _app;
     static IntegrationEnvironment* _instance;
 };
 

--- a/core/test/integration/account_blockchain_observation.cpp
+++ b/core/test/integration/account_blockchain_observation.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "BaseFixture.h"
+#include <Uuid.hpp>
 
 class AccountBlockchainObservationTests : public BaseFixture {
 
@@ -49,8 +50,8 @@ static const std::string NOTIF_WITH_BLOCK_9 = "\"bcea0c64e5d51baf8615c0373e94833
 
 
 TEST_F(AccountBlockchainObservationTests, EmitNewTransaction) {
-    auto pool = newDefaultPool();
-    auto wallet = wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
+    auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "bitcoin", api::DynamicObject::newInstance()));
     auto account = createBitcoinLikeAccount(wallet, 0, P2PKH_MEDIUM_XPUB_INFO);
     auto receiver = make_receiver([&] (const std::shared_ptr<api::Event>& event) {
         if (event->getCode() == api::EventCode::NEW_OPERATION) {
@@ -68,8 +69,8 @@ TEST_F(AccountBlockchainObservationTests, EmitNewTransaction) {
 }
 
 TEST_F(AccountBlockchainObservationTests, EmitNewTransactionAndReceiveOnPool) {
-    auto pool = newDefaultPool();
-    auto wallet = wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
+    auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "bitcoin", api::DynamicObject::newInstance()));
     auto account = createBitcoinLikeAccount(wallet, 0, P2PKH_MEDIUM_XPUB_INFO);
     auto receiver = make_receiver([&] (const std::shared_ptr<api::Event>& event) {
         if (event->getCode() == api::EventCode::NEW_OPERATION) {
@@ -87,8 +88,8 @@ TEST_F(AccountBlockchainObservationTests, EmitNewTransactionAndReceiveOnPool) {
 }
 
 TEST_F(AccountBlockchainObservationTests, AutoReconnect) {
-    auto pool = newDefaultPool();
-    auto wallet = wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
+    auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "bitcoin", api::DynamicObject::newInstance()));
     auto account = createBitcoinLikeAccount(wallet, 0, P2PKH_MEDIUM_XPUB_INFO);
     auto receiver = make_receiver([&] (const std::shared_ptr<api::Event>& event) {
 
@@ -117,8 +118,8 @@ TEST_F(AccountBlockchainObservationTests, AutoReconnect) {
 }
 
 TEST_F(AccountBlockchainObservationTests, EmitNewBlock) {
-    auto pool = newDefaultPool();
-    auto wallet = wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
+    auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "bitcoin", api::DynamicObject::newInstance()));
     auto account = createBitcoinLikeAccount(wallet, 0, P2PKH_MEDIUM_XPUB_INFO);
     auto receiver = make_receiver([&] (const std::shared_ptr<api::Event>& event) {
         if (event->getCode() == api::EventCode::NEW_BLOCK) {

--- a/core/test/integration/account_creation_tests.cpp
+++ b/core/test/integration/account_creation_tests.cpp
@@ -30,11 +30,12 @@
  */
 
 #include "BaseFixture.h"
+#include <Uuid.hpp>
 
 class AccountCreationTest : public BaseFixture {};
 
 TEST_F(AccountCreationTest, CreateBitcoinAccountWithInfo) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     auto wallet = wait(pool->createWallet("my_wallet", "bitcoin", DynamicObject::newInstance()));
     auto account = std::dynamic_pointer_cast<BitcoinLikeAccount>(wait(wallet->newAccountWithInfo(P2PKH_MEDIUM_KEYS_INFO)));
     auto address = wait(account->getFreshPublicAddresses())[0]->toString();
@@ -42,14 +43,16 @@ TEST_F(AccountCreationTest, CreateBitcoinAccountWithInfo) {
 }
 
 TEST_F(AccountCreationTest, CreateBitcoinAccountWithInfoOnExistingWallet) {
+    auto poolName = uuid::generate_uuid_v4();
+    auto walletName = uuid::generate_uuid_v4();
     {
-        auto pool = newDefaultPool();
-        auto wallet = wait(pool->createWallet("my_wallet", "bitcoin", DynamicObject::newInstance()));
+        auto pool = newDefaultPool(poolName);
+        auto wallet = wait(pool->createWallet(walletName, "bitcoin", DynamicObject::newInstance()));
     }
     {
-        auto pool = newDefaultPool();
-        EXPECT_THROW(wait(pool->createWallet("my_wallet", "bitcoin", DynamicObject::newInstance())), Exception);
-        auto wallet = wait(pool->getWallet("my_wallet"));
+        auto pool = newDefaultPool(poolName);
+        EXPECT_THROW(wait(pool->createWallet(walletName, "bitcoin", DynamicObject::newInstance())), Exception);
+        auto wallet = wait(pool->getWallet(walletName));
         auto account = std::dynamic_pointer_cast<BitcoinLikeAccount>(wait(wallet->newAccountWithInfo(P2PKH_MEDIUM_KEYS_INFO)));
         auto address = wait(account->getFreshPublicAddresses())[0]->toString();
         EXPECT_EQ(address, "1DDBzjLyAmDr4qLRC2T2WJ831cxBM5v7G7");
@@ -61,7 +64,7 @@ TEST_F(AccountCreationTest, ChangePassword) {
     auto newPassword = "new_test";
 
     // Create wallet, account ... in plain DB
-    auto pool = newDefaultPool("my_pool", oldPassword);
+    auto pool = newDefaultPool(uuid::generate_uuid_v4(), oldPassword);
     {
         auto wallet = wait(pool->createWallet("my_wallet", "bitcoin", DynamicObject::newInstance()));
         auto account = std::dynamic_pointer_cast<BitcoinLikeAccount>(wait(wallet->newAccountWithInfo(P2PKH_MEDIUM_KEYS_INFO)));

--- a/core/test/integration/account_info_test.cpp
+++ b/core/test/integration/account_info_test.cpp
@@ -30,13 +30,14 @@
  */
 
 #include "BaseFixture.h"
+#include <Uuid.hpp>
 
 class AccountInfoTests : public BaseFixture {
 
 };
 
 TEST_F(AccountInfoTests, FirstAccountInfo) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     auto wallet = wait(pool->createWallet("my_wallet", "bitcoin", DynamicObject::newInstance()));
     auto info = wait(wallet->getNextAccountCreationInfo());
     EXPECT_EQ(info.index, 0);
@@ -47,7 +48,7 @@ TEST_F(AccountInfoTests, FirstAccountInfo) {
 }
 
 TEST_F(AccountInfoTests, FirstEthAccountInfo) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     auto wallet = wait(pool->createWallet("my_wallet", "ethereum", DynamicObject::newInstance()));
     auto info = wait(wallet->getNextAccountCreationInfo());
     EXPECT_EQ(info.index, 0);
@@ -57,7 +58,7 @@ TEST_F(AccountInfoTests, FirstEthAccountInfo) {
 }
 
 TEST_F(AccountInfoTests, FirstXRPAccountInfo) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     auto wallet = wait(pool->createWallet("my_wallet", "ripple", DynamicObject::newInstance()));
     auto info = wait(wallet->getNextAccountCreationInfo());
     EXPECT_EQ(info.index, 0);
@@ -68,7 +69,7 @@ TEST_F(AccountInfoTests, FirstXRPAccountInfo) {
 }
 
 TEST_F(AccountInfoTests, FirstXTZAccountInfo) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     auto wallet = wait(pool->createWallet("my_wallet", "tezos", DynamicObject::newInstance()));
     auto info = wait(wallet->getNextAccountCreationInfo());
     EXPECT_EQ(info.index, 0);
@@ -81,7 +82,7 @@ TEST_F(AccountInfoTests, FirstXTZAccountInfo) {
 TEST_F(AccountInfoTests, FirstEthCustomDerivationAccountInfo) {
     auto config = DynamicObject::newInstance();
     config->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME, "44'/<coin_type>'/<account>'/<node>/<address>");
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     auto wallet = wait(pool->createWallet("my_wallet", "ethereum", DynamicObject::newInstance()));
     auto info = wait(wallet->getNextAccountCreationInfo());
     EXPECT_EQ(info.index, 0);
@@ -90,7 +91,7 @@ TEST_F(AccountInfoTests, FirstEthCustomDerivationAccountInfo) {
 }
 
 TEST_F(AccountInfoTests, AnotherAccountInfo) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     auto wallet = wait(pool->createWallet("my_wallet", "bitcoin", DynamicObject::newInstance()));
     auto info = wait(wallet->getAccountCreationInfo(20));
     EXPECT_EQ(info.index, 20);
@@ -101,7 +102,7 @@ TEST_F(AccountInfoTests, AnotherAccountInfo) {
 }
 
 TEST_F(AccountInfoTests, GetAddressFromRange) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     auto wallet = wait(pool->createWallet("my_wallet", "bitcoin", DynamicObject::newInstance()));
     auto account = createBitcoinLikeAccount(wallet, 0, P2PKH_MEDIUM_XPUB_INFO);
 

--- a/core/test/integration/accounts_public_interfaces_test.cpp
+++ b/core/test/integration/accounts_public_interfaces_test.cpp
@@ -36,6 +36,7 @@
 #include <api/KeychainEngines.hpp>
 #include <utils/DateUtils.hpp>
 #include <iostream>
+#include <Uuid.hpp>
 using namespace std;
 class AccountsPublicInterfaceTest : public BaseFixture {
 public:
@@ -45,7 +46,7 @@ public:
     }
 
     void recreate() {
-        pool = newDefaultPool();
+        pool = newDefaultPool(uuid::generate_uuid_v4());
         wallet = wait(pool->createWallet("my_wallet", "bitcoin", DynamicObject::newInstance()));
     }
 

--- a/core/test/integration/keychains/ethereum_keychain_test.cpp
+++ b/core/test/integration/keychains/ethereum_keychain_test.cpp
@@ -39,12 +39,13 @@
 #include "keychain_test_helper.h"
 #include "../BaseFixture.h"
 #include <iostream>
+#include <Uuid.hpp>
 using namespace std;
 class EthereumKeychains : public BaseFixture {
 public:
     void testEthKeychain(const KeychainTestData &data, std::function<void (EthereumLikeKeychain&)> f) {
         auto backend = std::make_shared<ledger::core::PreferencesBackend>(
-                "/preferences/tests.db",
+                fmt::format("/preferences/{}/tests.db", uuid::generate_uuid_v4()),
                 dispatcher->getMainExecutionContext(),
                 resolver
         );
@@ -243,7 +244,7 @@ const std::vector<DerivationSchemeTestData> derivationSchemeTestData = {
 };
 
 TEST_F(EthereumKeychains, EthereumDerivationSchemes) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     auto configuration = DynamicObject::newInstance();
     {
         for (auto &elem : derivationSchemeTestData) {

--- a/core/test/integration/keychains/keychain_test_helper.h
+++ b/core/test/integration/keychains/keychain_test_helper.h
@@ -35,6 +35,7 @@
 #include <src/wallet/currencies.hpp>
 #include <api/EthereumLikeNetworkParameters.hpp>
 #include <api/Currency.hpp>
+#include <Uuid.hpp>
 #include "../BaseFixture.h"
 
 
@@ -122,7 +123,7 @@ class KeychainFixture : public BaseFixture {
 public:
     void testKeychain(const KeychainTestData &data, std::function<void (Keychain&)> f) {
         auto backend = std::make_shared<ledger::core::PreferencesBackend>(
-                "/preferences/tests.db",
+                fmt::format("/preferences/{}/tests.db", uuid::generate_uuid_v4()),
                 dispatcher->getMainExecutionContext(),
                 resolver
         );

--- a/core/test/integration/keychains/ripple_keychain_test.cpp
+++ b/core/test/integration/keychains/ripple_keychain_test.cpp
@@ -35,6 +35,7 @@
 #include <src/utils/optional.hpp>
 #include "keychain_test_helper.h"
 #include "../BaseFixture.h"
+#include <Uuid.hpp>
 using namespace std;
 class RippleKeychains : public BaseFixture {
 public:
@@ -95,7 +96,7 @@ const std::vector<DerivationSchemeData> derivationSchemeTestData = {
 };
 
 TEST_F(RippleKeychains, RippleDerivationSchemes) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     auto configuration = DynamicObject::newInstance();
     {
         for (auto &elem : derivationSchemeTestData) {

--- a/core/test/integration/synchronization/cosmos_synchronization.cpp
+++ b/core/test/integration/synchronization/cosmos_synchronization.cpp
@@ -30,6 +30,7 @@
  */
 
 #include <iostream>
+#include <chrono>
 #include <set>
 
 #include <test/cosmos/Fixtures.hpp>
@@ -55,6 +56,7 @@
 #include <wallet/cosmos/CosmosLikeOperationQuery.hpp>
 #include <wallet/cosmos/CosmosLikeConstants.hpp>
 #include <cosmos/bech32/CosmosBech32.hpp>
+#include <Uuid.hpp>
 
 #include <wallet/cosmos/database/CosmosLikeOperationDatabaseHelper.hpp>
 
@@ -76,9 +78,9 @@ public:
     const bool usePostgreSQL = true;
     auto poolConfig = DynamicObject::newInstance();
     poolConfig->putString(api::PoolConfiguration::DATABASE_NAME, "postgres://localhost:5432/test_db");
-    pool = newDefaultPool("postgres", "", poolConfig, usePostgreSQL);
+    pool = newDefaultPool(uuid::generate_uuid_v4(), "", poolConfig, usePostgreSQL);
 #else
-    pool = newDefaultPool();
+    pool = newDefaultPool(uuid::generate_uuid_v4());
 #endif
 
         explorer = std::make_shared<GaiaCosmosLikeBlockchainExplorer>(
@@ -94,7 +96,7 @@ public:
 
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME, "44'/<coin_type>'/<account>'/<node>/<address>");
-        wallet = wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "cosmos", configuration));
+        wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "cosmos", configuration));
 
         auto accountInfo = wait(wallet->getNextAccountCreationInfo());
         EXPECT_EQ(accountInfo.index, 0);
@@ -126,7 +128,7 @@ public:
      }
 
     void TearDown() override {
-        wait(pool->freshResetAll());
+        wait(pool->eraseDataSince(std::chrono::time_point<std::chrono::system_clock>{}));
         BaseFixture::TearDown();
     }
 
@@ -321,14 +323,14 @@ TEST_F(CosmosLikeWalletSynchronization, GetCurrentBlockWithExplorer) {
 }
 
 TEST_F(CosmosLikeWalletSynchronization, MediumXpubSynchronization) {
-    auto walletName = "8d99cc44-9061-43a4-9edd-f938d2007926";
+    auto walletName = uuid::generate_uuid_v4();
 #ifdef PG_SUPPORT
     const bool usePostgreSQL = true;
     auto poolConfig = DynamicObject::newInstance();
     poolConfig->putString(api::PoolConfiguration::DATABASE_NAME, "postgres://localhost:5432/test_db");
-    auto pool = newDefaultPool("postgres", "", poolConfig, usePostgreSQL);
+    auto pool = newDefaultPool(uuid::generate_uuid_v4(), "", poolConfig, usePostgreSQL);
 #else
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
 #endif
     backend->enableQueryLogging(true);
 

--- a/core/test/integration/synchronization/cosmos_synchronization_benchmarks.cpp
+++ b/core/test/integration/synchronization/cosmos_synchronization_benchmarks.cpp
@@ -60,6 +60,7 @@
 #include <wallet/cosmos/database/CosmosLikeOperationDatabaseHelper.hpp>
 #include <wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.hpp>
 #include <wallet/cosmos/transaction_builders/CosmosLikeTransactionBuilder.hpp>
+#include <Uuid.hpp>
 
 using namespace std;
 using namespace ledger::core;
@@ -98,9 +99,9 @@ class CosmosWalletSyncBenchmark : public BaseFixture {
         auto poolConfig = DynamicObject::newInstance();
         poolConfig->putString(
             api::PoolConfiguration::DATABASE_NAME, "postgres://localhost:5432/test_db");
-        pool = newDefaultPool("postgres", "", poolConfig, usePostgreSQL);
+        pool = newDefaultPool(uuid::generate_uuid_v4(), "", poolConfig, usePostgreSQL);
 #else
-        pool = newDefaultPool();
+        pool = newDefaultPool(uuid::generate_uuid_v4());
 #endif
 
         explorer = std::make_shared<GaiaCosmosLikeBlockchainExplorer>(
@@ -117,7 +118,7 @@ class CosmosWalletSyncBenchmark : public BaseFixture {
             api::Configuration::KEYCHAIN_DERIVATION_SCHEME,
             "44'/<coin_type>'/<account>'/<node>/<address>");
         wallet = wait(
-            pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "cosmos", configuration));
+            pool->createWallet(uuid::generate_uuid_v4(), "cosmos", configuration));
 
         auto accountInfo = wait(wallet->getNextAccountCreationInfo());
         EXPECT_EQ(accountInfo.index, 0);

--- a/core/test/integration/synchronization/ripple_synchronization.cpp
+++ b/core/test/integration/synchronization/ripple_synchronization.cpp
@@ -39,6 +39,7 @@
 #include <api/BlockchainExplorerEngines.hpp>
 #include <api/RippleLikeOperation.hpp>
 #include <api/RippleLikeTransaction.hpp>
+#include <Uuid.hpp>
 
 using namespace std;
 
@@ -47,12 +48,12 @@ class RippleLikeWalletSynchronization : public BaseFixture {
 };
 
 TEST_F(RippleLikeWalletSynchronization, MediumXpubSynchronization) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     {
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,
                                  "44'/<coin_type>'/<account>'/<node>/<address>");
-        auto wallet = wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "ripple", configuration));
+        auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "ripple", configuration));
         std::set<std::string> emittedOperations;
         {
             auto nextIndex = wait(wallet->getNextAccountIndex());
@@ -117,12 +118,12 @@ TEST_F(RippleLikeWalletSynchronization, MediumXpubSynchronization) {
 }
 
 TEST_F(RippleLikeWalletSynchronization, BalanceHistory) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     {
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,
                                  "44'/<coin_type>'/<account>'/<node>/<address>");
-        auto wallet = wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "ripple", configuration));
+        auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "ripple", configuration));
         std::set<std::string> emittedOperations;
         {
             auto nextIndex = wait(wallet->getNextAccountIndex());
@@ -184,10 +185,10 @@ TEST_F(RippleLikeWalletSynchronization, BalanceHistory) {
 
 const std::string NOTIF_WITH_TX = "{\"engine_result\":\"tesSUCCESS\",\"engine_result_code\":1,\"engine_result_message\":\"A destination tag is required.\",\"ledger_hash\":\"42A6250BE0CED050AD5AA7858B9D8F53E2F39377525C04B98DBB62F9321AB176\",\"ledger_index\":50394479,\"meta\":{\"AffectedNodes\":[{\"ModifiedNode\":{\"FinalFields\":{\"Account\":\"rJXvTXRLvQVhLGLaBsLE8JEFzRvNs9SY5e\",\"Balance\":\"30457198\",\"Flags\":0,\"OwnerCount\":0,\"Sequence\":72},\"LedgerEntryType\":\"AccountRoot\",\"LedgerIndex\":\"77C8BE5F5FBBFA60CB291BDE1BF0D76D961CD427539CCEF7F39F1467112F9518\",\"PreviousFields\":{\"Balance\":\"30457209\",\"Sequence\":71},\"PreviousTxnID\":\"91B5AF6E6CDA92DE8AADF6A8ABE17E0183A9A4A6CBFC1D4182D03355972E00C6\",\"PreviousTxnLgrSeq\":50394473}}],\"TransactionIndex\":12,\"TransactionResult\":\"tesSUCCESS\"},\"status\":\"success\",\"transaction\":{\"Account\":\"rJXvTXRLvQVhLGLaBsLE8JEFzRvNs9SY5e\",\"Amount\":\"1\",\"Destination\":\"rageXHB6Q4VbvvWdTzKANwjeCT4HXFCKX7\",\"Fee\":\"10\",\"Flags\":2147483648,\"Sequence\":71,\"SigningPubKey\":\"028EB02B5AEB00B704953BB1075E03AB88B34FCF38A256A0E62A7CEE5F246976E4\",\"TransactionType\":\"Payment\",\"TxnSignature\":\"3045022100E0A428A6C3F123591063C10220744026D2BE154BE00039797347C5AAAF70FF4702203843347E2CF6700536AC7236CD455AF76225FA9D5B55A1E7A1C1CE580047B482\",\"date\":623185870,\"hash\":\"AC0D84CB81E8ECA92E7EF9ABC3526FAED54DE07763A308296B28468D68D34991\"},\"type\":\"transaction\",\"validated\":true}";
 TEST_F(RippleLikeWalletSynchronization, EmitNewTransactionAndReceiveOnPool) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     {
         auto configuration = DynamicObject::newInstance();
-        auto wallet = wait(pool->createWallet("e847815f-488a-4301", "ripple", configuration));
+        auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "ripple", configuration));
         auto account = createRippleLikeAccount(wallet, 0, XRP_KEYS_INFO);
 
         auto receiver = make_receiver([&] (const std::shared_ptr<api::Event>& event) {
@@ -208,9 +209,9 @@ TEST_F(RippleLikeWalletSynchronization, EmitNewTransactionAndReceiveOnPool) {
 
 const std::string NOTIF_WITH_BLOCK = "{\"fee_base\":10,\"fee_ref\":10,\"ledger_hash\":\"43BF0F7D1131B5926153E8847CC42B8652B451DF09F94558BE8FF9FF9F846428\",\"ledger_index\":44351888,\"ledger_time\":600609550,\"reserve_base\":20000000,\"reserve_inc\":5000000,\"txn_count\":26,\"type\":\"ledgerClosed\",\"validated_ledgers\":\"32570-44351888\"}";
 TEST_F(RippleLikeWalletSynchronization, EmitNewBlock) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     {
-        auto wallet = wait(pool->createWallet("e847815f-488a-4301", "ripple", api::DynamicObject::newInstance()));
+        auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "ripple", api::DynamicObject::newInstance()));
         auto account = createRippleLikeAccount(wallet, 0, XRP_KEYS_INFO);
         auto receiver = make_receiver([&] (const std::shared_ptr<api::Event>& event) {
             if (event->getCode() == api::EventCode::NEW_BLOCK) {
@@ -238,11 +239,11 @@ TEST_F(RippleLikeWalletSynchronization, EmitNewBlock) {
 }
 
 TEST_F(RippleLikeWalletSynchronization, VaultAccountSynchronization) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     auto configuration = DynamicObject::newInstance();
     configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,
                              "44'/<coin_type>'/<account>'/<node>/<address>");
-    auto wallet = wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "ripple", configuration));
+    auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "ripple", configuration));
     auto nextIndex = wait(wallet->getNextAccountIndex());
     auto account = createRippleLikeAccount(wallet, nextIndex, VAULT_XRP_KEYS_INFO);
     auto receiver = make_receiver([=](const std::shared_ptr<api::Event> &event) {

--- a/core/test/integration/synchronization/synchronization_P2SH_tests.cpp
+++ b/core/test/integration/synchronization/synchronization_P2SH_tests.cpp
@@ -36,19 +36,20 @@
 #include <utils/DateUtils.hpp>
 #include <wallet/bitcoin/database/BitcoinLikeAccountDatabaseHelper.h>
 #include <wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h>
+#include <Uuid.hpp>
 
 class BitcoinLikeWalletP2SHSynchronization : public BaseFixture {
 
 };
 
 TEST_F(BitcoinLikeWalletP2SHSynchronization, MediumXpubSynchronization) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     {
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::KEYCHAIN_ENGINE,api::KeychainEngines::BIP49_P2SH);
         configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"49'/<coin_type>'/<account>'/<node>/<address>");
 
-        auto wallet = wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "bitcoin_testnet", configuration));
+        auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "bitcoin_testnet", configuration));
         std::set<std::string> emittedOperations;
         {
             auto nextIndex = wait(wallet->getNextAccountIndex());
@@ -88,13 +89,13 @@ TEST_F(BitcoinLikeWalletP2SHSynchronization, MediumXpubSynchronization) {
 }
 
 TEST_F(BitcoinLikeWalletP2SHSynchronization, SynchronizeOnceAtATime) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     {
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::KEYCHAIN_ENGINE,api::KeychainEngines::BIP49_P2SH);
         configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"49'/<coin_type>'/<account>'/<node>/<address>");
 
-        auto wallet = wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a62", "bitcoin_testnet",configuration));
+        auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "bitcoin_testnet",configuration));
         {
             auto nextIndex = wait(wallet->getNextAccountIndex());
             EXPECT_EQ(nextIndex, 0);
@@ -121,13 +122,13 @@ TEST_F(BitcoinLikeWalletP2SHSynchronization, SynchronizeOnceAtATime) {
 }
 
 TEST_F(BitcoinLikeWalletP2SHSynchronization, SynchronizeFromLastBlock) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     {
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::KEYCHAIN_ENGINE,api::KeychainEngines::BIP49_P2SH);
         configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"49'/<coin_type>'/<account>'/<node>/<address>");
 
-        auto wallet = wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a63", "bitcoin_testnet",configuration));
+        auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "bitcoin_testnet",configuration));
         createBitcoinLikeAccount(wallet, 0, P2SH_XPUB_INFO);
         auto synchronize = [wallet, pool, this] (bool expectNewOp) {
             auto account = wait(wallet->getAccount(0));
@@ -164,7 +165,7 @@ TEST_F(BitcoinLikeWalletP2SHSynchronization, SynchronizeFromLastBlock) {
 }
 
 TEST_F(BitcoinLikeWalletP2SHSynchronization, EraseDataSinceAfterSynchronization) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     {
         //Set configuration
         auto configuration = DynamicObject::newInstance();
@@ -172,7 +173,7 @@ TEST_F(BitcoinLikeWalletP2SHSynchronization, EraseDataSinceAfterSynchronization)
         configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,
                                  "49'/<coin_type>'/<account>'/<node>/<address>");
         //Create wallet
-        auto wallet = wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a63", "bitcoin_testnet", configuration));
+        auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "bitcoin_testnet", configuration));
         //Create account
         auto account = createBitcoinLikeAccount(wallet, 0, P2SH_XPUB_INFO);
         //Sync account
@@ -220,12 +221,12 @@ TEST_F(BitcoinLikeWalletP2SHSynchronization, EraseDataSinceAfterSynchronization)
     }
 }
 TEST_F(BitcoinLikeWalletP2SHSynchronization, TestNetSynchronization) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     {
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::KEYCHAIN_ENGINE,api::KeychainEngines::BIP49_P2SH);
         configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"49'/<coin_type>'/<account>'/<node>/<address>");
-        auto wallet = wait(pool->createWallet("testnet_wallet", "bitcoin_testnet",configuration));
+        auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "bitcoin_testnet",configuration));
         std::set<std::string> emittedOperations;
         {
             auto nextIndex = wait(wallet->getNextAccountIndex());
@@ -258,9 +259,9 @@ TEST_F(BitcoinLikeWalletP2SHSynchronization, TestNetSynchronization) {
 }
 
 TEST_F(BitcoinLikeWalletP2SHSynchronization, DecredParsingAndSerialization) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     {
-        auto wallet = wait(pool->createWallet("testnet_wallet", "decred",DynamicObject::newInstance()));
+        auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "decred",DynamicObject::newInstance()));
         auto strTx = "01000000016b9b4d4cdd2cf78907e62cddf31911ae4d4af1d89228ae4afc4459edee6a60c40100000000ffffff000240420f000000000000001976a9141d19445f397f6f0d3e2e6d741f61ba66b53886cf88acf0d31d000000000000001976a91415101bac61dca29add75996a0836a469dc8eee0788ac00000000ffffffff01000000000000000000000000ffffffff6a47304402200466bbc2aa8a742e85c3b68911502e73cdcb620ceaaa7a3cd199dbb4f8e9b969022063afeedd37d05e44b655a9de92eb36124acc045baf7b9e2941f81e41af91f1150121030ac79bab351084fdc82b4fa46eaa6a9cd2b5eb97ee93e367422bf47219b54a14";
         auto tx = BitcoinLikeTransactionApi::parseRawSignedTransaction(wallet->getCurrency(), hex::toByteArray(strTx), 0);
         EXPECT_EQ(hex::toString(tx->serialize()), strTx);

--- a/core/test/integration/synchronization/tezos_synchronization.cpp
+++ b/core/test/integration/synchronization/tezos_synchronization.cpp
@@ -43,6 +43,7 @@
 #include <wallet/tezos/delegation/TezosLikeOriginatedAccount.h>
 #include <api/TezosConfiguration.hpp>
 #include <api/TezosConfigurationDefaults.hpp>
+#include <Uuid.hpp>
 
 using namespace std;
 
@@ -55,7 +56,7 @@ class TezosLikeWalletSynchronization : public BaseFixture {
 };
 
 TEST_F(TezosLikeWalletSynchronization, MediumXpubSynchronization) {
-    auto pool = newDefaultPool("xtz", "");
+    auto pool = newDefaultPool(uuid::generate_uuid_v4(), "");
     static std::function<void (
             const std::string &,
             const std::string &,
@@ -154,18 +155,18 @@ TEST_F(TezosLikeWalletSynchronization, MediumXpubSynchronization) {
             test(nextWalletName, "", explorerURL);
         }
     };
-    test("e847815f-488a-4301-b67c-378a5e9c8a61", "e847815f-488a-4301-b67c-378a5e9c8a60", kExplorerUrl);
+    test(uuid::generate_uuid_v4(), uuid::generate_uuid_v4(), kExplorerUrl);
 }
 
 TEST_F(TezosLikeWalletSynchronization, SynchronizeAccountWithMoreThan100OpsAndDeactivateSyncToken) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     auto configuration = DynamicObject::newInstance();
     configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"44'/<coin_type>'/<account>'/<node>'/<address>");
     configuration->putString(api::TezosConfiguration::TEZOS_XPUB_CURVE, api::TezosConfigurationDefaults::TEZOS_XPUB_CURVE_ED25519);
     configuration->putBoolean(api::Configuration::DEACTIVATE_SYNC_TOKEN, true);
     configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, api::BlockchainExplorerEngines::TZSTATS_API);
     configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT, kExplorerUrl);
-    auto wallet = wait(pool->createWallet("xtz", "tezos", configuration));
+    auto wallet = wait(pool->createWallet(uuid::generate_uuid_v4(), "tezos", configuration));
     auto account = createTezosLikeAccount(wallet, 0, XTZ_WITH_100_OPS_KEYS_INFO);
     account->synchronize()->subscribe(account->getContext(), make_receiver([=](const std::shared_ptr<api::Event> &event) {
         if (event->getCode() == api::EventCode::SYNCHRONIZATION_STARTED)

--- a/core/test/integration/transactions/bitcoin_P2PKH_transaction_tests.cpp
+++ b/core/test/integration/transactions/bitcoin_P2PKH_transaction_tests.cpp
@@ -84,7 +84,7 @@ struct BitcoinStardustTransaction : public BitcoinMakeBaseTransaction {
     }
 
     void recreate() override {
-        pool = newDefaultPool();
+        pool = newDefaultPool(uuid::generate_uuid_v4());
         pool->addCurrency(bitcoinStardust);
         wallet = wait(pool->createWallet(testData.walletName, testData.currencyName, testData.configuration));
         account = testData.inflate_btc(pool, wallet);

--- a/core/test/integration/transactions/transaction_test_helper.h
+++ b/core/test/integration/transactions/transaction_test_helper.h
@@ -47,6 +47,8 @@
 #include <wallet/tezos/TezosLikeAccount.h>
 #include <wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.h>
 #include "../BaseFixture.h"
+#include <Uuid.hpp>
+#include <chrono>
 
 
 using namespace ledger::core;
@@ -76,7 +78,7 @@ struct BitcoinMakeBaseTransaction : public BaseFixture {
     }
 
     virtual void recreate() {
-        pool = newDefaultPool();
+        pool = newDefaultPool(uuid::generate_uuid_v4());
         wallet = wait(pool->createWallet(testData.walletName, testData.currencyName, testData.configuration));
         account = testData.inflate_btc(pool, wallet);
         currency = wallet->getCurrency();
@@ -84,6 +86,7 @@ struct BitcoinMakeBaseTransaction : public BaseFixture {
 
     void TearDown() override {
         BaseFixture::TearDown();
+        wait(pool->eraseDataSince(std::chrono::time_point<std::chrono::system_clock>{}));
         pool = nullptr;
         wallet = nullptr;
         account = nullptr;
@@ -111,7 +114,7 @@ struct EthereumMakeBaseTransaction : public BaseFixture {
     }
 
     void recreate() {
-        pool = newDefaultPool();
+        pool = newDefaultPool(uuid::generate_uuid_v4());
         wallet = wait(pool->createWallet(testData.walletName, testData.currencyName, testData.configuration));
         account = testData.inflate_eth(pool, wallet);
         currency = wallet->getCurrency();
@@ -119,6 +122,7 @@ struct EthereumMakeBaseTransaction : public BaseFixture {
 
     void TearDown() override {
         BaseFixture::TearDown();
+        wait(pool->eraseDataSince(std::chrono::time_point<std::chrono::system_clock>{}));
         pool = nullptr;
         wallet = nullptr;
         account = nullptr;
@@ -146,7 +150,7 @@ struct RippleMakeBaseTransaction : public BaseFixture {
     }
 
     void recreate() {
-        pool = newDefaultPool();
+        pool = newDefaultPool(uuid::generate_uuid_v4());
         wallet = wait(pool->createWallet(testData.walletName, testData.currencyName, testData.configuration));
         account = testData.inflate_xrp(pool, wallet);
         currency = wallet->getCurrency();
@@ -154,6 +158,7 @@ struct RippleMakeBaseTransaction : public BaseFixture {
 
     void TearDown() override {
         BaseFixture::TearDown();
+        wait(pool->eraseDataSince(std::chrono::time_point<std::chrono::system_clock>{}));
         pool = nullptr;
         wallet = nullptr;
         account = nullptr;
@@ -181,7 +186,7 @@ struct TezosMakeBaseTransaction : public BaseFixture {
     }
 
     void recreate() {
-        pool = newDefaultPool();
+        pool = newDefaultPool(uuid::generate_uuid_v4());
         wallet = wait(pool->createWallet(testData.walletName, testData.currencyName, testData.configuration));
         account = testData.inflate_xtz(pool, wallet);
         currency = wallet->getCurrency();
@@ -189,6 +194,7 @@ struct TezosMakeBaseTransaction : public BaseFixture {
 
     void TearDown() override {
         BaseFixture::TearDown();
+        wait(pool->eraseDataSince(std::chrono::time_point<std::chrono::system_clock>{}));
         pool = nullptr;
         wallet = nullptr;
         account = nullptr;

--- a/core/test/integration/wallet_database_tests.cpp
+++ b/core/test/integration/wallet_database_tests.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "BaseFixture.h"
+#include <Uuid.hpp>
 
 static const std::string XPUB_1 = "xpub6EedcbfDs3pkzgqvoRxTW6P8NcCSaVbMQsb6xwCdEBzqZBronwY3Nte1Vjunza8f6eSMrYvbM5CMihGo6SbzpHxn4R5pvcr2ZbZ6wkDmgpy";
 
@@ -43,7 +44,7 @@ class BitcoinWalletDatabaseTests : public BaseFixture {
 };
 
 TEST_F(BitcoinWalletDatabaseTests, EmptyWallet) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     BitcoinLikeWalletDatabase db(pool, "my_wallet", "bitcoin");
 
     EXPECT_EQ(db.getAccountsCount(), 0);
@@ -51,7 +52,7 @@ TEST_F(BitcoinWalletDatabaseTests, EmptyWallet) {
 }
 
 TEST_F(BitcoinWalletDatabaseTests, CreateWalletWithOneAccount) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
 
     BitcoinLikeWalletDatabase db(pool, "my_wallet", "bitcoin");
 
@@ -69,7 +70,7 @@ TEST_F(BitcoinWalletDatabaseTests, CreateWalletWithOneAccount) {
 }
 
 TEST_F(BitcoinWalletDatabaseTests, CreateWalletWithMultipleAccountAndDelete) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
 
     auto currencyName = "bitcoin";
     auto configuration = DynamicObject::newInstance();
@@ -97,7 +98,7 @@ TEST_F(BitcoinWalletDatabaseTests, CreateWalletWithMultipleAccountAndDelete) {
 }
 
 TEST_F(BitcoinWalletDatabaseTests, PutTransaction) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
 
     auto currencyName = "bitcoin";
     auto configuration = DynamicObject::newInstance();
@@ -123,7 +124,7 @@ TEST_F(BitcoinWalletDatabaseTests, PutTransaction) {
 }
 
 TEST_F(BitcoinWalletDatabaseTests, PutTransactionWithMultipleOutputs) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
 
     auto currencyName = "bitcoin";
     auto configuration = DynamicObject::newInstance();
@@ -184,7 +185,7 @@ TEST_F(BitcoinWalletDatabaseTests, PutTransactionWithMultipleOutputs) {
 }
 
 TEST_F(BitcoinWalletDatabaseTests, PutOperations) {
-    auto pool = newDefaultPool();
+    auto pool = newDefaultPool(uuid::generate_uuid_v4());
     auto wallet = wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
     auto nextIndex = wait(wallet->getNextAccountIndex());
     EXPECT_EQ(nextIndex, 0);

--- a/core/test/lib/libledger-test/NativePathResolver.cpp
+++ b/core/test/lib/libledger-test/NativePathResolver.cpp
@@ -62,7 +62,8 @@ std::string NativePathResolver::resolvePreferencesPath(const std::string &path) 
 
 void NativePathResolver::clean() {
     for (auto path : _createdPaths) {
-        //ledger::core::fs::remove_all(path);
+        // ledger::core::fs::remove_all(path);
+        // QFile::remove(QString::fromStdString(path));
     }
 }
 

--- a/core/test/lib/libledger-test/Uuid.hpp
+++ b/core/test/lib/libledger-test/Uuid.hpp
@@ -31,9 +31,7 @@
  * SOFTWARE.
  *
  */
-#ifndef LEDGER_CORE_UUID_HPP
-#define LEDGER_CORE_UUID_HPP
-
+#pragma once
 #include <random>
 #include <sstream>
 
@@ -43,7 +41,7 @@ namespace uuid {
     static std::uniform_int_distribution<> dis(0, 15);   // **** random byte
     static std::uniform_int_distribution<> dis2(8, 11);  // 10** in MSB-first order
 
-    std::string generate_uuid_v4() {
+    static std::string generate_uuid_v4() {
         std::stringstream ss;
         int i;
         ss << std::hex;
@@ -70,5 +68,3 @@ namespace uuid {
         return ss.str();
     }
 }
-
-#endif  // LEDGER_CORE_UUID_HPP

--- a/core/test/lib/libledger-test/Uuid.hpp
+++ b/core/test/lib/libledger-test/Uuid.hpp
@@ -1,0 +1,74 @@
+/*
+ *
+ * Uuid
+ * RFC 4122 compliant implementation of Universally Unique IDentifiers
+ * https://tools.ietf.org/html/rfc4122
+ *
+ * ledger-core
+ *
+ * Created by Gerry Agbobada on 09/06/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+#ifndef LEDGER_CORE_UUID_HPP
+#define LEDGER_CORE_UUID_HPP
+
+#include <random>
+#include <sstream>
+
+namespace uuid {
+    static std::random_device              rd;
+    static std::mt19937                    gen(rd());
+    static std::uniform_int_distribution<> dis(0, 15);   // **** random byte
+    static std::uniform_int_distribution<> dis2(8, 11);  // 10** in MSB-first order
+
+    std::string generate_uuid_v4() {
+        std::stringstream ss;
+        int i;
+        ss << std::hex;
+        for (i = 0; i < 8; i++) {
+            ss << dis(gen);
+        }
+        ss << "-";
+        for (i = 0; i < 4; i++) {
+            ss << dis(gen);
+        }
+        ss << "-4";
+        for (i = 0; i < 3; i++) {
+            ss << dis(gen);
+        }
+        ss << "-";
+        ss << dis2(gen);
+        for (i = 0; i < 3; i++) {
+            ss << dis(gen);
+        }
+        ss << "-";
+        for (i = 0; i < 12; i++) {
+            ss << dis(gen);
+        };
+        return ss.str();
+    }
+}
+
+#endif  // LEDGER_CORE_UUID_HPP


### PR DESCRIPTION
## Purpose

Got to fail faster.

## Changes

- [x] Run all ctest in CI in parallel
- [x] Only produce the output from tests if failing (otherwise it gets messy really quickly)
- [x] Randomize the uids in tests : `pool` names, `wallet` names so that no database conflicts occur when reading/writing from sqlite databases
- [ ] Add pragmas to sqlite3Backend to help filesystem handle the additional load on Disk I/O coming from parallel tests
- [x] Use `WalletPool::eraseDataSince` as much as possible instead of using `freshResetAll` to reduce filesystem load *and* to prevent race conditions on PgSQL backend that use a single `database`

## Known issues (aka HODL status)

- [x] GetAccountAfterPoolReopen fails : `newDefaultPool(poolName)` with an already used `poolName` fails to get the older database. But only in parallel runs. This means all tests using a second call to `newDefaultPool` to check wallets/operations are "additional failures" compared to sequential runs. This is under investigation
- [ ] The real bottleneck here is filesystem, sqlite3Backend currently does not fail gracefully if it needs to wait for filesystem/Disk bandwidth.
- [ ] The sqlite3 backend performance pragmas should only be enabled in the tests

## Notes

- This is a draft, just to see if we encounter the same I/O problems in CI environments
- Testing on PostgresQL backend : tests that can switch automatically from sqlite to postgresQL do the switch and never fail. The test database is not randomized (because it needs to be created Ahead Of Time) so to avoid issues with `freshResetAll()` racing against `WalletPool::newInstance()` the use of the former one has been reduced as much as possible (only one call left in the test that actually has `FreshResetAll` in its name) and `eraseDataSince(epoch)` is used instead.