### PR TITLE
Add ~Option() destructor to fix Android runtime linkage

### DIFF
--- a/core/src/utils/Option.hpp
+++ b/core/src/utils/Option.hpp
@@ -56,6 +56,7 @@ namespace ledger {
             static const Option<T> NONE;
 
             Option() {};
+            ~Option() {};
             Option(const T& value) : _optional(value) {};
             Option(T&& value) : _optional(std::move(value)) {};
 

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeUtxo.hpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeUtxo.hpp
@@ -56,6 +56,7 @@ namespace ledger {
 
             operator BitcoinLikeBlockchainExplorerOutput() const;
             BitcoinLikeUtxo() = default;
+            ~BitcoinLikeUtxo() = default;
         };
 
         BitcoinLikeUtxo makeUtxo(BitcoinLikeBlockchainExplorerOutput const& output, api::Currency const& currency);


### PR DESCRIPTION
For some reason `~Option()` destructor is not found at runtime, _only on Android integration_, starting from commit 5b10c2e6c281995e379ea26d73770cf9c91e82cd.

Further investigation will be needed to check whether:
1. `~Option()` was never defined but never needed until that commit... seems unlikely...
2. `~Option()` did exist before that commit and disappeared... no idea why...