### PR TITLE
[cosmos] Force account-level data synchronization on getSequence

### DIFF
--- a/core/src/api/CosmosConfigurationDefaults.cpp
+++ b/core/src/api/CosmosConfigurationDefaults.cpp
@@ -5,7 +5,7 @@
 
 namespace ledger { namespace core { namespace api {
 
-std::string const CosmosConfigurationDefaults::COSMOS_DEFAULT_API_ENDPOINT = {"http://lite-client-0e27eefb-4031-4859-a88e-249fd241989d.cosmos.bison.run:1317"};
+std::string const CosmosConfigurationDefaults::COSMOS_DEFAULT_API_ENDPOINT = {"https://cosmos.coin.staging.aws.ledger.com"};
 
 std::string const CosmosConfigurationDefaults::COSMOS_OBSERVER_WS_ENDPOINT = {""};
 

--- a/core/src/wallet/cosmos/CosmosLikeAccount.cpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.cpp
@@ -101,6 +101,26 @@ void CosmosLikeAccount::updateFromDb()
     }
 }
 
+void CosmosLikeAccount::updateAccountDataFromNetwork()
+{
+    auto self = std::static_pointer_cast<CosmosLikeAccount>(shared_from_this());
+    _explorer->getAccount(getAddress())
+        .onComplete(getContext(), [self](const TryPtr<cosmos::Account> &accountData) mutable {
+            if (accountData.isSuccess()) {
+                self->_accountData = accountData.getValue();
+                const CosmosLikeAccountDatabaseEntry update = {
+                    0,  // unused in
+                        // CosmosLikeAccountDatabaseHelper::updateAccount
+                    "",  // unused in
+                         // CosmosLikeAccountDatabaseHelper::updateAccount
+                    *(self->_accountData),
+                    std::chrono::system_clock::now()};
+                soci::session sql(self->getWallet()->getDatabase()->getPool());
+                CosmosLikeAccountDatabaseHelper::updateAccount(sql, self->getAccountUid(), update);
+            }
+        });
+}
+
 std::string CosmosLikeAccount::getAddress() const
 {
     return getKeychain()->getAddress()->toBech32();
@@ -527,7 +547,8 @@ Future<std::vector<std::shared_ptr<api::Amount>>> CosmosLikeAccount::getBalanceH
                         // NOTE : we ignore the fees field here as well, since the fees paid by the Account
                         // were already included in an OperationType::SEND
                         // See CosmosLikeAccount::fillOperationTypeAmountFromFees
-                        // Therefore, nothing to do on default: case.
+                        // Therefore, nothing to
+                        // do on default: case.
                     } break;
                     }
                 }
@@ -612,37 +633,7 @@ std::shared_ptr<api::EventBus> CosmosLikeAccount::synchronize()
             }
         });
 
-    // Update account level data (sequence, accountnumber...)
-    // Example result from Gaia explorer :
-    // base_url/auth/accounts/{address} with a valid, 0 transaction address :
-    // {
-    //  "height": "1296656",
-    //  "result": {
-    //    "type": "cosmos-sdk/Account",
-    //    "value": {
-    //      "address": "",
-    //      "coins": [],
-    //      "public_key": null,
-    //      "account_number": "0",
-    //      "sequence": "0"
-    //    }
-    //  }
-    //}
-    _explorer->getAccount(getAddress())
-        .onComplete(getContext(), [self](const TryPtr<cosmos::Account> &accountData) mutable {
-            if (accountData.isSuccess()) {
-                self->_accountData = accountData.getValue();
-                const CosmosLikeAccountDatabaseEntry update = {
-                    0,  // unused in
-                        // CosmosLikeAccountDatabaseHelper::updateAccount
-                    "",  // unused in
-                         // CosmosLikeAccountDatabaseHelper::updateAccount
-                    *(self->_accountData),
-                    std::chrono::system_clock::now()};
-                soci::session sql(self->getWallet()->getDatabase()->getPool());
-                CosmosLikeAccountDatabaseHelper::updateAccount(sql, self->getAccountUid(), update);
-            }
-        });
+    updateAccountDataFromNetwork();
 
     auto startTime = DateUtils::now();
     eventPublisher->postSticky(
@@ -785,6 +776,7 @@ void CosmosLikeAccount::estimateGas(
 
 void CosmosLikeAccount::getSequence(const std::shared_ptr<api::StringCallback> &callback)
 {
+    updateAccountDataFromNetwork();
     if (!_accountData) {
         throw make_exception(api::ErrorCode::ILLEGAL_STATE, "account must be synchronized first");
     }

--- a/core/src/wallet/cosmos/CosmosLikeAccount.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.hpp
@@ -228,6 +228,24 @@ class CosmosLikeAccount : public api::CosmosLikeAccount, public AbstractAccount 
     std::shared_ptr<CosmosLikeAccount> getSelf();
     void updateFromDb();
 
+    /// Updates account level data (sequence, accountNumber, ...)
+    /// Example result from Gaia explorer :
+    /// base_url/auth/accounts/{address} with a valid, 0 transaction address :
+    /// {
+    ///  "height": "1296656",
+    ///  "result": {
+    ///    "type": "cosmos-sdk/Account",
+    ///    "value": {
+    ///      "address": "",
+    ///      "coins": [],
+    ///      "public_key": null,
+    ///      "account_number": "0",
+    ///      "sequence": "0"
+    ///    }
+    ///  }
+    /// }
+    void updateAccountDataFromNetwork();
+
     // These helpers stay on CosmosLikeAccount *only* because they have to use their
     // knowledge of Address information in order to correctly map operation type.
     // An operation type is always seen from the account point of view.


### PR DESCRIPTION
This fixes an issue where the "getSequence()" call was not up to date
when called more often than the full account synchronization.

The update is _not_ called on getAccountNumber() since this value is
immutable.