### PR TITLE
[cosmos] Fetch block data on each transaction fetch

### DIFF
--- a/core/src/wallet/cosmos/explorers/CosmosLikeBlockchainExplorer.hpp
+++ b/core/src/wallet/cosmos/explorers/CosmosLikeBlockchainExplorer.hpp
@@ -74,7 +74,7 @@ class CosmosLikeBlockchainExplorer : public ConfigurationMatchable {
     virtual Future<int64_t> getTimestamp() const = 0;
     virtual FuturePtr<cosmos::Block> getCurrentBlock() const = 0;
     virtual FuturePtr<cosmos::Block> getCurrentBlock() = 0;
-    virtual FuturePtr<cosmos::Block> getBlock(uint64_t &blockHeight) = 0;
+    virtual FuturePtr<cosmos::Block> getBlock(uint64_t &blockHeight) const = 0;
     virtual FuturePtr<cosmos::Account> getAccount(const std::string &account) const = 0;
     virtual const std::vector<TransactionFilter> &getTransactionFilters() = 0;
 

--- a/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.cpp
@@ -261,52 +261,58 @@ FuturePtr<cosmos::TransactionsBulk> GaiaCosmosLikeBlockchainExplorer::getTransac
                     result.hasNext = (count < total_count);
                 }
                 return Future<cosmos::TransactionsBulk>::successful(result);
-                })
-                .flatMapPtr<cosmos::TransactionsBulk>(
-                getContext(),
-                [this](const cosmos::TransactionsBulk& inputBulk) mutable -> FuturePtr<cosmos::TransactionsBulk> {
-                    auto retval = inputBulk;
-                    auto inputTxs = inputBulk.transactions;
-                    std::vector<FuturePtr<cosmos::Transaction>> filledTxsFutures;
-                    std::transform(
-                        inputTxs.cbegin(),
-                        inputTxs.cend(),
-                        std::back_inserter(filledTxsFutures),
-                        [this](const cosmos::Transaction &inputTx) {
-                            return this->inflateTransactionWithBlockData(inputTx);
+            })
+        .flatMapPtr<cosmos::TransactionsBulk>(
+            getContext(),
+            [this](const cosmos::TransactionsBulk &inputBulk) mutable
+            -> FuturePtr<cosmos::TransactionsBulk> {
+                auto const &inputTxs = inputBulk.transactions;
+                std::vector<FuturePtr<cosmos::Transaction>> filledTxsFutures;
+                filledTxsFutures.reserve(inputTxs.size());
+                std::transform(
+                    inputTxs.cbegin(),
+                    inputTxs.cend(),
+                    std::back_inserter(filledTxsFutures),
+                    [this](const cosmos::Transaction &inputTx) {
+                        return this->inflateTransactionWithBlockData(inputTx);
+                    });
+                return async::sequence(getContext(), filledTxsFutures)
+                    .flatMapPtr<cosmos::TransactionsBulk>(
+                        getContext(),
+                        [inputBulk = std::move(inputBulk)](
+                            const std::vector<std::shared_ptr<cosmos::Transaction>>
+                                &filledTxsList) mutable {
+                            inputBulk.transactions.clear();
+                            std::transform(
+                                filledTxsList.cbegin(),
+                                filledTxsList.cend(),
+                                std::back_inserter(inputBulk.transactions),
+                                [](const std::shared_ptr<cosmos::Transaction> filledTx) {
+                                    return *filledTx;
+                                });
+                            return FuturePtr<cosmos::TransactionsBulk>::successful(
+                                std::make_shared<cosmos::TransactionsBulk>(inputBulk));
                         });
-                    return async::sequence(getContext(), filledTxsFutures)
-                        .flatMapPtr<cosmos::TransactionsBulk>(
-                            getContext(),
-                            [retval](
-                                const std::vector<std::shared_ptr<cosmos::Transaction>> &filledTxsList) mutable {
-                                retval.transactions.clear();
-                                std::transform(
-                                    filledTxsList.cbegin(),
-                                    filledTxsList.cend(),
-                                    std::back_inserter(retval.transactions),
-                                    [](const std::shared_ptr<cosmos::Transaction> filledTx) {
-                                        return *filledTx;
-                                    });
-                                return FuturePtr<cosmos::TransactionsBulk>::successful(
-                                    std::make_shared<cosmos::TransactionsBulk>(retval));
-                            });
-                });
+            });
 }
 
