### PR TITLE
Update Algorand reverse proxy endpoints for libcore and tests

### DIFF
--- a/core/src/wallet/algorand/AlgorandWalletFactory.cpp
+++ b/core/src/wallet/algorand/AlgorandWalletFactory.cpp
@@ -43,7 +43,7 @@ namespace core {
 namespace algorand {
 
     // Aliases for long constants names
-    const std::string ALGORAND_API_ENDPOINT = "https://algorand.coin.prod.aws.ledger.com";
+    const std::string ALGORAND_API_ENDPOINT = "https://algorand.coin.ledger.com";
     const std::string ALGORAND_NODE_EXPLORER = api::AlgorandBlockchainExplorerEngines::ALGORAND_NODE;
 
     WalletFactory::WalletFactory(const api::Currency &currency, const std::shared_ptr<WalletPool>& pool) :

--- a/core/src/wallet/algorand/AlgorandWalletFactory.cpp
+++ b/core/src/wallet/algorand/AlgorandWalletFactory.cpp
@@ -43,7 +43,7 @@ namespace core {
 namespace algorand {
 
     // Aliases for long constants names
-    const std::string ALGORAND_API_ENDPOINT = "https://algorand.coin.staging.aws.ledger.com";
+    const std::string ALGORAND_API_ENDPOINT = "https://algorand.coin.prod.aws.ledger.com";
     const std::string ALGORAND_NODE_EXPLORER = api::AlgorandBlockchainExplorerEngines::ALGORAND_NODE;
 
     WalletFactory::WalletFactory(const api::Currency &currency, const std::shared_ptr<WalletPool>& pool) :

--- a/core/test/algorand/AlgorandExplorerTests.cpp
+++ b/core/test/algorand/AlgorandExplorerTests.cpp
@@ -41,8 +41,8 @@ public:
         BaseFixture::SetUp();
 
         auto worker = dispatcher->getSerialExecutionContext("worker");
-        // NOTE: we run the tests on the TestNet
-        auto client = std::make_shared<HttpClient>("https://testnet-algorand.api.purestake.io", http, worker);
+        // NOTE: we run the tests on the staging environment which is on the TestNet
+        auto client = std::make_shared<HttpClient>("https://algorand.coin.staging.aws.ledger.com", http, worker);
 
         // Read API key from environment
         auto configuration = std::make_shared<DynamicObject>();

--- a/core/test/algorand/AlgorandSynchronizationTests.cpp
+++ b/core/test/algorand/AlgorandSynchronizationTests.cpp
@@ -57,7 +57,8 @@ public:
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"44'/<coin_type>'/<account>'/<node>'/<address>");
         configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, api::AlgorandBlockchainExplorerEngines::ALGORAND_NODE);
-        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT, "https://testnet-algorand.api.purestake.io"); // NOTE: We run Algorand tests on the TestNet
+        // NOTE: we run the tests on the staging environment which is on the TestNet
+        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT, "https://algorand.coin.staging.aws.ledger.com");
 
         auto wallet = std::dynamic_pointer_cast<Wallet>(wait(pool->createWallet("test-wallet", "algorand", configuration)));
 


### PR DESCRIPTION
PR to update Algorand reverse proxy endpoints:

- Make libcore hit https://algorand.coin.ledger.com instead of https://algorand.coin.staging.aws.ledger.com
- Make libcore tests hit https://algorand.coin.staging.aws.ledger.com instead of https://testnet-algorand.api.purestake.io