### PR TITLE
Fix synchronization for RBF transaction

### DIFF
--- a/.circleci/init_submodules.sh
+++ b/.circleci/init_submodules.sh
@@ -21,6 +21,7 @@ git submodule update -- core/lib/ethash || echo "===========ethash submodule alr
 git submodule update -- core/lib/fmt || echo "===========fmt submodule already updated"
 git submodule update -- core/test/lib/googletest || echo "===========googletest submodule already updated"
 git submodule update -- core/lib/CRCpp || echo "===========CRCpp submodule already updated"
+git submodule update -- core/test/lib/libuv || echo "===========libuv submodule already updated"
 #should checkout leveldb bitcoin-fork branch on leveldb submodule
 cd $HOME/lib-ledger-core/core/lib/leveldb && git checkout bitcoin-fork
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "core/lib/CRCpp"]
 	path = core/lib/CRCpp
 	url = https://github.com/d-bahr/CRCpp.git
+[submodule "core/test/lib/libuv"]
+	path = core/test/lib/libuv
+	url = git@github.com:libuv/libuv.git

--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
@@ -719,5 +719,9 @@ namespace ledger {
         std::shared_ptr<api::Keychain> BitcoinLikeAccount::getAccountKeychain() {
           return _keychain;
         }
+
+        void BitcoinLikeAccount::dropTransactions(const std::vector<std::string> &hashes) {
+            // TODO implement SQL + publish
+        }
     }
 }

--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
@@ -308,6 +308,7 @@ namespace ledger {
                 if (result.isSuccess()) {
                     code = !isEmpty && wasEmpty ? api::EventCode::SYNCHRONIZATION_SUCCEED_ON_PREVIOUSLY_EMPTY_ACCOUNT
                                                 : api::EventCode::SYNCHRONIZATION_SUCCEED;
+                    self->getWallet()->invalidateBalanceCache(self->getIndex());
                 } else {
                     code = api::EventCode::SYNCHRONIZATION_FAILED;
                     payload->putString(api::Account::EV_SYNC_ERROR_CODE, api::to_string(result.getFailure().getErrorCode()));
@@ -718,10 +719,6 @@ namespace ledger {
 
         std::shared_ptr<api::Keychain> BitcoinLikeAccount::getAccountKeychain() {
           return _keychain;
-        }
-
-        void BitcoinLikeAccount::dropTransactions(const std::vector<std::string> &hashes) {
-            // TODO implement SQL + publish
         }
     }
 }

--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.hpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.hpp
@@ -88,6 +88,12 @@ namespace ledger {
              */
             bool putBlock(soci::session& sql, const BitcoinLikeBlockchainExplorer::Block& block);
 
+            /**
+             * Drop transactions from the list (and all attached operations)
+             * @return
+             */
+            void dropTransactions(const std::vector<std::string>& hashes);
+
             std::shared_ptr<BitcoinLikeKeychain> getKeychain() const;
 
             void startBlockchainObservation() override;

--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.hpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.hpp
@@ -88,12 +88,6 @@ namespace ledger {
              */
             bool putBlock(soci::session& sql, const BitcoinLikeBlockchainExplorer::Block& block);
 
-            /**
-             * Drop transactions from the list (and all attached operations)
-             * @return
-             */
-            void dropTransactions(const std::vector<std::string>& hashes);
-
             std::shared_ptr<BitcoinLikeKeychain> getKeychain() const;
 
             void startBlockchainObservation() override;

--- a/core/src/wallet/bitcoin/database/BitcoinLikeAccountDatabaseHelper.h
+++ b/core/src/wallet/bitcoin/database/BitcoinLikeAccountDatabaseHelper.h
@@ -33,6 +33,7 @@
 
 #include <soci.h>
 #include "BitcoinLikeAccountDatabaseEntry.h"
+#include <math/BigInt.h>
 
 namespace ledger {
     namespace core {

--- a/core/src/wallet/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.cpp
+++ b/core/src/wallet/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.cpp
@@ -253,5 +253,11 @@ namespace ledger {
             return true;
         }
 
+        void
+        BitcoinLikeTransactionDatabaseHelper::getMempoolTransactions(soci::session &sql, const std::string &accountUid,
+                                                                     std::vector<BitcoinLikeBlockchainExplorerTransaction> &out) {
+            
+        }
+
     }
 }

--- a/core/src/wallet/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.h
+++ b/core/src/wallet/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.h
@@ -65,9 +65,22 @@ namespace ledger {
                                                   const std::string &accountUid,
                                                   BitcoinLikeBlockchainExplorerTransaction& out);
 
+            /**
+             * Get all mempool transactions for the given account from database.
+             * @param sql
+             * @param accountUid
+             * @param out This vector is used to store the result of the DB query.
+             */
             static void getMempoolTransactions(soci::session& sql,
                                                const std::string& accountUid,
                                                std::vector<BitcoinLikeBlockchainExplorerTransaction>& out);
+
+            /**
+             * Remove all operations and transactions in mempool for the given account
+             * @param sql
+             * @param accountUid
+             */
+            static void removeAllMempoolOperation(soci::session& sql, const std::string& accountUid);
         };
     }
 }

--- a/core/src/wallet/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.h
+++ b/core/src/wallet/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.h
@@ -64,6 +64,10 @@ namespace ledger {
                                                   const soci::row& row,
                                                   const std::string &accountUid,
                                                   BitcoinLikeBlockchainExplorerTransaction& out);
+
+            static void getMempoolTransactions(soci::session& sql,
+                                               const std::string& accountUid,
+                                               std::vector<BitcoinLikeBlockchainExplorerTransaction>& out);
         };
     }
 }

