### PR TITLE
Remove DB update of Algorand operation

### DIFF
--- a/core/src/wallet/algorand/database/AlgorandOperationDatabaseHelper.cpp
+++ b/core/src/wallet/algorand/database/AlgorandOperationDatabaseHelper.cpp
@@ -46,12 +46,8 @@ namespace algorand {
                 soci::use(opUid),
                 soci::use(txUid),
                 soci::use(txHash);
-        } else {
-            sql << "UPDATE algorand_operations SET uid = :op_uid, transaction_hash = :tx_hash WHERE transaction_uid = :txUid",
-                soci::use(opUid),
-                soci::use(txHash),
-                soci::use(txUid);
         }
+
         return newOperation;
     }
 


### PR DESCRIPTION
DB update of an Algorand operation causes a crash on Windows, and is not actually required because the content of an operation never changes after initial creation.