### PR TITLE
LLC-692 | Fix the way we check whether a Tezos account is funded.

### DIFF
--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -304,5 +304,23 @@ namespace ledger {
                                                             getRPCNodeEndpoint());
         }
 
+        Future<bool> ExternalTezosLikeBlockchainExplorer::isFunded(const std::string &address) {
+            return
+                _http->GET(fmt::format("account/{}", address))
+                    .json().map<bool>(getExplorerContext(), [=](const HttpRequest::JsonResult &result) {
+                        auto& json = *std::get<1>(result);
+
+                        // look for the is_funded field
+                        //Is there a fees field ?
+                        auto field = "is_funded";
+                        if (!json.IsObject() || !json.HasMember(field) ||
+                            !json[field].IsBool()) {
+                            throw make_exception(api::ErrorCode::HTTP_ERROR,
+                                                 "Failed to get is_funded from network, no (or malformed) field \"result\" in response");
+                        }
+
+                        return json[field].GetBool();
+                    });
+        }
     }
 }

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -311,8 +311,7 @@ namespace ledger {
                         auto& json = *std::get<1>(result);
 
                         // look for the is_funded field
-                        //Is there a fees field ?
-                        auto field = "is_funded";
+                        const auto field = "is_funded";
                         if (!json.IsObject() || !json.HasMember(field) ||
                             !json[field].IsBool()) {
                             throw make_exception(api::ErrorCode::HTTP_ERROR,

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
@@ -39,16 +39,16 @@
 namespace ledger {
     namespace core {
         using ExternalApiBlockchainExplorer = AbstractLedgerApiBlockchainExplorer<
-                TezosLikeBlockchainExplorerTransaction, 
-                TezosLikeBlockchainExplorer::TransactionsBulk, 
+                TezosLikeBlockchainExplorerTransaction,
+                TezosLikeBlockchainExplorer::TransactionsBulk,
                 TezosLikeTransactionsParser,
                 TezosLikeTransactionsBulkParser,
-                TezosLikeBlockParser, 
+                TezosLikeBlockParser,
                 api::TezosLikeNetworkParameters>;
 
-        class ExternalTezosLikeBlockchainExplorer : public TezosLikeBlockchainExplorer, 
+        class ExternalTezosLikeBlockchainExplorer : public TezosLikeBlockchainExplorer,
                                                     public ExternalApiBlockchainExplorer,
-                                                    public DedicatedContext, 
+                                                    public DedicatedContext,
                                                     public std::enable_shared_from_this<ExternalTezosLikeBlockchainExplorer> {
         public:
             ExternalTezosLikeBlockchainExplorer(const std::shared_ptr<api::ExecutionContext> &context,
@@ -103,6 +103,9 @@ namespace ledger {
             Future<std::string> getManagerKey(const std::string &address) override;
 
             Future<bool> isAllocated(const std::string &address) override;
+
+            Future<bool> isFunded(const std::string &address) override;
+
         private:
             /*
              * Helper to a get specific field's value from given url

--- a/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.cpp
@@ -289,5 +289,24 @@ namespace ledger {
                                                             _http,
                                                             getRPCNodeEndpoint());
         }
+
+        Future<bool> NodeTezosLikeBlockchainExplorer::isFunded(const std::string &address) {
+            return
+                _http->GET(fmt::format("blockchain/{}/{}/account/{}", address))
+                    .json().map<bool>(getExplorerContext(), [=](const HttpRequest::JsonResult &result) {
+                        auto& json = *std::get<1>(result);
+
+                        // look for the is_funded field
+                        //Is there a fees field ?
+                        auto field = "is_funded";
+                        if (!json.IsObject() || !json.HasMember(field) ||
+                            !json[field].IsBool()) {
+                            throw make_exception(api::ErrorCode::HTTP_ERROR,
+                                                 "Failed to get is_funded from network, no (or malformed) field \"result\" in response");
+                        }
+
+                        return json[field].GetBool();
+                    });
+        }
     }
 }

--- a/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.cpp
@@ -297,8 +297,7 @@ namespace ledger {
                         auto& json = *std::get<1>(result);
 
                         // look for the is_funded field
-                        //Is there a fees field ?
-                        auto field = "is_funded";
+                        const auto field = "is_funded";
                         if (!json.IsObject() || !json.HasMember(field) ||
                             !json[field].IsBool()) {
                             throw make_exception(api::ErrorCode::HTTP_ERROR,

--- a/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.h
@@ -101,6 +101,8 @@ namespace ledger {
 
             Future<bool> isAllocated(const std::string &address) override;
 
+            Future<bool> isFunded(const std::string &address) override;
+
         private:
             /*
              * Helper to a get specific field's value from given url

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
@@ -151,6 +151,9 @@ namespace ledger {
                                             const std::shared_ptr<HttpClient> &http,
                                             const std::string &rpcNode);
 
+            /// Check that the account is funded.
+            virtual Future<bool> isFunded(const std::string &address) = 0;
+
         protected:
             std::string getRPCNodeEndpoint() const {
                 return _rpcNode;


### PR DESCRIPTION
We now depend on the explorer instead of looking at the transactions.
Doing a transaction check is tricky, because of the fact failed
transactions are still recorded on the blockchain (someone has to pay
the fees), but they don’t credit the recipient account; so it still
stays unfunded.