### PR TITLE
Change return type of PreferencesBackend::get from string to binary

### DIFF
--- a/core/idl/preferences/preferences.djinni
+++ b/core/idl/preferences/preferences.djinni
@@ -93,7 +93,7 @@ PreferencesBackend = interface +c {
     # Gets the value associated to the given key.
     # @param key The data key.
     # @return The value associated to the key if it exists, an empty option otherwise.
-    const get(key: binary): optional<string>;
+    const get(key: binary): optional<binary>;
 
     # Commit a change.
     # @param changes The list of changes to commit.

--- a/core/src/api/PreferencesBackend.hpp
+++ b/core/src/api/PreferencesBackend.hpp
@@ -32,7 +32,7 @@ public:
      * @param key The data key.
      * @return The value associated to the key if it exists, an empty option otherwise.
      */
-    virtual std::experimental::optional<std::string> get(const std::vector<uint8_t> & key) const = 0;
+    virtual std::experimental::optional<std::vector<uint8_t>> get(const std::vector<uint8_t> & key) const = 0;
 
     /**
      * Commit a change.

--- a/core/src/jni/jni/PreferencesBackend.cpp
+++ b/core/src/jni/jni/PreferencesBackend.cpp
@@ -21,13 +21,13 @@ CJNIEXPORT void JNICALL Java_co_ledger_core_PreferencesBackend_00024CppProxy_nat
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-CJNIEXPORT jstring JNICALL Java_co_ledger_core_PreferencesBackend_00024CppProxy_native_1get(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jbyteArray j_key)
+CJNIEXPORT jbyteArray JNICALL Java_co_ledger_core_PreferencesBackend_00024CppProxy_native_1get(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jbyteArray j_key)
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::PreferencesBackend>(nativeRef);
         auto r = ref->get(::djinni::Binary::toCpp(jniEnv, j_key));
-        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::String>::fromCpp(jniEnv, r));
+        return ::djinni::release(::djinni::Optional<std::experimental::optional, ::djinni::Binary>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 

--- a/core/src/preferences/Preferences.cpp
+++ b/core/src/preferences/Preferences.cpp
@@ -47,7 +47,7 @@ namespace ledger {
             auto value = _backend.get(wrapKey(key));
             if (!value)
                 return fallbackValue;
-            return *value;
+            return std::string(value->cbegin(), value->cend());
         }
 
         int32_t Preferences::getInt(const std::string &key, int32_t fallbackValue) const {

--- a/core/src/preferences/PreferencesBackend.cpp
+++ b/core/src/preferences/PreferencesBackend.cpp
@@ -129,21 +129,20 @@ namespace ledger {
             }
         }
 
-        optional<std::string> PreferencesBackend::get(const std::vector<uint8_t>& key) const {
+        optional<std::vector<uint8_t>> PreferencesBackend::get(const std::vector<uint8_t>& key) const {
             auto value = getRaw(key);
 
             if (value) {
                 if (_cipher.hasValue()) {
                     auto ciphertext = std::vector<uint8_t>(value->cbegin(), value->cend());
                     auto plaindata = decrypt_preferences_change(ciphertext, *_cipher);
-                    auto plaintext = std::string(plaindata.cbegin(), plaindata.cend());
 
-                    return optional<std::string>(plaintext);
+                    return optional<std::vector<uint8_t>>(plaindata);
                 } else {
-                    return optional<std::string>(value);
+                    return std::vector<uint8_t>(value->cbegin(), value->cend());
                 }
             } else {
-                return optional<std::string>();
+                return optional<std::vector<uint8_t>>();
             }
         }
 
@@ -151,7 +150,7 @@ namespace ledger {
             auto db = _db.lock();
 
             if (db == nullptr) {
-              return optional<std::string>();
+                return optional<std::string>();
             }
 
             leveldb::Slice k((const char *)key.data(), key.size());

--- a/core/src/preferences/PreferencesBackend.hpp
+++ b/core/src/preferences/PreferencesBackend.hpp
@@ -65,7 +65,7 @@ namespace ledger {
 
             std::shared_ptr<Preferences> getPreferences(const std::string& name);
 
-            optional<std::string> get(const std::vector<uint8_t>& key) const override;
+            optional<std::vector<uint8_t>> get(const std::vector<uint8_t>& key) const override;
 
             bool commit(const std::vector<api::PreferencesChange>& changes) override;
 


### PR DESCRIPTION
This is just for consistency as both `key` and `value` are binary (`std::vector<uint8_t>`) in `api::PreferencesChange`.