### PR TITLE
Fix segfault related to openssl

### DIFF
--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -104,6 +104,7 @@ endif()
 
 if(UNIX AND NOT APPLE AND NOT ANDROID)
     target_link_libraries(ledger-core-interface INTERFACE -static-libstdc++)
+    target_link_options(ledger-core-interface INTERFACE -Wl,--exclude-libs,libcrypto.a)
 endif()
 
 target_link_libraries(ledger-core-interface INTERFACE bigd)


### PR DESCRIPTION
This commit fix a segfault on Linux occuring when the system openssl is different from the libcore embedded openssl. It prevents openssl from automatically export its symbols which was causing the segfault in the first place.