### PR TITLE
Faster CI builds

### DIFF
--- a/.circleci/cmake-install.sh
+++ b/.circleci/cmake-install.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+
+
 echo "========> Install CMake"
 cd $HOME
 wget --quiet https://github.com/Kitware/CMake/releases/download/v3.16.5/cmake-3.16.5-Linux-x86_64.tar.gz && tar -xf cmake-3.16.5-Linux-x86_64.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,28 +6,16 @@ dependencies:
 jobs:
   build_linux_release:
     environment:
-        CORE_SSL_1_1: arch_ssl_1_1
+      CORE_SSL_1_1: arch_ssl_1_1
     docker:
-      - image: debian:stretch
+      - image: ledgerhq/lib-ledger-core-build-env:1.0.1
     working_directory: ~/lib-ledger-core
     steps:
-      - run:
-          command: |
-            apt-get update
-            apt-get -y install git ssh
       - checkout
-      - run:
-          name: Setup
-          command: |
-            . .circleci/setup_debian.sh Release
       - run:
           name: Submodule_Initialization
           command: |
             . .circleci/init_submodules.sh
-      - run:
-          name: CMake_Install
-          command: |
-            . .circleci/cmake-install.sh
       - run:
           name: Build_Library
           command: |
@@ -48,14 +36,60 @@ jobs:
           name: Copy_Artifacts (with OpenSSL 1.1)
           command: |
             . .circleci/copy_artifacts.sh $CORE_SSL_1_1 Release
+      - deploy:
+          name: Deploy_Artifacts
+          command: |
+            . .circleci/deploy.sh
+
+  build_linux_jni_release:
+    environment:
+      CORE_SSL_1_1: arch_ssl_1_1
+    docker:
+      - image: ledgerhq/lib-ledger-core-build-env:1.0.1
+    working_directory: ~/lib-ledger-core
+    steps:
+      - checkout
+      - run:
+          name: Submodule_Initialization
+          command: |
+            . .circleci/init_submodules.sh
       - run:
           name: Build_Library_jni
           command: |
             . .circleci/build_lib.sh target_jni Release
       - run:
-          name: Copy_Artifacts_jni
+          name: Export_Lib_Version
           command: |
-            . .circleci/copy_artifacts.sh target_jni
+            . .circleci/export_lib_version.sh
+      - run:
+          name: Copy_Artifacts
+          command: |
+            . .circleci/copy_artifacts.sh
+      - persist_to_workspace:
+          root: ~/lib-ledger-core-artifacts
+          paths:
+            - linux/jni/libledger-core_jni.so
+      - deploy:
+          name: Deploy_Artifacts
+          command: |
+            . .circleci/deploy.sh
+
+  build_android_release:
+    environment:
+      CORE_SSL_1_1: arch_ssl_1_1
+    docker:
+      - image: ledgerhq/lib-ledger-core-build-env:1.0.1
+    working_directory: ~/lib-ledger-core
+    steps:
+      - checkout
+      - run:
+          name: Submodule_Initialization
+          command: |
+            . .circleci/init_submodules.sh
+      - run:
+          name: Export_Lib_Version
+          command: |
+            . .circleci/export_lib_version.sh
       - run:
           name: Setup NDK
           command: |
@@ -95,14 +129,11 @@ jobs:
           name: Copy_Artifacts_Android_arm64-v8a
           command: |
             . .circleci/copy_artifacts.sh android arm64-v8a
-      - persist_to_workspace:
-          root: ~/lib-ledger-core-artifacts
-          paths:
-            - linux/jni/libledger-core_jni.so
       - deploy:
           name: Deploy_Artifacts
           command: |
             . .circleci/deploy.sh
+
   build_linux_debug:
       docker:
         - image: debian:stretch
@@ -295,6 +326,14 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - build_linux_jni_release:
+          filters:
+            tags:
+              only: /.*/
+      - build_android_release:
+          filters:
+            tags:
+              only: /.*/
       - build_macos_release:
           filters:
             tags:
@@ -303,7 +342,7 @@ workflows:
       - build_macos_debug
       - publish_jar:
           requires:
-            - build_linux_release
+            - build_linux_jni_release
             - build_macos_release
           filters:
             tags:

--- a/.circleci/setup_debian.sh
+++ b/.circleci/setup_debian.sh
@@ -2,8 +2,8 @@
 
 BUILD_CONFIG=$1
 
-echo ">>>>>>> GETTING CIRCLE_TAG : $CIRCLE_TAG"
-echo ">>>>>>> GETTING CIRCLE_BRANCH : $CIRCLE_BRANCH"
+apt-get update
+apt-get -y install git ssh
 
 echo "========> Install basic config"
 apt-get update
@@ -41,12 +41,4 @@ apt-get install -y postgresql-9.6 libpq-dev postgresql-server-dev-all
 echo "========> Install Sqlite"
 apt-get install -y sqlite3 sqlite libsqlite3-dev
 
-echo "========> Install node"
-curl -sL https://deb.nodesource.com/setup_9.x | bash -
-apt-get install -y nodejs
-
-echo "========> Install yarn"
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-apt-get update && apt-get install -y yarn
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,10 @@
 FROM debian:stretch
 
-# Install build dependencies
+COPY .circleci/ circleci
+WORKDIR circleci
 
-# Enable sourcefiles repositories, for use with apt build-dep
-RUN echo "deb-src http://deb.debian.org/debian stretch main" >> /etc/apt/sources.list \
-  && echo "deb-src http://deb.debian.org/debian-security/ stretch/updates main" >> /etc/apt/sources.list \
-  && echo "deb-src http://deb.debian.org/debian stretch-updates main" >> /etc/apt/sources.list
+RUN ./setup_debian.sh Release
+RUN ./cmake-install.sh
 
-RUN apt update
+ENV PATH="${PATH}:/root/cmake_folder/bin"
 
-RUN apt-get install -y \
-  build-essential \
-  qt5-default \
-  qtbase5-dev \
-  libqt5websockets5-dev \
-  git \
-  curl \
-  zsh \
-  wget
-
-# Dependencies for building cmake
-RUN apt build-dep -y cmake
-
-# Get and build a more up to date version of cmake
-RUN cd /usr/local/src \ 
-  && wget https://cmake.org/files/v3.12/cmake-3.12.4.tar.gz \
-  && tar xf cmake-3.12.4.tar.gz \ 
-  && cd cmake-3.12.4 \
-  && ./bootstrap --system-curl -- -DCMAKE_BUILD_TYPE:STRING=Release \
-  && make -j4 \
-  && make install \
-  && cd .. \
-  && rm -rf cmake*
-
-RUN zsh -c "$(curl -fsSL https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" || true
-
-# Move library files to the image
-
-ADD . /lib-ledger-core
-WORKDIR /lib-ledger-core
-RUN git clean -fdx
-
-CMD zsh


### PR DESCRIPTION
- Factorize env setup in a docker image `ledgerhq/lib-ledger-core-build-env`
- Split build_linux_release into 3 jobs:
  - build_linux_release: generate artifacts for linux and linux with OpenSSL 1.1
  - build_linux_jni_release: generate artifact for linux with JNI
  - build_android_release: generate artifact of android (archs: x86_64, armeabi-v7a, arm64-v8a)