--- a/core/src/wallet/bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp
+++ b/core/src/wallet/bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp
@@ -108,6 +108,8 @@ namespace ledger {
                                               public AbstractBlockchainExplorer<BitcoinLikeBlockchainExplorerTransaction> {
         public:
             typedef ledger::core::Block Block;
+            using Transaction = BitcoinLikeBlockchainExplorerTransaction;
+
             BitcoinLikeBlockchainExplorer(const std::shared_ptr<api::DynamicObject>& configuration,
                                           const std::vector<std::string> &matchableKeys);
 

--- a/core/src/wallet/bitcoin/explorers/api/InputParser.cpp
+++ b/core/src/wallet/bitcoin/explorers/api/InputParser.cpp
@@ -70,6 +70,8 @@ namespace ledger {
                 _input->value = Option<BigInt>(value);
             } else if (_lastKey == "output_index") {
                 _input->previousTxOutputIndex = value.toUint64();
+            } else if (_lastKey == "sequence") {
+                _input->sequence = value.toUint64();
             }
             return true;
         }

--- a/core/src/wallet/bitcoin/synchronizers/BlockchainExplorerAccountSynchronizer.cpp
+++ b/core/src/wallet/bitcoin/synchronizers/BlockchainExplorerAccountSynchronizer.cpp
@@ -30,9 +30,23 @@
  */
 #include "BlockchainExplorerAccountSynchronizer.h"
 #include <wallet/bitcoin/BitcoinLikeAccount.hpp>
+#include <wallet/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.h>
+#include <async/algorithm.h>
 
 namespace ledger {
     namespace core {
+
+        constexpr auto ADDRESS_BATCH_SIZE = 20;
+
+        using Transaction = BitcoinLikeBlockchainExplorerTransaction;
+        using Input = BitcoinLikeBlockchainExplorerInput;
+        using CommonBuddy = BlockchainExplorerAccountSynchronizer::SynchronizationBuddy;
+        using TransactionMap = std::unordered_map<std::string, std::pair<Transaction, bool /* replaceable */>>;
+
+        struct BitcoinSynchronizationBuddy : public CommonBuddy {
+            std::vector<BitcoinLikeBlockchainExplorerTransaction> mempoolTransaction;
+            std::vector<BitcoinLikeBlockchainExplorerTransaction> previousMempool;
+        };
 
         BlockchainExplorerAccountSynchronizer::BlockchainExplorerAccountSynchronizer(
                 const std::shared_ptr<WalletPool> &pool,
@@ -66,6 +80,12 @@ namespace ledger {
                                                             "LEFT OUTER JOIN bitcoin_operations AS btc_op ON btc_op.uid = op.uid "
                                                             "WHERE op.block_uid IS NULL AND op.account_uid = :uid ", soci::use(accountUid));
 
+            // Remove all mempool transaction
+            BitcoinLikeTransactionDatabaseHelper::removeAllMempoolOperation(sql, accountUid);
+            auto btcBuddy = std::static_pointer_cast<BitcoinSynchronizationBuddy>(buddy);
+            // Get all operation in mempool (will be used to restore mempool in case of error)
+            BitcoinLikeTransactionDatabaseHelper::getMempoolTransactions(sql, accountUid, btcBuddy->previousMempool);
+
             for (auto &row : rows) {
                 if (row.get_indicator(0) != soci::i_null && row.get_indicator(1) != soci::i_null) {
                     buddy->transactionsToDrop.insert(std::pair<std::string, std::string>(row.get<std::string>(1), row.get<std::string>(0)));
@@ -87,12 +107,7 @@ namespace ledger {
                 _notifier = std::make_shared<ProgressNotifier<Unit>>();
                 auto self = std::dynamic_pointer_cast<BlockchainExplorerAccountSynchronizer>(getSharedFromThis());
                 performSynchronization(account)
-                .flatMap<std::vector<std::string>>(getSynchronizerContext(), [self] (auto unit) {
-                    return self->getReplacedTransactionHashes();
-                }).map<Unit>(getSynchronizerContext(), [self] (const auto& hashes) {
-                    self->_currentAccount->dropTransactions(hashes);
-                    return unit;
-                }).onComplete(getSynchronizerContext(), [self] (const auto &result) {
+               .onComplete(getSynchronizerContext(), [self] (const auto &result) {
                     std::lock_guard<std::mutex> l(self->_lock);
                     if (result.isFailure()) {
                         self->_notifier->failure(result.getFailure());
@@ -121,23 +136,184 @@ namespace ledger {
             return getContext();
         }
 
-        Future<std::vector<std::string>> BlockchainExplorerAccountSynchronizer::getReplacedTransactionHashes() {
-            // Get all transaction from the mempool
+        int BlockchainExplorerAccountSynchronizer::putTransaction(soci::session &sql,
+                                                                  const BitcoinLikeBlockchainExplorerTransaction &transaction,
+                                                                  const std::shared_ptr<CommonBuddy> &buddy) {
+            // In case the transaction is in mempool, keep in memory before inserting it in database.
+            if (transaction.block.isEmpty()) {
+                std::static_pointer_cast<BitcoinSynchronizationBuddy>(buddy)->mempoolTransaction.emplace_back(
+                        transaction);
+                auto keychain = buddy->account->getKeychain();
+                auto const markAddress = [&keychain](auto &txIo) {
+                    auto flag = 0;
 
-            // If two (or more) transactions share the same input group them
-            // (and mark them as RBF transactions)
+                    for (auto &io : txIo) {
+                        if (io.address.hasValue()) {
+                            keychain->markAsUsed(io.address.getValue());
+                            flag |= BitcoinLikeAccount::FLAG_TRANSACTION_CREATED_SENDING_OPERATION;
+                        }
+                    }
+                    return flag;
+                };
+                return markAddress(transaction.inputs) | markAddress(transaction.outputs);
+            }
+            return buddy->account->putTransaction(sql, transaction);
+        }
 
-            // Find the highest input sequence of the group and remove all
-            // transaction using a sequence which is less than the max in database
+        std::shared_ptr<CommonBuddy>
+        BlockchainExplorerAccountSynchronizer::makeSynchronizationBuddy() {
+            return std::make_shared<BitcoinSynchronizationBuddy>();
+        }
 
-            // For all transaction marked as RBF, iterate through all inputs
-            // of all transaction to get addresses
+        inline bool isInputReplaced(const Input& input, uint32_t conflictingInputSequence) {
+            return input.sequence < conflictingInputSequence;
+        }
 
-            // Get all transactions in mempool for the addresses
+        inline bool isInputReplaceable(const Input& input) {
+            return input.sequence < std::numeric_limits<uint32_t>::max();
+        }
 
-            // Iterate through all transaction and remove from database
-            // my RBF transactions if the sequence is higher in one of the addresses transactions
-            return Future<std::vector<std::string>>::successful({});
+        void filterReplacedTransaction(const std::vector<Transaction>& transactions, TransactionMap& txByHash) {
+            using InputWithTxHash = std::tuple<std::string /* tx hash */, uint32_t /* input sequence */>;
+            std::unordered_map<std::string, InputWithTxHash> txByIntputs;
+            for (const auto& tx : transactions) {
+                if (txByHash.find(tx.hash) != txByHash.end()) {
+                    // Transaction is already in result map, don't go though all filtering.
+                    continue;
+                }
+                bool replaceable = false;
+                bool replaced = false;
+                for (const auto& input : tx.inputs) {
+                    if (!input.previousTxHash || !input.previousTxOutputIndex)
+                        continue;
+                    auto inputId = fmt::format("{}{}", input.previousTxHash.getValue(), input.previousTxOutputIndex.getValue());
+                    auto entry = txByIntputs.find(inputId);
+                    if (entry == txByIntputs.end()) {
+                        txByIntputs[inputId] = std::make_pair(tx.hash, input.sequence);
+                    } else if (!isInputReplaced(input, std::get<1>(entry->second))) {
+                        replaced = replaced || (std::get<0>(entry->second) == tx.hash);
+                        txByHash.erase(std::get<0>(entry->second));
+                        txByIntputs[inputId] = std::make_pair(tx.hash, input.sequence);
+                    } else {
+                        replaced = true;
+                        break;
+                    }
+                    replaceable = replaceable || isInputReplaceable(input);
+                }
+                if (!replaced)
+                    txByHash[tx.hash] = std::make_pair(tx, replaceable);
+            }
+        }
+
+        Future<std::vector<Transaction>> getMempoolTransactionBatch(const std::shared_ptr<CommonBuddy>& buddy,
+                                                                    const api::Block& lastBlock,
+                                                                    const std::vector<std::string>& addresses) {
+            return buddy->account->getExplorer()->getTransactions(addresses, Option<std::string>(lastBlock.blockHash))
+            .map<std::vector<Transaction>>(buddy->account->getContext(), [] (const auto& bulk) {
+                std::vector<Transaction> mempoolTxs;
+                for (const auto& tx : bulk->transactions) {
+                    if (!tx.block.hasValue())
+                        mempoolTxs.emplace_back(tx);
+                }
+                return mempoolTxs;
+            });
+        }
+
+        Future<std::vector<Transaction>> getMempoolTransactions(const std::shared_ptr<CommonBuddy>& buddy,
+                                                                const std::vector<std::string>& addresses) {
+            using TransactionBatchVector = std::vector<std::vector<Transaction>>;
+            return buddy->account->getLastBlock()
+            .flatMap<TransactionBatchVector>(buddy->account->getContext(), [=] (const auto& block) {
+                std::vector<Future<std::vector<Transaction>>> getTxs;
+                for(std::size_t i = 0; i < addresses.size(); i += ADDRESS_BATCH_SIZE) {
+                    auto last = std::min(addresses.size(), i + ADDRESS_BATCH_SIZE);
+                    std::vector<std::string> batch(addresses.begin() + i, addresses.begin() + last);
+                    getTxs.emplace_back(getMempoolTransactionBatch(buddy, block, batch));
+                }
+                return async::sequence(buddy->account->getContext(), getTxs);
+            }).map<std::vector<Transaction>>(buddy->account->getContext(), [] (const auto& batches) {
+                std::vector<Transaction> mempoolTxs;
+                for (const auto& batch : batches) {
+                    mempoolTxs.insert(mempoolTxs.end(), batch.begin(), batch.end());
+                }
+                return mempoolTxs;
+            });
+        }
+
+        Future<Unit> resolveMempool(const std::shared_ptr<BitcoinSynchronizationBuddy>& buddy) {
+            // Do a first round of filtering with transaction bound to the account
+            TransactionMap txsByHash;
+            filterReplacedTransaction(buddy->mempoolTransaction, txsByHash);
+            // Get all transaction which are still replaceable and create a list of addresses
+            std::vector<Transaction> notReplaceableTxs;
+            std::vector<Transaction> replaceableTxs;
+            std::unordered_set<std::string> foreignAddresses;
+
+            for (const auto& txWithHash : txsByHash) {
+                if (txWithHash.second.second) {
+                    // Tx is replaceable add it in the list to filter later
+                    // and go though all inputs to find foreign address
+                    replaceableTxs.emplace_back(txWithHash.second.first);
+                    for (const auto& input : txWithHash.second.first.inputs) {
+                        if (input.address.hasValue() &&
+                            !buddy->account->getKeychain()->contains(input.address.getValue())) {
+                            foreignAddresses.insert(input.address.getValue());
+                        }
+                    }
+                } else {
+                    notReplaceableTxs.emplace_back(txWithHash.second.first);
+                }
+            }
+            // Use the list of addresses to get all mempool transaction for those addresses
+            return getMempoolTransactions(buddy,
+                    std::vector<std::string>(foreignAddresses.begin(), foreignAddresses.end()))
+            .map<Unit>(buddy->account->getContext(), [=] (const auto& foreignTxs) {
+                // Do another round of filtering on replaceable transaction vs foreign transactions
+                TransactionMap filteredTxs;
+                std::vector<Transaction> txs(replaceableTxs.begin(), replaceableTxs.end());
+                txs.insert(txs.end(), foreignTxs.begin(), foreignTxs.end());
+                filterReplacedTransaction(txs, filteredTxs);
+                // Insert everything in database
+                soci::session sql(buddy->account->getWallet()->getDatabase()->getPool());
+                soci::transaction tr(sql);
+                // Insert not replaceable transactions
+                for (const auto& tx : notReplaceableTxs) {
+                    buddy->account->putTransaction(sql, tx);
+                }
+                // Insert replaceable transaction
+                for (const auto& entry : filteredTxs) {
+                    buddy->account->putTransaction(sql, entry.second.first);
+                }
+                tr.commit();
+                return unit;
+            });
+        }
+
+        Future<Unit> BlockchainExplorerAccountSynchronizer::synchronizeMempool(
+                const std::shared_ptr<AbstractBlockchainExplorerAccountSynchronizer<BitcoinLikeAccount, BitcoinLikeAddress, BitcoinLikeKeychain, BitcoinLikeBlockchainExplorer>::SynchronizationBuddy> &buddy) {
+            auto bitcoinBuddy = std::static_pointer_cast<BitcoinSynchronizationBuddy>(buddy);
+            return resolveMempool(bitcoinBuddy);
+        }
+
+        Future<Unit> BlockchainExplorerAccountSynchronizer::recoverFromFailedSynchronization(
+                const std::shared_ptr<CommonBuddy> &commonBuddy) {
+            auto buddy = std::static_pointer_cast<BitcoinSynchronizationBuddy>(commonBuddy);
+            return Future<Unit>::async(buddy->account->getContext(), [buddy] () {
+                soci::session sql(buddy->account->getWallet()->getDatabase()->getPool());
+                for (const auto& tx : buddy->previousMempool) {
+                    soci::transaction tr(sql);
+                    auto result = make_try<int>([&] () {
+                        return buddy->account->putTransaction(sql, tx);
+                    });
+                    if (result.isSuccess()) {
+                        tr.commit();
+                    } else {
+                        tr.rollback();
+                        buddy->logger->error("Unable to restore transaction {} ({})", tx.hash, result.getFailure().getMessage());
+                    }
+                }
+                return unit;
+            });
         }
 
     }

--- a/core/src/wallet/bitcoin/synchronizers/BlockchainExplorerAccountSynchronizer.h
+++ b/core/src/wallet/bitcoin/synchronizers/BlockchainExplorerAccountSynchronizer.h
@@ -66,6 +66,8 @@ namespace ledger {
         private:
             std::shared_ptr<BlockchainAccountSynchronizer> getSharedFromThis() override ;
             std::shared_ptr<api::ExecutionContext> getSynchronizerContext() override ;
+            Future<std::vector<std::string>> getReplacedTransactionHashes();
+
         };
     }
 }

--- a/core/src/wallet/bitcoin/synchronizers/BlockchainExplorerAccountSynchronizer.h
+++ b/core/src/wallet/bitcoin/synchronizers/BlockchainExplorerAccountSynchronizer.h
@@ -63,10 +63,17 @@ namespace ledger {
             std::shared_ptr<ProgressNotifier<Unit>> synchronize(const std::shared_ptr<BitcoinLikeAccount>& account) override;
             bool isSynchronizing() const override;
 
+            int putTransaction(soci::session &sql, const Transaction &transaction,
+                               const std::shared_ptr<SynchronizationBuddy> &buddy) override;
+
+            std::shared_ptr<SynchronizationBuddy> makeSynchronizationBuddy() override;
+            Future<Unit> synchronizeMempool(const std::shared_ptr<SynchronizationBuddy> &buddy) override;
+
+            Future<Unit> recoverFromFailedSynchronization(const std::shared_ptr<SynchronizationBuddy> &buddy) override;
+
         private:
             std::shared_ptr<BlockchainAccountSynchronizer> getSharedFromThis() override ;
             std::shared_ptr<api::ExecutionContext> getSynchronizerContext() override ;
-            Future<std::vector<std::string>> getReplacedTransactionHashes();
 
         };
     }

--- a/core/src/wallet/common/AbstractWallet.cpp
+++ b/core/src/wallet/common/AbstractWallet.cpp
@@ -380,6 +380,10 @@ namespace ledger {
             _balanceCache.put(fmt::format("{}-{}", _currency.name, accountIndex), balance);
         }
 
+        void AbstractWallet::invalidateBalanceCache(size_t accountIndex) {
+            _balanceCache.erase(fmt::format("{}-{}", _currency.name, accountIndex));
+        }
+
         std::shared_ptr<api::DynamicObject> AbstractWallet::getConfiguration() {
             return getConfig();
         }

--- a/core/src/wallet/common/AbstractWallet.hpp
+++ b/core/src/wallet/common/AbstractWallet.hpp
@@ -136,6 +136,7 @@ namespace ledger {
 
             Option<Amount> getBalanceFromCache(size_t accountIndex);
             void updateBalanceCache(size_t accountIndex, Amount balance);
+            void invalidateBalanceCache(size_t accountIndex);
 
             virtual FuturePtr<api::Account> newAccountWithInfo(const api::AccountCreationInfo& info) = 0;
             virtual FuturePtr<api::Account> newAccountWithExtendedKeyInfo(const api::ExtendedKeyAccountCreationInfo& info) = 0;

--- a/core/src/wallet/common/synchronizers/AbstractBlockchainExplorerAccountSynchronizer.h
+++ b/core/src/wallet/common/synchronizers/AbstractBlockchainExplorerAccountSynchronizer.h
@@ -87,6 +87,7 @@ namespace ledger {
         template<typename Account, typename AddressType, typename Keychain, typename Explorer>
         class AbstractBlockchainExplorerAccountSynchronizer {
         public:
+            using Transaction = typename Explorer::Transaction;
 
             std::shared_ptr<ProgressNotifier<Unit>> synchronizeAccount(const std::shared_ptr<Account>& account) {
                 std::lock_guard<std::mutex> lock(_lock);
@@ -111,8 +112,6 @@ namespace ledger {
                 return _notifier;
             };
 
-        protected:
-
             struct SynchronizationBuddy {
                 std::shared_ptr<Preferences> preferences;
                 std::shared_ptr<spdlog::logger> logger;
@@ -125,8 +124,13 @@ namespace ledger {
                 Option<void *> token;
                 std::shared_ptr<Account> account;
                 std::map<std::string, std::string> transactionsToDrop;
+
+                virtual ~SynchronizationBuddy() {
+
+                };
             };
 
+        protected:
 
             static void initializeSavedState(Option<BlockchainExplorerAccountSynchronizationSavedState> &savedState,
                                              int32_t halfBatchSize) {
@@ -167,9 +171,12 @@ namespace ledger {
                 }
             };
 
-            Future<Unit> performSynchronization(const std::shared_ptr<Account> &account) {
-                auto buddy = std::make_shared<SynchronizationBuddy>();
+            virtual std::shared_ptr<SynchronizationBuddy> makeSynchronizationBuddy() {
+                return std::make_shared<SynchronizationBuddy>();
+            }
 
+            Future<Unit> performSynchronization(const std::shared_ptr<Account> &account) {
+                auto buddy = makeSynchronizationBuddy();
                 buddy->account = account;
                 buddy->preferences = std::static_pointer_cast<AbstractAccount>(account)->getInternalPreferences()
                         ->getSubPreferences(
@@ -257,40 +264,23 @@ namespace ledger {
                         return Future<Unit>::successful(unit);
                     }
                     return tryKillSession.getValue();
+                }).template flatMap<Unit>(account->getContext(), [self, buddy] (auto) {
+                    return self->synchronizeMempool(buddy);
                 }).template map<Unit>(ImmediateExecutionContext::INSTANCE, [self, buddy] (const Unit&) {
                     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
                             (DateUtils::now() - buddy->startDate.time_since_epoch()).time_since_epoch());
                     buddy->logger->info("End synchronization for account#{} of wallet {} in {}", buddy->account->getIndex(),
                                         buddy->account->getWallet()->getName(), DurationUtils::formatDuration(duration));
 
-                    //Delete dropped txs from DB
-                    soci::session sql(buddy->wallet->getDatabase()->getPool());
-                    for (auto& tx : buddy->transactionsToDrop) {
-                        //Check if tx is pending
-                        auto it = buddy->savedState.getValue().pendingTxsHash.find(tx.first);
-                        if (it == buddy->savedState.getValue().pendingTxsHash.end()) {
-                            soci::transaction tr(sql);
-                            buddy->logger->info("Drop transaction {}", tx.first);
-                            buddy->logger->info("Deleting operation from DB {}", tx.second);
-                            try {
-                                sql << "DELETE FROM operations WHERE uid = :uid", soci::use(tx.second);
-                                tr.commit();
-                            } catch(std::exception& ex) {
-                                buddy->logger->info("Failed to delete operation from DB {} reason: {}, rollback ...", tx.second, ex.what());
-                                tr.rollback();
-                            }
-                        }
-                    }
-
                     self->_currentAccount = nullptr;
                     return unit;
-                }).recover(ImmediateExecutionContext::INSTANCE, [buddy] (const Exception& ex) -> Unit {
+                }).recoverWith(ImmediateExecutionContext::INSTANCE, [self, buddy] (const Exception& ex) -> Future<Unit> {
                     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
                             (DateUtils::now() - buddy->startDate.time_since_epoch()).time_since_epoch());
                     buddy->logger->error("Error during during synchronization for account#{} of wallet {} in {} ms", buddy->account->getIndex(),
                                          buddy->account->getWallet()->getName(), duration.count());
                     buddy->logger->error("Due to {}, {}", api::to_string(ex.getErrorCode()), ex.getMessage());
-                    return unit;
+                    return self->recoverFromFailedSynchronization(buddy);
                 });
             };
 
@@ -474,8 +464,8 @@ namespace ledger {
                         for (const auto& tx : bulk->transactions) {
                             soci::transaction tr(sql);
                             // A lot of things could happen here, better to wrap it
-                            auto tryPutTx = Try<int>::from([&buddy, &tx, &sql] () {
-                                auto flag = buddy->account->putTransaction(sql, tx);
+                            auto tryPutTx = Try<int>::from([&buddy, &tx, &sql, &self] () {
+                                auto flag = self->putTransaction(sql, tx, buddy);
                                 //Update first pendingTxHash in savedState
                                 auto it = buddy->transactionsToDrop.find(tx.hash);
                                 if (it != buddy->transactionsToDrop.end()) {
@@ -524,11 +514,41 @@ namespace ledger {
                     });
             };
 
+            virtual Future<Unit> synchronizeMempool(const std::shared_ptr<SynchronizationBuddy>& buddy) {
+                //Delete dropped txs from DB
+                soci::session sql(buddy->wallet->getDatabase()->getPool());
+                for (auto& tx : buddy->transactionsToDrop) {
+                    //Check if tx is pending
+                    auto it = buddy->savedState.getValue().pendingTxsHash.find(tx.first);
+                    if (it == buddy->savedState.getValue().pendingTxsHash.end()) {
+                        soci::transaction tr(sql);
+                        buddy->logger->info("Drop transaction {}", tx.first);
+                        buddy->logger->info("Deleting operation from DB {}", tx.second);
+                        try {
+                            sql << "DELETE FROM operations WHERE uid = :uid", soci::use(tx.second);
+                            tr.commit();
+                        } catch(std::exception& ex) {
+                            buddy->logger->info("Failed to delete operation from DB {} reason: {}, rollback ...", tx.second, ex.what());
+                            tr.rollback();
+                        }
+                    }
+                }
+                return Future<Unit>::successful(unit);
+            }
+
+            virtual Future<Unit> recoverFromFailedSynchronization(const std::shared_ptr<SynchronizationBuddy>& buddy) {
+                return Future<Unit>::successful(unit);
+            }
+
+            virtual int putTransaction(soci::session& sql, const Transaction& transaction, const std::shared_ptr<SynchronizationBuddy>& buddy) = 0;
+
             virtual void updateCurrentBlock(std::shared_ptr<SynchronizationBuddy> &buddy,
                                             const std::shared_ptr<api::ExecutionContext> &context) = 0;
             virtual void updateTransactionsToDrop(soci::session &sql,
                                                   std::shared_ptr<SynchronizationBuddy> &buddy,
                                                   const std::string &accountUid) = 0;
+
+
 
             std::shared_ptr<Explorer> _explorer;
             std::shared_ptr<ProgressNotifier<Unit>> _notifier;

--- a/core/src/wallet/ethereum/explorers/EthereumLikeBlockchainExplorer.h
+++ b/core/src/wallet/ethereum/explorers/EthereumLikeBlockchainExplorer.h
@@ -115,6 +115,8 @@ namespace ledger {
                                                public AbstractBlockchainExplorer<EthereumLikeBlockchainExplorerTransaction> {
         public:
             typedef ledger::core::Block Block;
+            using Transaction = EthereumLikeBlockchainExplorerTransaction;
+
             EthereumLikeBlockchainExplorer(const std::shared_ptr<ledger::core::api::DynamicObject> &configuration,
                                            const std::vector<std::string> &matchableKeys);
 

--- a/core/src/wallet/ethereum/synchronizers/EthereumLikeBlockchainExplorerAccountSynchronizer.cpp
+++ b/core/src/wallet/ethereum/synchronizers/EthereumLikeBlockchainExplorerAccountSynchronizer.cpp
@@ -93,5 +93,11 @@ namespace ledger {
         std::shared_ptr<api::ExecutionContext> EthereumLikeBlockchainExplorerAccountSynchronizer::getSynchronizerContext() {
             return getContext();
         }
+
+        int EthereumLikeBlockchainExplorerAccountSynchronizer::putTransaction(soci::session &sql,
+                                                                              const EthereumLikeBlockchainExplorerTransaction &transaction,
+                                                                              const std::shared_ptr<AbstractBlockchainExplorerAccountSynchronizer<EthereumLikeAccount, EthereumLikeAddress, EthereumLikeKeychain, EthereumLikeBlockchainExplorer>::SynchronizationBuddy> &buddy) {
+            return buddy->account->putTransaction(sql, transaction);
+        }
     }
 }

--- a/core/src/wallet/ethereum/synchronizers/EthereumLikeBlockchainExplorerAccountSynchronizer.h
+++ b/core/src/wallet/ethereum/synchronizers/EthereumLikeBlockchainExplorerAccountSynchronizer.h
@@ -68,6 +68,9 @@ namespace ledger {
 
             bool isSynchronizing() const override;
 
+        protected:
+            int putTransaction(soci::session &sql, const Transaction &transaction,
+                               const std::shared_ptr<SynchronizationBuddy> &buddy) override;
 
         private:
             std::shared_ptr<EthereumBlockchainAccountSynchronizer> getSharedFromThis() override ;

--- a/core/src/wallet/ripple/explorers/RippleLikeBlockchainExplorer.h
+++ b/core/src/wallet/ripple/explorers/RippleLikeBlockchainExplorer.h
@@ -78,6 +78,7 @@ namespace ledger {
                                              public AbstractBlockchainExplorer<RippleLikeBlockchainExplorerTransaction> {
         public:
             typedef ledger::core::Block Block;
+            using Transaction = RippleLikeBlockchainExplorerTransaction;
 
             RippleLikeBlockchainExplorer(const std::shared_ptr<ledger::core::api::DynamicObject> &configuration,
                                          const std::vector<std::string> &matchableKeys);

--- a/core/src/wallet/ripple/synchronizers/RippleLikeBlockchainExplorerAccountSynchronizer.cpp
+++ b/core/src/wallet/ripple/synchronizers/RippleLikeBlockchainExplorerAccountSynchronizer.cpp
@@ -101,5 +101,11 @@ namespace ledger {
         RippleLikeBlockchainExplorerAccountSynchronizer::getSynchronizerContext() {
             return getContext();
         }
+
+        int RippleLikeBlockchainExplorerAccountSynchronizer::putTransaction(soci::session &sql,
+                                                                            const RippleLikeBlockchainExplorerTransaction &transaction,
+                                                                            const std::shared_ptr<AbstractBlockchainExplorerAccountSynchronizer<RippleLikeAccount, RippleLikeAddress, RippleLikeKeychain, RippleLikeBlockchainExplorer>::SynchronizationBuddy> &buddy) {
+            return buddy->account->putTransaction(sql, transaction);
+        }
     }
 }

--- a/core/src/wallet/ripple/synchronizers/RippleLikeBlockchainExplorerAccountSynchronizer.h
+++ b/core/src/wallet/ripple/synchronizers/RippleLikeBlockchainExplorerAccountSynchronizer.h
@@ -74,6 +74,8 @@ namespace ledger {
 
             bool isSynchronizing() const override;
 
+            int putTransaction(soci::session &sql, const Transaction &transaction,
+                               const std::shared_ptr<SynchronizationBuddy> &buddy) override;
 
         private:
             std::shared_ptr<RippleBlockchainAccountSynchronizer> getSharedFromThis() override;

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
@@ -109,6 +109,7 @@ namespace ledger {
                                             public AbstractBlockchainExplorer<TezosLikeBlockchainExplorerTransaction> {
         public:
             typedef ledger::core::Block Block;
+            using Transaction = TezosLikeBlockchainExplorerTransaction;
 
             TezosLikeBlockchainExplorer(const std::shared_ptr<ledger::core::api::DynamicObject> &configuration,
                                         const std::vector<std::string> &matchableKeys);

--- a/core/src/wallet/tezos/synchronizers/TezosLikeBlockchainExplorerAccountSynchronizer.cpp
+++ b/core/src/wallet/tezos/synchronizers/TezosLikeBlockchainExplorerAccountSynchronizer.cpp
@@ -100,5 +100,11 @@ namespace ledger {
         TezosLikeBlockchainExplorerAccountSynchronizer::getSynchronizerContext() {
             return getContext();
         }
+
+        int TezosLikeBlockchainExplorerAccountSynchronizer::putTransaction(soci::session &sql,
+                                                                           const TezosLikeBlockchainExplorerTransaction &transaction,
+                                                                           const std::shared_ptr<AbstractBlockchainExplorerAccountSynchronizer<TezosLikeAccount, TezosLikeAddress, TezosLikeKeychain, TezosLikeBlockchainExplorer>::SynchronizationBuddy> &buddy) {
+            return buddy->account->putTransaction(sql, transaction);
+        }
     }
 }

--- a/core/src/wallet/tezos/synchronizers/TezosLikeBlockchainExplorerAccountSynchronizer.h
+++ b/core/src/wallet/tezos/synchronizers/TezosLikeBlockchainExplorerAccountSynchronizer.h
@@ -38,6 +38,7 @@
 #include <wallet/pool/WalletPool.hpp>
 #include <async/DedicatedContext.hpp>
 #include <events/ProgressNotifier.h>
+
 namespace ledger {
     namespace core {
 
@@ -70,6 +71,8 @@ namespace ledger {
 
             bool isSynchronizing() const override;
 
+            int putTransaction(soci::session &sql, const Transaction &transaction,
+                               const std::shared_ptr<SynchronizationBuddy> &buddy) override;
 
         private:
             std::shared_ptr <TezosBlockchainAccountSynchronizer> getSharedFromThis() override;

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -5,6 +5,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(gtest_force_shared_crt ON CACHE BOOL "Build gtest with shared runtime" FORCE)
 add_subdirectory(lib/googletest)
 
+add_subdirectory(lib/libuv)
 add_subdirectory(lib/libledger-test)
 add_subdirectory(common)
 add_subdirectory(bytes)

--- a/core/test/integration/synchronization/synchronization_btc_rbf_tests.cpp
+++ b/core/test/integration/synchronization/synchronization_btc_rbf_tests.cpp
@@ -1,0 +1,148 @@
+/*
+ *
+ * synchronization_btc_rbf_tests.cpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 13/06/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <gtest/gtest.h>
+#include "../BaseFixture.h"
+#include <set>
+#include <api/KeychainEngines.hpp>
+#include <utils/DateUtils.hpp>
+#include <wallet/bitcoin/database/BitcoinLikeAccountDatabaseHelper.h>
+#include <wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h>
+#include "ExplorerStorage.hpp"
+#include "HttpClientOnFakeExplorer.hpp"
+#include <UvThreadDispatcher.hpp>
+
+struct BitcoinLikeWalletBtcRbfSynchronization : public BaseFixture {
+
+    void SetUp() override {
+        BaseFixture::SetUp();
+        explorer = std::make_shared<test::ExplorerStorage>();
+        backend = std::static_pointer_cast<DatabaseBackend>(DatabaseBackend::getSqlite3Backend());
+    }
+
+    void TearDown() override {
+        BaseFixture::TearDown();
+        explorer = nullptr;
+    }
+
+    std::shared_ptr<WalletPool> newPool() {
+        auto dispatcher = uv::createDispatcher();
+        printer = std::make_shared<CoutLogPrinter>(dispatcher->getMainExecutionContext());
+        return WalletPool::newInstance(
+                "rbf_pool",
+                "test",
+                std::make_shared<test::HttpClientOnFakeExplorer>(explorer),
+                nullptr,
+                resolver,
+                printer,
+                dispatcher,
+                rng,
+                backend,
+                api::DynamicObject::newInstance()
+        );
+    }
+
+    void synchronizeAccount(const std::shared_ptr<BitcoinLikeAccount>& account) {
+        auto bus = account->synchronize();
+        Promise<Unit> promise;
+        bus->subscribe(dispatcher->getSerialExecutionContext("worker"),
+                       make_receiver([=](const std::shared_ptr<api::Event>& event) mutable {
+                           std::cout << api::to_string(event->getCode()) << std::endl;
+                           if (event->getCode() == api::EventCode::SYNCHRONIZATION_STARTED)
+                               return;
+                           promise.success(unit);
+                       }));
+        uv::wait(promise.getFuture());
+    }
+
+    std::shared_ptr<test::ExplorerStorage> explorer;
+};
+
+struct Output {
+    //   [{"output_index":0,"value":182483500,"address":"18BkSm7P2wQJfQhV7B5st14t13mzHRJ2o1","script_hex":"76a9144ed14e321713e1c97056643a233b968d34b2231188ac"},{"output_index":1,"value":100000,"address":"1NMfmPC9yHBe5US2CUwWARPRM6cDP6N86m","script_hex":"76a914ea4351fd2a0a2cd62ab264d9f0b1997696a632f488ac"}]
+    uint64_t value;
+    std::string address;
+
+    Output(uint64_t val, const std::string& addr) : value(val), address(addr) {}
+
+    std::string toJson(int index) {
+        return fmt::format(R"({{"output_index": {}, "address": "{}", "value": {}, "script_hex": "0000"}})", index, address, value);
+    }
+};
+
+struct Input {
+// {"input_index":0,"output_hash":"666613fd82459f94c74211974e74ffcb4a4b96b62980a6ecaee16af7702bbbe5","output_index":0,"value":182593500,"address":"1DDBzjLyAmDr4qLRC2T2WJ831cxBM5v7G7","script_signature":"473044022018ac8a44412d66f489138c3e8f9196b60dba1c24fb715dd8c3d66921bcc13f4702201f222fd3e25fe8f3807347650ae7b41451c078c9a8fc2e5b7d82d6a928a8c363012103da611b1fcacc0056ceb5489ee951b523e52de7ff1902fd1c6f9c212a542da297"}]
+    std::string outputHash;
+    int outputIndex;
+    Output prevOutput;
+    uint64_t sequence;
+
+    Input(const std::string& hash, int index, const Output& output, uint64_t seq)
+        : outputHash(hash), outputIndex(index), prevOutput(output), sequence(seq) {
+
+    }
+
+};
+
+struct Block {
+    // {"hash":"00000000000000000198e024d936c87807b4198f9de7105015036ce785fa2bdc","height":362055,"time":"2015-06-22T15:58:30Z"}
+};
+
+static std::string mockTransaction(const std::vector<Input>& input, const std::vector<Output>& output) {
+    std::ostringstream ss;
+
+    //"{\"hash\":\"\",\"received_at\":\"2015-06-22T15:58:30Z\",\"lock_time\":0,\"block\":,\"inputs\":,\"outputs\":,\"fees\":,\"amount\":0,\"confirmations\":110200}"
+    return "";
+}
+
+Future<int> do_it(std::shared_ptr<api::ExecutionContext> context, int n, int max) {
+    return Future<int>::async(context, [=] () {
+        std::cout << " -> " <<  n << std::endl;
+        return n + 1;
+    }).flatMap<int>(context, [=] (int v) {
+        if (v < max) {
+            return do_it(context, v, max);
+        }
+        return Future<int>::successful(v);
+    });
+}
+
+TEST_F(BitcoinLikeWalletBtcRbfSynchronization, SimpleRbfScenario) {
+    auto pool = newPool();
+    auto wallet = wait(pool->createWallet("e857815f-488a-4301-b67c-378a5e9c8a63", "bitcoin",
+                                          api::DynamicObject::newInstance()));
+    auto account = createBitcoinLikeAccount(wallet, 0, P2PKH_MEDIUM_XPUB_INFO);
+    synchronizeAccount(account);
+    synchronizeAccount(account);
+
+    std::cout <<  Output(9000, "1DDBzjLyAmDr4qLRC2T2WJ831cxBM5v7G7").toJson(12) << std::endl;
+
+}

--- a/core/test/lib/libledger-test/CMakeLists.txt
+++ b/core/test/lib/libledger-test/CMakeLists.txt
@@ -14,7 +14,8 @@ add_library(ledger-test STATIC
             FakeHttpClient.hpp FakeHttpClient.cpp
             FakeUrlConnection.hpp FakeUrlConnection.cpp
             ExplorerStorage.hpp ExplorerStorage.cpp
-            HttpClientOnFakeExplorer.hpp HttpClientOnFakeExplorer.cpp)
+            HttpClientOnFakeExplorer.hpp HttpClientOnFakeExplorer.cpp
+            UvThreadDispatcher.hpp UvThreadDispatcher.cpp)
 if (SYS_OPENSSL)
     include_directories(${CMAKE_BINARY_DIR}/include ${OPENSSL_INCLUDE_DIR})
 else()
@@ -25,6 +26,7 @@ if (MSVC)
 endif ()
 
 target_link_libraries(mangoose PUBLIC ssl)
+target_link_libraries(ledger-test PUBLIC uv)
 
 target_link_libraries(ledger-test PUBLIC crypto)
 target_link_libraries(ledger-test PUBLIC ledger-core-static)
@@ -34,3 +36,4 @@ target_include_directories(ledger-test PUBLIC ../../../lib/cereal/)
 target_include_directories(ledger-test PUBLIC ../../../../core)
 target_include_directories(ledger-test PUBLIC ../../../../core/src)
 target_include_directories(ledger-test PUBLIC ../../../lib/boost/)
+target_include_directories(ledger-test PUBLIC ../libuv/include)

--- a/core/test/lib/libledger-test/CMakeLists.txt
+++ b/core/test/lib/libledger-test/CMakeLists.txt
@@ -12,7 +12,9 @@ add_library(ledger-test STATIC
             MongooseHttpClient.cpp MongooseHttpClient.hpp MongooseSimpleRestServer.cpp MongooseSimpleRestServer.hpp
             route.cc route.h OpenSSLRandomNumberGenerator.cpp OpenSSLRandomNumberGenerator.hpp callbacks.cpp callbacks.hpp FakeWebSocketClient.cpp FakeWebSocketClient.h
             FakeHttpClient.hpp FakeHttpClient.cpp
-            FakeUrlConnection.hpp FakeUrlConnection.cpp)
+            FakeUrlConnection.hpp FakeUrlConnection.cpp
+            ExplorerStorage.hpp ExplorerStorage.cpp
+            HttpClientOnFakeExplorer.hpp HttpClientOnFakeExplorer.cpp)
 if (SYS_OPENSSL)
     include_directories(${CMAKE_BINARY_DIR}/include ${OPENSSL_INCLUDE_DIR})
 else()

--- a/core/test/lib/libledger-test/ExplorerStorage.cpp
+++ b/core/test/lib/libledger-test/ExplorerStorage.cpp
@@ -1,0 +1,97 @@
+#include "ExplorerStorage.hpp"
+#include <algorithm>
+#include <rapidjson/reader.h>
+#include <rapidjson/writer.h>
+#include <rapidjson/stream.h>
+#include <fmt/format.h>
+#include <wallet/bitcoin/explorers/api/TransactionParser.hpp>
+#include <utils/DateUtils.hpp>
+
+namespace ledger {
+    namespace core {
+        namespace test {
+
+            bool transactionContainAddresses(const BitcoinLikeBlockchainExplorerTransaction& tr, const std::unordered_set<std::string>& addresses) {
+                return
+                    (std::find_if(
+                        tr.inputs.begin(),
+                        tr.inputs.end(),
+                        [&](const auto& input) {return input.address.hasValue() && (addresses.find(input.address.getValue()) != addresses.end()); }) != tr.inputs.end())
+                    ||
+                    (std::find_if(
+                        tr.outputs.begin(),
+                        tr.outputs.end(),
+                        [&](const auto& output) {return output.address.hasValue() && (addresses.find(output.address.getValue()) != addresses.end()); }) != tr.outputs.end());
+            }
+
+            void ExplorerStorage::addTransaction(const std::string& jsonTransaction) {
+                std::string dummy;
+                BitcoinLikeBlockchainExplorerTransaction transaction;
+                TransactionParser parser(dummy);
+                parser.init(&transaction);
+                rapidjson::Reader reader;
+                rapidjson::StringStream ss(jsonTransaction.c_str());
+                if (reader.Parse(ss, parser).IsError())
+                    throw std::runtime_error("Can't parse transaction");
+                if (!transaction.block.nonEmpty()) {
+                    _memPool.push_back(std::make_pair(transaction, jsonTransaction));
+                    return;
+                }
+                _transactions.push_back(std::make_pair(transaction, jsonTransaction));
+                std::sort(
+                    _transactions.begin(),
+                    _transactions.end(),
+                    [](const auto& a, const auto& b) { return  a.first.block.getValue().height < b.first.block.getValue().height; });
+            }
+
+            void ExplorerStorage::removeTransaction(const std::string& hash) {
+                auto it = std::find_if(_transactions.begin(), _transactions.end(), [&](auto& x) {return x.first.hash == hash; });
+                if (it != _transactions.end())
+                    _transactions.erase(it);
+                it = std::find_if(_memPool.begin(), _memPool.end(), [&](auto& x) {return x.first.hash == hash; });
+                if (it != _memPool.end())
+                    _transactions.erase(it);
+            }
+
+            std::vector<std::string> ExplorerStorage::getTransactions(
+                const std::vector<std::string>& addresses,
+                const std::string& blockHash) {
+                std::unordered_set<std::string> addrs(addresses.begin(), addresses.end());
+                std::vector<std::string> result;
+                auto it = _transactions.begin();
+                if (blockHash != "") 
+                    it = std::find_if(_transactions.begin(), _transactions.end(), [&](auto& x) {return x.first.block.getValue().hash == blockHash; });
+                for (;it != _transactions.end(); ++it) {
+                    if (transactionContainAddresses(it->first, addrs))
+                        result.push_back(it->second);
+                }
+                for (auto it = _memPool.begin(); it != _memPool.end(); ++it) {
+                    if (transactionContainAddresses(it->first, addrs))
+                        result.push_back(it->second);
+                }
+                return result;
+            }
+
+            std::string ExplorerStorage::getLastBlock() {
+                if (_transactions.empty())
+                    return "{}";
+                rapidjson::StringBuffer s;
+                rapidjson::Writer<rapidjson::StringBuffer> writer(s);
+                auto lastBlock = _transactions.back().first.block.getValue();
+                writer.StartObject();
+                writer.Key("hash");
+                writer.String(lastBlock.hash.c_str());
+                writer.Key("height");
+                writer.Uint64(lastBlock.height);
+                writer.Key("time");
+                writer.String(DateUtils::toJSON(lastBlock.time).c_str());
+                writer.Key("txs");
+                writer.StartArray();
+                writer.EndArray();
+                writer.EndObject();
+
+                return s.GetString();
+            }
+        }
+    }
+}

--- a/core/test/lib/libledger-test/ExplorerStorage.cpp
+++ b/core/test/lib/libledger-test/ExplorerStorage.cpp
@@ -69,6 +69,9 @@ namespace ledger {
                     if (transactionContainAddresses(it->first, addrs))
                         result.push_back(it->second);
                 }
+                for (auto r : result) {
+                    std::cout << r << std::endl;
+                }
                 return result;
             }
 

--- a/core/test/lib/libledger-test/ExplorerStorage.hpp
+++ b/core/test/lib/libledger-test/ExplorerStorage.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <unordered_set>
+#include <wallet/bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp>
+
+namespace ledger {
+    namespace core {
+        namespace test {
+            // This class simulate the work of Explorer for unit tests
+            class ExplorerStorage {
+            public:
+                void addTransaction(const std::string& jsonTransaction);
+
+                void removeTransaction(const std::string& hash);
+
+                std::vector<std::string> getTransactions(
+                    const std::vector<std::string>& addresses,
+                    const std::string& blockHash);
+
+                std::string getLastBlock();
+            private:
+                std::vector<std::pair<BitcoinLikeBlockchainExplorerTransaction, std::string>> _transactions;
+                std::vector<std::pair<BitcoinLikeBlockchainExplorerTransaction, std::string>> _memPool;
+            };
+        }
+    }
+}

--- a/core/test/lib/libledger-test/HttpClientOnFakeExplorer.cpp
+++ b/core/test/lib/libledger-test/HttpClientOnFakeExplorer.cpp
@@ -1,0 +1,85 @@
+#include "HttpClientOnFakeExplorer.hpp"
+#include <unordered_map>
+#include <boost/algorithm/string.hpp>
+#include "api/HttpRequest.hpp"
+#include "api/HttpReadBodyResult.hpp"
+#include "utils/optional.hpp"
+#include "api/Error.hpp"
+
+namespace ledger {
+    namespace core {
+        namespace test {
+            std::string createTrunsactionBulkJson(std::vector<std::string>& transactions) {
+                return "{\"truncated\":false, \"txs\" : [" + boost::algorithm::join(transactions, ",") + "]}";
+            }
+
+            std::unordered_map<std::string, std::string> parseParameters(const std::string& parameters) {
+                std::unordered_map<std::string, std::string> result;
+                std::vector<std::string> splited;
+                boost::split(splited, parameters, [](char c) { return c == '&'; });
+                for (auto& param : splited) {
+                    if (param.empty())
+                        continue;
+                    std::vector<std::string> key_value;
+                    boost::split(key_value, param, [](char c) { return c == '='; });
+                    if (key_value.size() == 1) {
+                        result[key_value[0]] = "";
+                    }
+                    else {
+                        result[key_value[0]] = key_value[1];
+                    }
+                }
+                return result;
+            }
+
+            HttpClientOnFakeExplorer::HttpClientOnFakeExplorer(std::shared_ptr<ExplorerStorage> explorer) : _explorer(explorer) {
+            };
+
+            void HttpClientOnFakeExplorer::execute(const std::shared_ptr<api::HttpRequest>& request) {
+                std::string url = request->getUrl();
+                // TODO: replace this code when we will have "standart" url parsing 
+                std::vector<std::string> result;
+                boost::split(result, url, [](char c) {return c == '?'; });
+                std::unordered_map<std::string, std::string> parameters;
+                if (result.size() > 1)
+                    parameters = parseParameters(result[1]);
+                std::vector<std::string> pathComponents;
+                boost::split(pathComponents, result[0], [](char c) {return c == '/'; });
+                auto it = std::find(pathComponents.begin(),pathComponents.end(), "addresses");
+                if (it != pathComponents.end()) {
+                    auto addressesIt = it + 1;
+                    if (addressesIt == pathComponents.end()) {
+                        request->complete(std::shared_ptr<api::HttpUrlConnection>(), api::Error(api::ErrorCode::API_ERROR, ""));
+                        return;
+                    }
+                    std::vector<std::string> addresses;
+                    boost::split(addresses, *addressesIt, [](char c) {return c == ','; });
+                    std::string blockHash = "";
+                    auto blockHashIt = parameters.find("block_hash");
+                    if (blockHashIt != parameters.end()) {
+                        blockHash = blockHashIt->second;
+                    }
+                    auto transactions = _explorer->getTransactions(addresses, blockHash);
+                    request->complete(FakeUrlConnection::fromString(createTrunsactionBulkJson(transactions)), std::experimental::optional<api::Error>());
+                    return;
+                }
+                it = std::find(pathComponents.begin(), pathComponents.end(), "current");
+                if (it != pathComponents.end()) {
+                    std::string lastBlock = _explorer->getLastBlock();
+                    if (lastBlock.empty()) {
+                        request->complete(std::shared_ptr<api::HttpUrlConnection>(), api::Error(api::ErrorCode::BLOCK_NOT_FOUND, "Block not found"));
+                        return;
+                    }
+                    request->complete(FakeUrlConnection::fromString(lastBlock), std::experimental::optional<api::Error>());
+                    return;
+                }
+                it = std::find(pathComponents.begin(), pathComponents.end(), "syncToken");
+                if (it != pathComponents.end()) {
+                    request->complete(FakeUrlConnection::fromString("{\"token\":\"PLEASE-LET-ME-IN\"}"), std::experimental::optional<api::Error>());
+                    return;
+                }
+            }
+
+        }
+    }
+}

--- a/core/test/lib/libledger-test/HttpClientOnFakeExplorer.hpp
+++ b/core/test/lib/libledger-test/HttpClientOnFakeExplorer.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <unordered_map>
+#include <memory>
+#include "api/HttpClient.hpp"
+#include "FakeUrlConnection.hpp"
+#include "ExplorerStorage.hpp"
+
+namespace ledger {
+    namespace core {
+        namespace test {
+
+            class HttpClientOnFakeExplorer : public api::HttpClient {
+            public:
+                HttpClientOnFakeExplorer(std::shared_ptr<ExplorerStorage> explorer);
+                void execute(const std::shared_ptr<api::HttpRequest>& request) override;
+            private:
+                std::shared_ptr<ExplorerStorage> _explorer;
+            };
+
+        }
+    }
+}

--- a/core/test/lib/libledger-test/UvThreadDispatcher.cpp
+++ b/core/test/lib/libledger-test/UvThreadDispatcher.cpp
@@ -1,0 +1,227 @@
+/*
+ *
+ * UvThreadDispatcher.cpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 14/06/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include "UvThreadDispatcher.hpp"
+#include <uv.h>
+#include <thread>
+#include <ledger/core/utils/Option.hpp>
+#include <ledger/core/utils/Try.hpp>
+#include <unordered_map>
+
+using namespace ledger::core;
+
+enum class EventType {
+    RUN,
+    CLOSE
+};
+
+struct Event {
+    EventType eventType;
+    std::shared_ptr<api::Runnable> runnable;
+};
+
+static void context_callback(uv_async_t* handle);
+
+class EventLoop {
+public:
+    EventLoop() : _loop(new uv_loop_t), _async(new uv_async_t), _running(true) {
+        uv_loop_init(_loop);
+        uv_async_init(_loop, _async, context_callback);
+        _async->data = static_cast<void *>(this);
+    }
+
+    EventLoop(const EventLoop&) = delete;
+    EventLoop(EventLoop&&) = delete;
+    EventLoop & operator=(const EventLoop&) = delete;
+
+    void queue(const std::shared_ptr<api::Runnable>& runnable) {
+        std::unique_lock<std::mutex> lock(_mutex);
+        if (_running) {
+            Event event;
+            event.eventType = EventType::RUN;
+            event.runnable = runnable;
+            _queue.emplace(std::move(event));
+            uv_async_send(_async);
+        }
+    }
+
+    void queue(const std::shared_ptr<api::Runnable>& runnable, int64_t millis) {
+        throw std::runtime_error("Queuing with delay is not implemented.");
+    }
+
+    bool run() {
+        uv_run(_loop, UV_RUN_DEFAULT);
+        return uv_loop_alive(_loop) != 0;
+    }
+
+    void tick() {
+        Option<Event> event;
+        while ((event = dequeue()).hasValue()) {
+            switch (event.getValue().eventType) {
+                case EventType::RUN: {
+                    auto result = Try<Unit>::from([&]() {
+                        event.getValue().runnable->run();
+                        return unit;
+                    });
+                    if (result.isFailure()) {
+                        std::cerr << "An error happened during asynchronous execution: "
+                                  << result.getFailure().getMessage() << std::endl;
+                    }
+                    break;
+                }
+                case EventType::CLOSE: {
+                    std::unique_lock<std::mutex> lock(_mutex);
+                    _running = false;
+                    uv_stop(_loop);
+                    uv_loop_close(_loop);
+                    uv_close(reinterpret_cast<uv_handle_t*>(_async), NULL);
+                    break;
+                }
+            }
+        }
+    }
+
+    void close() {
+        std::unique_lock<std::mutex> lock(_mutex);
+        Event event;
+        event.eventType = EventType::CLOSE;
+        _queue.emplace(event);
+        uv_async_send(_async);
+    }
+
+    Option<Event> dequeue() {
+        std::unique_lock<std::mutex> lock(_mutex);
+        if (!_queue.empty() && _running) {
+            auto event = _queue.front();
+            _queue.pop();
+            return event;
+        } else {
+            return Option<Event>::NONE;
+        }
+    }
+
+    ~EventLoop() {
+        delete _loop;
+        delete _async;
+    }
+
+private:
+    uv_loop_t* _loop;
+    uv_async_t* _async;
+    uv_timer_t* timer;
+    std::mutex _mutex;
+    bool _running;
+    std::queue<Event> _queue;
+};
+
+static void context_callback(uv_async_t* handle) {
+    static_cast<EventLoop *>(handle->data)->tick();
+}
+
+class SequentialExecutionContext : public api::ExecutionContext {
+public:
+
+    SequentialExecutionContext() {
+        _thread = std::thread([this] () {
+            run();
+        });
+    }
+
+    void run() {
+        while (_loop.run());
+    }
+
+    void stop() {
+        _loop.close();
+        _thread.join();
+    }
+
+    void execute(const std::shared_ptr<api::Runnable> &runnable) override {
+        _loop.queue(runnable);
+    }
+
+    void delay(const std::shared_ptr<api::Runnable> &runnable, int64_t millis) override {
+        _loop.queue(runnable, millis);
+    }
+
+    ~SequentialExecutionContext() override {
+
+    }
+
+private:
+    std::thread _thread;
+    EventLoop _loop;
+};
+
+class ThreadDispatcher : public api::ThreadDispatcher {
+public:
+    std::shared_ptr<api::ExecutionContext> getSerialExecutionContext(const std::string &name) override {
+        std::unique_lock<std::mutex> lock(_mutex);
+        auto it = _serialContexts.find(name);
+        if (it == _serialContexts.end()) {
+            auto context = std::make_shared<SequentialExecutionContext>();
+            _serialContexts[name] = context;
+            return context;
+        }
+        return it->second;
+    }
+
+    std::shared_ptr<api::ExecutionContext> getThreadPoolExecutionContext(const std::string &name) override {
+        // TODO Implement thread pools
+        return getSerialExecutionContext(name);
+    }
+
+    std::shared_ptr<api::ExecutionContext> getMainExecutionContext() override {
+        return getSerialExecutionContext("__uv__main__");
+    }
+
+    std::shared_ptr<api::Lock> newLock() override {
+        return nullptr;
+    }
+
+    ~ThreadDispatcher() {
+       for (auto& context : _serialContexts) {
+           context.second->stop();
+       }
+    }
+
+private:
+    std::mutex _mutex;
+    std::unordered_map<std::string, std::shared_ptr<SequentialExecutionContext>> _serialContexts;
+};
+
+namespace uv {
+
+    std::shared_ptr<ledger::core::api::ThreadDispatcher> createDispatcher() {
+        return std::make_shared<ThreadDispatcher>();
+    }
+
+}

--- a/core/test/lib/libledger-test/UvThreadDispatcher.hpp
+++ b/core/test/lib/libledger-test/UvThreadDispatcher.hpp
@@ -1,0 +1,70 @@
+/*
+ *
+ * UvThreadDispatcher.hpp
+ * ledger-core
+ *
+ * Created by Pierre Pollastri on 14/06/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#ifndef LEDGER_CORE_UVTHREADDISPATCHER_HPP
+#define LEDGER_CORE_UVTHREADDISPATCHER_HPP
+
+#include <ledger/core/api/ThreadDispatcher.hpp>
+#include <ledger/core/api/ExecutionContext.hpp>
+#include <ledger/core/async/Future.hpp>
+#include <ledger/core/api/Runnable.hpp>
+#include <ledger/core/api/Lock.hpp>
+#include <condition_variable>
+
+namespace uv {
+    std::shared_ptr<ledger::core::api::ThreadDispatcher> createDispatcher();
+
+    template <typename T>
+    static T wait(ledger::core::Future<T> future) {
+        std::mutex mutex;
+        std::condition_variable condition;
+        auto dispatcher = createDispatcher();
+        ledger::core::Try<T> result;
+        future.onComplete(dispatcher->getMainExecutionContext(), [&] (auto res) mutable {
+            std::unique_lock<std::mutex> lock(mutex);
+            result = res;
+            condition.notify_all();
+        });
+        {
+            std::unique_lock<std::mutex> lock(mutex);
+            condition.wait(lock, [&] () {
+                return result.isComplete();
+            });
+        }
+        if (result.isFailure()) {
+            throw result.getFailure();
+        }
+        return result.getValue();
+    }
+}
+
+
+#endif //LEDGER_CORE_UVTHREADDISPATCHER_HPP


### PR DESCRIPTION
- Fix synchronization to replace transaction in user accounts when they are replaced in the mempool
- The code is not optimal, there is multiple thing to rework regarding the transaction and how the library deals with mempool transaction

This PR brings the following changes to the synchronization:
- Mempool is not handled by doing a diff between the mempool stored in DB and the transaction fetched from the network. Now it removes all mempool operations at the beginning of the synchronization (DB mempool is kept in memory in case of failures during synchronization, to be able to restore it).
- It accumulates all mempool transaction fetched on network in memory
- Filter transactions once (remove replaced transaction) and get all input addresses from foreign addresses (addresses which are not part of the account)
- Fetch foreign addresses transactions on the mempool
- Filter once more with replaceable transactions with foreign addresses transactions
- Insert transactions in DB

There is a lot of "pirouettes", due to the common implementation between ETH, XRP, XTZ and BTC. Also DB schema forces to do a lot of queries to be able to properly delete transactions in DB. 

Current Qt host has bugs regarding threading, this PR brings another ThreadDispatcher using libuv which is stable for now but there is no thread pool implementation (it returns sequential execution context).

Last thing this PR change is the use of TTL cache, BTC balance is computed at the end of the synchronization and stored in database. TTL cache is hard to manage when multiple instances of libcore on the same DB.