### PR TITLE
Release libcore 3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 ## 3.4.1
+> 2020/06/11
+
+- Multiple fixes on Cosmos integration:
+    * Use staging URL for explorer
+    * Do not include fees user didn't pay in operations
+    * Add baseline gas cost to estimation
+    * Handle fees properly in balance history
+    * Always return a derivation path in address object ("" is returned when the address doesn't belong to the wallet)
+
+
+## 3.4.1
 > 2020/06/10
 
 - Fix SBT download failures on the CI (for Debian and MacOS)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.4.1
+> 2020/06/10
+
+- Fix SBT download failures on the CI (for Debian and MacOS)
+- Fix a BTC test using a deprecated URL
+- Fix Stellar fee parsing for Horizon 1.3.0
+
 ## 3.4.0
 
 > 2020/06/01

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(UseBackportedModules)
 # The project version number.
 set(VERSION_MAJOR   3   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   4   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   1   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   2   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(UseBackportedModules)
 # The project version number.
 set(VERSION_MAJOR   3   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   4   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   0   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   1   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 1.0.{build}
 image:
 - Visual Studio 2017
 environment:
-  LIB_VERSION: 3.4.0 # Hardcode the LIB_VERSION : should be retrieved by building libcore node module and run tests/lib_version.js
+  LIB_VERSION: 3.4.1 # Hardcode the LIB_VERSION : should be retrieved by building libcore node module and run tests/lib_version.js
   nodejs_version: "9"
   appveyor_rdp_password:
     secure: jb1LsDmcxCww7tA38S3xSw==

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 1.0.{build}
 image:
 - Visual Studio 2017
 environment:
-  LIB_VERSION: 3.4.1 # Hardcode the LIB_VERSION : should be retrieved by building libcore node module and run tests/lib_version.js
+  LIB_VERSION: 3.4.2 # Hardcode the LIB_VERSION : should be retrieved by building libcore node module and run tests/lib_version.js
   nodejs_version: "9"
   appveyor_rdp_password:
     secure: jb1LsDmcxCww7tA38S3xSw==


### PR DESCRIPTION
- Multiple fixes on Cosmos integration:
    * Use staging URL for explorer
    * Do not include fees user didn't pay in operations
    * Add baseline gas cost to estimation
    * Handle fees properly in balance history
    * Always return a derivation path in address object ("" is returned when the address doesn't belong to the wallet)