-FuturePtr<cosmos::Transaction> GaiaCosmosLikeBlockchainExplorer::inflateTransactionWithBlockData(const cosmos::Transaction& inputTx) const {
-            auto retval = cosmos::Transaction(inputTx);
-            if (!retval.block) {
-                return FuturePtr<cosmos::Transaction>::successful(
-                    std::make_shared<cosmos::Transaction>(std::move(retval)));
-            }
-            auto height = retval.block.getValue().height;
-            return getBlock(height).flatMapPtr<cosmos::Transaction>(
-                getContext(), [retval](const auto &blockData) mutable -> FuturePtr<cosmos::Transaction> {
-                    retval.block = *blockData;
-                    return FuturePtr<cosmos::Transaction>::successful(
-                        std::make_shared<cosmos::Transaction>(retval));
-                });
+FuturePtr<cosmos::Transaction> GaiaCosmosLikeBlockchainExplorer::inflateTransactionWithBlockData(
+    const cosmos::Transaction &inputTx) const
+{
+    auto completeTx = cosmos::Transaction(inputTx);
+    if (!completeTx.block) {
+        return FuturePtr<cosmos::Transaction>::successful(
+            std::make_shared<cosmos::Transaction>(std::move(completeTx)));
+    }
+    auto height = completeTx.block.getValue().height;
+    return getBlock(height).flatMapPtr<cosmos::Transaction>(
+        getContext(),
+        [completeTx = std::move(completeTx)](
+            const auto &blockData) mutable -> FuturePtr<cosmos::Transaction> {
+            completeTx.block = *blockData;
+            return FuturePtr<cosmos::Transaction>::successful(
+                std::make_shared<cosmos::Transaction>(completeTx));
+        });
 }
 
 FuturePtr<cosmos::Transaction> GaiaCosmosLikeBlockchainExplorer::getTransactionByHash(

--- a/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.cpp
@@ -282,11 +282,10 @@ FuturePtr<cosmos::TransactionsBulk> GaiaCosmosLikeBlockchainExplorer::getTransac
                         [inputBulk = std::move(inputBulk)](
                             const std::vector<std::shared_ptr<cosmos::Transaction>>
                                 &filledTxsList) mutable {
-                            inputBulk.transactions.clear();
                             std::transform(
                                 filledTxsList.cbegin(),
                                 filledTxsList.cend(),
-                                std::back_inserter(inputBulk.transactions),
+                                inputBulk.transactions.begin(),
                                 [](const std::shared_ptr<cosmos::Transaction> filledTx) {
                                     return *filledTx;
                                 });

--- a/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.hpp
+++ b/core/src/wallet/cosmos/explorers/GaiaCosmosLikeBlockchainExplorer.hpp
@@ -66,7 +66,7 @@ class GaiaCosmosLikeBlockchainExplorer :
     const std::vector<TransactionFilter> &getTransactionFilters() override;
 
     // Block querier
-    FuturePtr<cosmos::Block> getBlock(uint64_t &blockHeight) override;
+    FuturePtr<cosmos::Block> getBlock(uint64_t &blockHeight) const override;
 
     // Account querier
     FuturePtr<ledger::core::cosmos::Account> getAccount(const std::string &account) const override;
@@ -129,6 +129,24 @@ class GaiaCosmosLikeBlockchainExplorer :
         double gasAdjustment = 1.0) const override;
 
    private:
+
+    /// Parse a transaction and add post-treatment / sanitization.
+    /// The sanitization of output includes :
+    /// - Adding the FESS as an extra message
+    /// - Query more information about the block included in the transaction
+    /// \param[in] node The (rapidjson) node with the transaction data to use
+    /// \param[out] transaction The Cosmos transaction to fill
+    template <typename T>
+    void parseTransactionWithPosttreatment(const T &node, cosmos::Transaction &transaction) const;
+
+    /// Inflate a transaction with all its block data (block hash and timestamp)
+    /// The hash information is necessary to compute a block_uid and therefore not having
+    /// it will prevent the OperationQuery from fetching the correct block to compute the
+    /// number of confirmations for a given transaction.
+    /// \param[in] The transaction to fill
+    /// \return a FuturePtr to the filled Transaction
+    FuturePtr<cosmos::Transaction> inflateTransactionWithBlockData(const cosmos::Transaction& inputTx) const;
+
     // Get all transactions relevant to an address
     // Concatenates multiple API calls for all relevant transaction types
     FuturePtr<cosmos::TransactionsBulk> getTransactionsForAddress(

--- a/core/test/integration/synchronization/cosmos_synchronization.cpp
+++ b/core/test/integration/synchronization/cosmos_synchronization.cpp
@@ -381,7 +381,13 @@ TEST_F(CosmosLikeWalletSynchronization, MediumXpubSynchronization) {
 
             auto ops = wait(std::dynamic_pointer_cast<OperationQuery>(account->queryOperations()->complete())->execute());
             fmt::print("Ops: {}\n", ops.size());
-            EXPECT_GT(ops.size(), 0);
+            ASSERT_GT(ops.size(), 0);
+            ASSERT_TRUE(ops[0]->getBlockHeight())
+                << "The first operation should have a block height.";
+            EXPECT_GT(ops[0]->getBlockHeight().value(), 0)
+                << "The first operation should have a non 0 height.";
+            EXPECT_LT(ops[0]->getBlockHeight().value(), block.height)
+                << "The first operation should not have the same height as the last block.";
 
             const auto sequenceNumber = account->getInfo().sequence;
             const int sequence = std::atoi(sequenceNumber.c_str());


### PR DESCRIPTION
If we do not fetch the block data each time a transaction is
fetched (although saving HTTP calls), then :

- The blockHash of the transaction is empty, therefore no block_uid can
be computed from the tx.block
- The block_uid column of the transaction in the database therefore
stays `NULL`
- When querying the operations later, the LEFT JOIN of
cosmos_transactions with blocks will fail to find a block
- Final state : the queried operation has no "height" information

Having no "height" information is a problem because this is used by
Ledger Live to compute the count of confirmations for a given Operation.