### PR TITLE
Empty transaction built improvement

### DIFF
--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
@@ -630,7 +630,7 @@ namespace ledger {
         std::shared_ptr<api::BitcoinLikeTransactionBuilder> BitcoinLikeAccount::buildTransaction(std::experimental::optional<bool> partial) {
             auto self = std::dynamic_pointer_cast<BitcoinLikeAccount>(shared_from_this());
             auto getUTXO = [=]() -> Future<std::vector<BitcoinLikeUtxo>> {
-                return async<std::vector<BitcoinLikeUtxo>>([=]() {
+                return Future<std::vector<BitcoinLikeUtxo>>::async(getContext(), [=]() {
                     auto keychain = self->getKeychain();
                     soci::session session(self->getWallet()->getDatabase()->getPool());
 

--- a/core/src/wallet/bitcoin/database/BitcoinLikeUTXODatabaseHelper.cpp
+++ b/core/src/wallet/bitcoin/database/BitcoinLikeUTXODatabaseHelper.cpp
@@ -33,6 +33,7 @@
 #include "BitcoinLikeUTXODatabaseHelper.h"
 #include <database/soci-number.h>
 #include <database/soci-option.h>
+#include <utils/Option.hpp>
 
 using namespace soci;
 
@@ -71,6 +72,7 @@ namespace ledger {
             for (auto& row : rows) {
                 if (row.get_indicator(0) != i_null && filter(row.get<std::string>(0))) {
                     BitcoinLikeBlockchainExplorerOutput output;
+                   
                     output.address = row.get<Option<std::string>>(0);
                     output.index = get_number<uint64_t>(row, 1);
                     output.transactionHash = row.get<std::string>(2);
@@ -86,7 +88,37 @@ namespace ledger {
             return out.size();
         }
 
+        std::vector<BitcoinLikeUtxo> BitcoinLikeUTXODatabaseHelper::queryAllUtxos(
+            soci::session &session, std::string const &accountUid, api::Currency const &currency)
+        {
+            soci::rowset<soci::row> rows = (
+                session.prepare <<
+                    "SELECT o.address, o.idx, o.transaction_hash, o.amount, o.script, o.block_height "
+                    "FROM bitcoin_outputs AS o "
+                    "LEFT OUTER JOIN bitcoin_inputs AS i ON i.previous_tx_uid = o.transaction_uid AND i.previous_output_idx = o.idx "
+                    "WHERE i.previous_tx_uid IS NULL AND o.account_uid = :uid "
+                    "ORDER BY o.block_height",
+                use(accountUid));
 
+            std::vector<BitcoinLikeUtxo> utxos;
 
+            for (auto& row : rows) {
+                if (row.get_indicator(0) != i_null) {
+                    BitcoinLikeUtxo output{
+                        get_number<uint64_t>(row, 1),
+                        row.get<std::string>(2),
+                        Amount(currency, 0, row.get<BigInt>(3)),
+                        row.get<Option<std::string>>(0),
+                        accountUid,
+                        row.get<std::string>(4),
+                        row.get_indicator(5) != i_null ? Option<uint64_t>{row.get<BigInt>(5).toUint64()} : Option<uint64_t>{}
+                    };
+
+                    utxos.push_back(output);
+                }
+            }
+
+            return utxos;
+        }
     }
 }

--- a/core/src/wallet/bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp
+++ b/core/src/wallet/bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp
@@ -37,6 +37,7 @@
 
 #include <api/Error.hpp>
 #include <api/BigInt.hpp>
+#include <api/Currency.hpp>
 #include <async/Future.hpp>
 #include <collections/collections.hpp>
 #include <math/BigInt.h>
@@ -44,9 +45,11 @@
 #include <utils/optional.hpp>
 #include <utils/Option.hpp>
 #include <wallet/common/explorers/AbstractBlockchainExplorer.h>
+#include <wallet/common/Amount.h>
 
 namespace ledger {
     namespace core {
+
         struct BitcoinLikeBlockchainExplorerInput {
             uint64_t index;
             Option<BigInt> value;
@@ -55,11 +58,7 @@ namespace ledger {
             Option<std::string> address;
             Option<std::string> signatureScript;
             Option<std::string> coinbase;
-            uint32_t sequence;
-
-            BitcoinLikeBlockchainExplorerInput() {
-                sequence = 0xFFFFFFFF;
-            };
+            uint32_t sequence = 0xFFFFFFFF;
         };
 
         struct BitcoinLikeBlockchainExplorerOutput {
@@ -74,6 +73,7 @@ namespace ledger {
             bool replaceable;
 
             BitcoinLikeBlockchainExplorerOutput() = default;
+            BitcoinLikeBlockchainExplorerOutput(BitcoinLikeBlockchainExplorerOutput const&) = default;
         };
 
         struct BitcoinLikeBlockchainExplorerTransaction {

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.cpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.cpp
@@ -37,6 +37,7 @@
 #include <wallet/bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
 
 #include <random>
+#include <numeric>
 
 namespace ledger {
     namespace core {
@@ -435,11 +436,10 @@ namespace ledger {
             std::vector<BitcoinLikeUtxo> out;
 
             //Random shuffle utxos
-            std::vector<size_t> indexes;
-            auto const seed = std::chrono::system_clock::now().time_since_epoch().count();
-
-            indexes.reserve(utxos.size());
+            std::vector<size_t> indexes(utxos.size());
             std::iota(indexes.begin(), indexes.end(), 0);
+
+            auto const seed = std::chrono::system_clock::now().time_since_epoch().count();
             std::shuffle(indexes.begin(), indexes.end(), std::default_random_engine(seed));
 
             //Add fees for a signed input to amount

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.cpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.cpp
@@ -106,7 +106,7 @@ namespace ledger {
 
             buddy->logger->debug("Start filterWithDeepFirst");
 
-            return filterWithSort(buddy, utxos, aggregatedAmount, [] (auto &lhs, auto &rhs) {
+            return filterWithSort(buddy, utxos, aggregatedAmount, currency, [] (auto &lhs, auto &rhs) {
                 constexpr auto maxBlockHeight = std::numeric_limits<uint64_t>::max();
                 return lhs.blockHeight.getValueOr(maxBlockHeight) < rhs.blockHeight.getValueOr(maxBlockHeight);
             });
@@ -542,7 +542,7 @@ namespace ledger {
 
             buddy->logger->debug("Start filterWithMergeOutputs");
 
-            return filterWithSort(buddy, utxos, aggregatedAmount, [](auto &lhs, auto &rhs) {
+            return filterWithSort(buddy, utxos, aggregatedAmount, currency, [](auto &lhs, auto &rhs) {
                 return lhs.value.toLong() < rhs.value.toLong();
             });
         }
@@ -551,7 +551,7 @@ namespace ledger {
                 const std::shared_ptr<BitcoinLikeUtxoPicker::Buddy> &buddy,
                 std::vector<BitcoinLikeUtxo> utxos,
                 BigInt amount,
-                const api::Currency& curreny,
+                const api::Currency& currency,
                 std::function<bool(BitcoinLikeUtxo&, BitcoinLikeUtxo&)> const& functor)
         {
             auto pickedUtxos = std::vector<BitcoinLikeUtxo>{};

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.cpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.cpp
@@ -186,26 +186,26 @@ namespace ledger {
                                                                      currency,
                                                                      buddy->keychain->getKeychainEngine());
             //Size of only 1 output (without fixed size)
-            auto const oneOutputSize = BitcoinLikeTransactionApi::estimateSize(0,
+            const int64_t oneOutputSize = BitcoinLikeTransactionApi::estimateSize(0,
                                                                          1,
                                                                          currency,
                                                                          buddy->keychain->getKeychainEngine()).Max - fixedSize.Max;
             //Size 1 signed UTXO (signed input)
-            auto const signedUTXOSize = BitcoinLikeTransactionApi::estimateSize(1,
+            const int64_t signedUTXOSize = BitcoinLikeTransactionApi::estimateSize(1,
                                                                           0,
                                                                           currency,
                                                                           buddy->keychain->getKeychainEngine()).Max - fixedSize.Max;
 
             //Size of unsigned change
-            auto const changeSize = oneOutputSize;
+            const int64_t changeSize = oneOutputSize;
             //Size of signed change
-            auto const signedChangeSize = signedUTXOSize;
+            const int64_t signedChangeSize = signedUTXOSize;
 
-            auto const effectiveFees = buddy->request.feePerByte;
+            const int64_t effectiveFees = buddy->request.feePerByte->toInt64();
             // Here signedChangeSize should be multiplied by discard fees
             // but since we don't have access to estimateSmartFees, we assume
             // that discard fees are equal to effectiveFees
-            const int64_t costOfChange = effectiveFees->toInt64() * (signedChangeSize + changeSize);
+            const int64_t costOfChange = effectiveFees * (signedChangeSize + changeSize);
 
             buddy->logger->debug("Cost of change {}, signedChangeSize {}, changeSize {}", costOfChange, signedChangeSize, changeSize);
 
@@ -222,10 +222,10 @@ namespace ledger {
             std::vector<EffectiveUtxo> effectiveUtxos;
             //Get size of utxos as a signed input in a transaction
             for (auto& utxo : utxos) {
-                auto outEffectiveValue = utxo.value.toLong() - effectiveFees->toInt64() * signedUTXOSize;
+                int64_t outEffectiveValue = utxo.value.toLong() - effectiveFees * signedUTXOSize;
                 if (outEffectiveValue > 0) {
-                    auto outEffectiveFees = effectiveFees->toInt64() * signedUTXOSize;
-                    auto outLongTermFees = longTermFees * signedUTXOSize;
+                    int64_t outEffectiveFees = effectiveFees * signedUTXOSize;
+                    int64_t outLongTermFees = longTermFees * signedUTXOSize;
                     effectiveUtxos.push_back(EffectiveUtxo{&utxo, outEffectiveValue, outEffectiveFees, outLongTermFees});
                     currentAvailableValue += outEffectiveValue;
                 }
@@ -233,7 +233,7 @@ namespace ledger {
 
             //Get no inputs fees
             // At beginning, there are no outputs in tx, so noInputFees are fixed fees
-            int64_t notInputFees = effectiveFees->toInt64() * (fixedSize.Max + (int64_t)(oneOutputSize * buddy->request.outputs.size()));//at least fixed size and outputs(version...)
+            int64_t notInputFees = effectiveFees * (fixedSize.Max + (int64_t)(oneOutputSize * buddy->request.outputs.size()));//at least fixed size and outputs(version...)
 
             //Start coin selection algorithm (according to SelectCoinBnb from Bitcoin Core)
             int64_t currentValue = 0;
@@ -407,12 +407,12 @@ namespace ledger {
                                                                      currency,
                                                                      buddy->keychain->getKeychainEngine());
             //Size of one output (without fixed size)
-            auto const oneOutputSize = BitcoinLikeTransactionApi::estimateSize(0,
+            const int64_t oneOutputSize = BitcoinLikeTransactionApi::estimateSize(0,
                                                                          1,
                                                                          currency,
                                                                          buddy->keychain->getKeychainEngine()).Max - fixedSize.Max;
             //Size of UTXO as signed input in tx
-            auto const signedUTXOSize = BitcoinLikeTransactionApi::estimateSize(1,
+            const int64_t signedUTXOSize = BitcoinLikeTransactionApi::estimateSize(1,
                                                                           0,
                                                                           currency,
                                                                           buddy->keychain->getKeychainEngine()).Max - fixedSize.Max;
@@ -420,11 +420,11 @@ namespace ledger {
             const int64_t signedUTXOCost = signedUTXOSize * buddy->request.feePerByte->toInt64();
 
             //Amount + fixed size fees + outputs fees
-            auto const amountWithFixedFees = buddy->request.feePerByte->toInt64() * (fixedSize.Max + (buddy->request.outputs.size() * oneOutputSize)) + buddy->outputAmount.toInt64();
+            const int64_t amountWithFixedFees = buddy->request.feePerByte->toInt64() * (fixedSize.Max + (buddy->request.outputs.size() * oneOutputSize)) + buddy->outputAmount.toInt64();
 
             // Minimum amount from which we are willing to create a change for it
             // We take the dust as a reference plus the cost of spending this change
-            auto const minimumChange = currency.bitcoinLikeNetworkParameters->DustAmount + signedUTXOCost;
+            const int64_t minimumChange = currency.bitcoinLikeNetworkParameters->DustAmount + signedUTXOCost;
 
             buddy->logger->debug("Start filterWithKnapsackSolver, target range is {} to {}", amountWithFixedFees, amountWithFixedFees + minimumChange);
 
@@ -446,8 +446,8 @@ namespace ledger {
             for (auto index : indexes) {
                 auto& utxo = utxos[index];
 
-                auto const currentAmount = utxo.value.toLong();
-                auto const currentAmountWithDeductedCost = currentAmount - signedUTXOCost;
+                const int64_t currentAmount = utxo.value.toLong();
+                const int64_t currentAmountWithDeductedCost = currentAmount - signedUTXOCost;
                 if (currentAmountWithDeductedCost == amountWithFixedFees) {
                     buddy->logger->debug("Found UTXO with right amount: {}", currentAmount);
                     out.push_back(utxo);
@@ -529,6 +529,10 @@ namespace ledger {
                 // Set amount of change
                 // Change amount = amountWithFixedFees + fees for 1 additional output (change)
                 buddy->changeAmount =  BigInt(bestValue - (int64_t)(amountWithFixedFees + oneOutputSize * buddy->request.feePerByte->toInt64()));
+            }
+
+            if (buddy->changeAmount.toInt64() < minimumChange) {
+                buddy->changeAmount = BigInt(0);
             }
 
             return out;

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.h
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.h
@@ -33,6 +33,7 @@
 #define LEDGER_CORE_BITCOINLIKESTRATEGYUTXOPICKER_H
 
 #include "BitcoinLikeUtxoPicker.h"
+#include <wallet/bitcoin/transaction_builders/BitcoinLikeUtxo.hpp>
 
 namespace ledger {
     namespace core {
@@ -47,21 +48,21 @@ namespace ledger {
                                           const api::Currency &currency);
         public:
             static UTXODescriptorList filterWithKnapsackSolver(const std::shared_ptr<Buddy>& buddy,
-                const std::vector<std::shared_ptr<api::BitcoinLikeOutput>>& utxos,
+                const std::vector<BitcoinLikeUtxo>& utxos,
                 const BigInt& aggregatedAmount,
                 const api::Currency& currrency);
 
             static UTXODescriptorList filterWithOptimizeSize(const std::shared_ptr<Buddy>& buddy,
-                const std::vector<std::shared_ptr<api::BitcoinLikeOutput>>& utxos,
+                const std::vector<BitcoinLikeUtxo>& utxos,
                 const BigInt& aggregatedAmount,
                 const api::Currency& currrency);
 
             static UTXODescriptorList filterWithMergeOutputs(const std::shared_ptr<Buddy>& buddy,
-                const std::vector<std::shared_ptr<api::BitcoinLikeOutput>>& utxos,
+                const std::vector<BitcoinLikeUtxo>& utxos,
                 const BigInt& aggregatedAmount,
                 const api::Currency& currrency);
             static UTXODescriptorList filterWithDeepFirst(const std::shared_ptr<Buddy>& buddy,
-                const std::vector<std::shared_ptr<api::BitcoinLikeOutput>>& utxo,
+                const std::vector<BitcoinLikeUtxo>& utxo,
                 const BigInt& aggregatedAmount,
                 const api::Currency& currrency);
             static bool hasEnough(const std::shared_ptr<Buddy>& buddy,
@@ -70,18 +71,9 @@ namespace ledger {
                 const api::Currency& currrency,
                 bool computeOutputAmount);
         protected:
-            Future<UTXODescriptorList> filterInputs(const std::shared_ptr<Buddy> &buddy) override;
-           
-            inline Future<BigInt> computeAggregatedAmount(const std::shared_ptr<Buddy>& buddy);
+            Future<std::vector<BitcoinLikeUtxo>> filterInputs(const std::shared_ptr<Buddy> &buddy) override;
 
-            //Only usefull for filterWithLowestFees
-            struct EffectiveUTXO {
-                std::shared_ptr<api::BitcoinLikeOutput> output;
-                int64_t effectiveValue;
-                int64_t effectiveFees;
-                int64_t longTermFees;
-            };
-            
+            inline Future<BigInt> computeAggregatedAmount(const std::shared_ptr<Buddy>& buddy);
 
             //Usefull for filterWithLowFeesFirst
             static const int64_t DEFAULT_FALLBACK_FEE = 20;
@@ -91,8 +83,14 @@ namespace ledger {
             static const uint32_t TOTAL_TRIES = 10000;
             static const int64_t CENT = 1000000;
         private:
-            
 
+            std::vector<BitcoinLikeUtxo> filterWithSort(
+                const std::shared_ptr<BitcoinLikeUtxoPicker::Buddy> &buddy,
+                std::vector<BitcoinLikeUtxo> utxos,
+                BigInt amount,
+                const api::Currency &currency,
+                std::function<bool(BitcoinLikeUtxo&, BitcoinLikeUtxo&)> const& functor
+            );
         };
     }
 }

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.h
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.h
@@ -47,21 +47,21 @@ namespace ledger {
             BitcoinLikeStrategyUtxoPicker(const std::shared_ptr<api::ExecutionContext> &context,
                                           const api::Currency &currency);
         public:
-            static UTXODescriptorList filterWithKnapsackSolver(const std::shared_ptr<Buddy>& buddy,
+            static std::vector<BitcoinLikeUtxo> filterWithKnapsackSolver(const std::shared_ptr<Buddy>& buddy,
                 const std::vector<BitcoinLikeUtxo>& utxos,
                 const BigInt& aggregatedAmount,
                 const api::Currency& currrency);
 
-            static UTXODescriptorList filterWithOptimizeSize(const std::shared_ptr<Buddy>& buddy,
+            static std::vector<BitcoinLikeUtxo> filterWithOptimizeSize(const std::shared_ptr<Buddy>& buddy,
                 const std::vector<BitcoinLikeUtxo>& utxos,
                 const BigInt& aggregatedAmount,
                 const api::Currency& currrency);
 
-            static UTXODescriptorList filterWithMergeOutputs(const std::shared_ptr<Buddy>& buddy,
+            static std::vector<BitcoinLikeUtxo> filterWithMergeOutputs(const std::shared_ptr<Buddy>& buddy,
                 const std::vector<BitcoinLikeUtxo>& utxos,
                 const BigInt& aggregatedAmount,
                 const api::Currency& currrency);
-            static UTXODescriptorList filterWithDeepFirst(const std::shared_ptr<Buddy>& buddy,
+            static std::vector<BitcoinLikeUtxo> filterWithDeepFirst(const std::shared_ptr<Buddy>& buddy,
                 const std::vector<BitcoinLikeUtxo>& utxo,
                 const BigInt& aggregatedAmount,
                 const api::Currency& currrency);
@@ -84,7 +84,7 @@ namespace ledger {
             static const int64_t CENT = 1000000;
         private:
 
-            std::vector<BitcoinLikeUtxo> filterWithSort(
+            static std::vector<BitcoinLikeUtxo> filterWithSort(
                 const std::shared_ptr<BitcoinLikeUtxoPicker::Buddy> &buddy,
                 std::vector<BitcoinLikeUtxo> utxos,
                 BigInt amount,

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeTransactionBuilder.h
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeTransactionBuilder.h
@@ -32,6 +32,8 @@
 #ifndef LEDGER_CORE_BITCOINLIKETRANSACTIONBUILDER_H
 #define LEDGER_CORE_BITCOINLIKETRANSACTIONBUILDER_H
 
+#include <unordered_set>
+
 #include <api/BitcoinLikeTransactionBuilder.hpp>
 #include <api/BitcoinLikePickingStrategy.hpp>
 #include <api/BitcoinLikeNetworkParameters.hpp>
@@ -43,16 +45,36 @@
 #include <math/BigInt.h>
 #include <spdlog/logger.h>
 #include <api/Currency.hpp>
+#include <wallet/bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+
+
 
 namespace ledger {
     namespace core {
 
+        struct BitcoinLikeTransactionUtxoDescriptor {
+            std::string transactionHash;
+            uint64_t outputIndex;
+
+            bool operator==(BitcoinLikeTransactionUtxoDescriptor const &other) const;
+        };
+
+        struct BitcoinLikeTransactionUtxoDescriptorHash {
+            size_t operator()(BitcoinLikeTransactionUtxoDescriptor const& utxo) const;
+        };
+
+        struct BitcoinLikeTransactionInputDescriptor {
+            std::string transactionHash;
+            uint64_t outputIndex;
+            uint64_t sequence;
+        };
+
         struct BitcoinLikeTransactionBuildRequest {
             BitcoinLikeTransactionBuildRequest(const std::shared_ptr<BigInt>& minChange);
-            std::list<std::tuple<std::string, int32_t, uint32_t>> inputs;
+            std::vector<BitcoinLikeTransactionInputDescriptor> inputs;
             std::list<std::tuple<std::shared_ptr<BigInt>, std::shared_ptr<api::BitcoinLikeScript>>> outputs;
             std::list<std::string> changePaths;
-            std::list<std::tuple<std::string, int32_t>> excludedUtxo;
+            std::unordered_set<BitcoinLikeTransactionUtxoDescriptor, BitcoinLikeTransactionUtxoDescriptorHash> excludedUtxos;
             int32_t changeCount;
             std::shared_ptr<BigInt> feePerByte;
             Option<std::tuple<api::BitcoinLikePickingStrategy, uint32_t>> utxoPicker;

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeUtxo.cpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeUtxo.cpp
@@ -1,0 +1,64 @@
+/*
+ *
+ * BitcoinLikeUtxo
+ * ledger-core
+ *
+ * Created by Alexis Le Provost on 02/06/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include "BitcoinLikeUtxo.hpp"
+
+namespace ledger {
+    namespace core {
+        BitcoinLikeUtxo makeUtxo(
+            BitcoinLikeBlockchainExplorerOutput const &output, api::Currency const& currency)
+        {
+            return {
+                output.index,
+                output.transactionHash,
+                Amount(currency, 0, output.value),
+                output.address,
+                output.accountUid,
+                output.script,
+                output.blockHeight
+            };
+        }
+
+        BitcoinLikeBlockchainExplorerOutput toExplorerOutput(BitcoinLikeUtxo const& utxo)
+        {
+            return {
+                utxo.index,
+                utxo.transactionHash,
+                *utxo.value.value(),
+                utxo.address,
+                utxo.accountUid,
+                utxo.script,
+                "",
+                utxo.blockHeight
+            };
+        }
+    }
+}

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeUtxo.hpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeUtxo.hpp
@@ -1,13 +1,13 @@
 /*
  *
- * BitcoinLikeUTXODatabaseHelper.h
+ * BitcoinLikeUtxo
  * ledger-core
  *
- * Created by Pierre Pollastri on 25/09/2017.
+ * Created by Alexis Le Provost on 02/06/2020.
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Ledger
+ * Copyright (c) 2020 Ledger
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,36 +29,38 @@
  *
  */
 
-#ifndef LEDGER_CORE_BITCOINLIKEUTXODATABASEHELPER_H
-#define LEDGER_CORE_BITCOINLIKEUTXODATABASEHELPER_H
+#ifndef __BITCOINLIKEUTXO_H_
+#define __BITCOINLIKEUTXO_H_
 
-#include <soci.h>
+#include <string>
 
+#include <utils/Option.hpp>
 #include <wallet/bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
-#include <wallet/bitcoin/transaction_builders/BitcoinLikeUtxo.hpp>
+#include <wallet/common/Amount.h>
 
 namespace ledger {
     namespace core {
-        class BitcoinLikeUTXODatabaseHelper {
-            BitcoinLikeUTXODatabaseHelper() = delete;
+        struct BitcoinLikeUtxo {
+            uint64_t index;
+            std::string transactionHash;
+            // HACK: Amount class lacks of constness so
+            // to avoid to const_cast everywhere I select that
+            // quick-win solution.
+            // We should change our generated interfaces and qualify
+            // at least all getters with const keyword
+            mutable Amount value;
+            Option<std::string> address;
+            Option<std::string> accountUid;
+            std::string script;
+            Option<uint64_t> blockHeight;
 
-            ~BitcoinLikeUTXODatabaseHelper() = delete;
-
-        public:
-            static std::size_t queryUTXO(soci::session &sql, const std::string &accountUid,
-                           int32_t offset,
-                           int32_t count,
-                           std::vector<BitcoinLikeBlockchainExplorerOutput>& out,
-                           std::function<bool (const std::string& address)> filter);
-
-            static std::size_t UTXOcount(soci::session& sql, const std::string& accountUid,
-                                         std::function<bool (const std::string& address)> filter);
-
-            static std::vector<BitcoinLikeUtxo> queryAllUtxos(
-                soci::session &session, std::string const &accountUid, api::Currency const &currency);
-
+            operator BitcoinLikeBlockchainExplorerOutput() const;
+            BitcoinLikeUtxo() = default;
         };
+
+        BitcoinLikeUtxo makeUtxo(BitcoinLikeBlockchainExplorerOutput const& output, api::Currency const& currency);
+        BitcoinLikeBlockchainExplorerOutput toExplorerOutput(BitcoinLikeUtxo const& utxo);
     }
 }
 
-#endif //LEDGER_CORE_BITCOINLIKEUTXODATABASEHELPER_H
+#endif // __BITCOINLIKEUTXO_H_

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeUtxoPicker.h
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeUtxoPicker.h
@@ -65,7 +65,6 @@ namespace ledger {
                     bool partial);
             const api::Currency& getCurrency() const;
 
-        protected:
             struct Buddy {
                 Buddy(
                         const BitcoinLikeTransactionBuildRequest& r,

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeUtxoPicker.h
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeUtxoPicker.h
@@ -40,14 +40,14 @@
 #include <api/Currency.hpp>
 #include <async/Future.hpp>
 #include <api/BitcoinLikeOutput.hpp>
-
+#include <wallet/bitcoin/transaction_builders/BitcoinLikeUtxo.hpp>
 
 namespace ledger {
     namespace core {
         class BitcoinLikeTransactionApi;
         class BitcoinLikeWritableInputApi;
-        using BitcoinLikeGetUtxoFunction = std::function<Future<std::vector<std::shared_ptr<api::BitcoinLikeOutput>>> ()>;
-        using BitcoinLikeGetTxFunction = std::function<FuturePtr<BitcoinLikeBlockchainExplorerTransaction> (const std::string&)>;
+        using BitcoinLikeGetUtxoFunction = std::function<Future<std::vector<BitcoinLikeUtxo>>()>;
+        using BitcoinLikeGetTxFunction = std::function<FuturePtr<BitcoinLikeBlockchainExplorerTransaction>(const std::string&)>;
 
         class BitcoinLikeUtxoPicker : public DedicatedContext, public std::enable_shared_from_this<BitcoinLikeUtxoPicker> {
         public:
@@ -65,9 +65,7 @@ namespace ledger {
                     bool partial);
             const api::Currency& getCurrency() const;
 
-        public:
-            using UTXODescriptor = std::tuple<std::string, int32_t, uint32_t >;
-            using UTXODescriptorList = std::vector<UTXODescriptor>;
+        protected:
             struct Buddy {
                 Buddy(
                         const BitcoinLikeTransactionBuildRequest& r,
@@ -100,15 +98,15 @@ namespace ledger {
             };
         protected:
             virtual Future<Unit> fillInputs(const std::shared_ptr<Buddy>& buddy);
-            virtual Future<UTXODescriptorList> filterInputs(const std::shared_ptr<Buddy>& buddy) = 0;
+            virtual Future<std::vector<BitcoinLikeUtxo>> filterInputs(const std::shared_ptr<Buddy>& buddy) = 0;
             virtual Future<Unit> fillOutputs(const std::shared_ptr<Buddy>& buddy);
             virtual Future<Unit> fillTransactionInfo(const std::shared_ptr<Buddy>& buddy);
 
         private:
-            Future<Unit> fillInput(const std::shared_ptr<Buddy>& buddy, const UTXODescriptor& desc);
-            BitcoinLikeGetUtxoFunction createFilteredUtxoFunction(const BitcoinLikeTransactionBuildRequest& buddy,
+            void fillInput(const std::shared_ptr<Buddy>& buddy, const BitcoinLikeUtxo& utxo, const uint32_t sequence);
+            BitcoinLikeGetUtxoFunction createFilteredUtxoFunction(const BitcoinLikeTransactionBuildRequest& request,
+                                                                  const std::shared_ptr<BitcoinLikeKeychain> &keychain,
                                                                   const BitcoinLikeGetUtxoFunction& getUtxo);
-
         protected:
             api::Currency _currency;
         };

--- a/core/src/wallet/common/Amount.h
+++ b/core/src/wallet/common/Amount.h
@@ -42,6 +42,7 @@ namespace ledger {
         public:
             Amount(const api::Currency& currency, int32_t unitIndex, const BigInt& value);
             Amount(const api::Currency& currency, int32_t unitIndex, BigInt&& value);
+
             std::shared_ptr<api::BigInt> toBigInt() override;
             api::Currency getCurrency() override;
             api::CurrencyUnit getUnit() override;


### PR DESCRIPTION
This PR aims to improve - in term of **time** - the performance of the empty transaction built for Bitcoin.
Several strategies has been applied : 
* Request once -  from DB - all information needed for the UTXO strategy pickers
* Remove the HTTP/SQL calls to get missing information from transactions
* Avoid copies as much as possible without refactorize all the legacy code

There are still place to another improvement such as :
* Remove in-place calculation from `BigInt` to integer in UTXO strategy pickers 
* Rewrite `Future` to accept non-const parameters and avoid deep copy; in other term avoid extra allocations

## Benchmark
| # | Amount | Strategy | Legacy Library Response Time | Improved Library Response Time | Response Time Change  | 
| -- | ---------- | ----------- | -----------------------------------------  | -------------------------------------------- | --------------------------------- |
| 1 | 60000000000 |  DEEP_OUTPUTS_FIRST | 4m01s | 40.7s | *-83.13%* |
| 2 | 60000000000 | OPTIMIZE_SIZE | 2m41s | 1.8s | *-98.86%* |
| 3 | 5000000000 | MERGE_OUTPUTS | 3m28s | 33s | *-84.12%* |
| 4 | 20000000000 | DEEP_OUTPUTS_FIRST | 1m28s | 14.7s | *-83.25%* |

The response time change has been calculated with the following formula :
**(improved_library_response_time - legacy_library_response_time) / legacy_library_response_time * 100** 

The `OPTIMIZE_SIZE` strategy contains a bug and will be fixed by the [PR 612](https://github.com/LedgerHQ/lib-ledger-core/pull/612) and [PR 610](https://github.com/LedgerHQ/lib-ledger-core/pull/610); do not consider the result #2
 for now.

## Mandatory picture of a cute animal
![wtf_cat](https://user-images.githubusercontent.com/6042495/84645039-4cb4ce80-af00-11ea-8100-b697aa5810ea.gif)
