### PR TITLE
Fix rollback script for migration 21

### DIFF
--- a/core/src/database/migrations.cpp
+++ b/core/src/database/migrations.cpp
@@ -976,7 +976,7 @@ namespace ledger {
                        "PRIMARY KEY (idx, transaction_uid)"
                        ")";
                 sql << "INSERT INTO bitcoin_outputs_swap "
-                       "SELECT idx, transaction_uid, transaction_hash, amount, scripts, "
+                       "SELECT idx, transaction_uid, transaction_hash, amount, script, "
                                    "address, account_uid "
                        "FROM bitcoin_outputs";
                 sql << "DROP TABLE bitcoin_outputs";


### PR DESCRIPTION
This PR fixes a typo in the SQL query for doing a rollback of database schema version 21