### PR TITLE
Make some Djinni API functions params non-optional

### DIFF
--- a/core/idl/wallet/bitcoin/bitcoin_like_wallet.djinni
+++ b/core/idl/wallet/bitcoin/bitcoin_like_wallet.djinni
@@ -293,7 +293,7 @@ BitcoinLikeTransactionBuilder = interface +c {
 
     # Parsing unsigned transaction.
     # parsing a tx might change depending on block height we are on (if an update is effective starting from a given hight)
-    static parseRawUnsignedTransaction(currency: Currency, rawTransaction: binary, currentBlockHeight: optional<i32>): BitcoinLikeTransaction;
+    static parseRawUnsignedTransaction(currency: Currency, rawTransaction: binary, currentBlockHeight: i32): BitcoinLikeTransaction;
 }
 
 # Class representing a Bitcoin account.
@@ -308,7 +308,7 @@ BitcoinLikeAccount = interface +c {
     getUTXOCount(callback: Callback<i32>);
     broadcastRawTransaction(transaction: binary, callback: Callback<string>);
     broadcastTransaction(transaction: BitcoinLikeTransaction, callback: Callback<string>);
-    buildTransaction(partial: optional<bool>): BitcoinLikeTransactionBuilder;
+    buildTransaction(partial: bool): BitcoinLikeTransactionBuilder;
     # Get fees from network, fees are ordered in descending order (i.e. fastest to slowest confirmation)
     # Note: it would have been better to have this method on BitcoinLikeWallet
     # but since BitcoinLikeWallet is not used anywhere, it's better to keep all

--- a/core/src/api/BitcoinLikeAccount.hpp
+++ b/core/src/api/BitcoinLikeAccount.hpp
@@ -4,7 +4,6 @@
 #ifndef DJINNI_GENERATED_BITCOINLIKEACCOUNT_HPP
 #define DJINNI_GENERATED_BITCOINLIKEACCOUNT_HPP
 
-#include "../utils/optional.hpp"
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -50,7 +49,7 @@ public:
 
     virtual void broadcastTransaction(const std::shared_ptr<BitcoinLikeTransaction> & transaction, const std::shared_ptr<StringCallback> & callback) = 0;
 
-    virtual std::shared_ptr<BitcoinLikeTransactionBuilder> buildTransaction(std::experimental::optional<bool> partial) = 0;
+    virtual std::shared_ptr<BitcoinLikeTransactionBuilder> buildTransaction(bool partial) = 0;
 
     /**
      * Get fees from network, fees are ordered in descending order (i.e. fastest to slowest confirmation)

--- a/core/src/api/BitcoinLikeTransactionBuilder.hpp
+++ b/core/src/api/BitcoinLikeTransactionBuilder.hpp
@@ -4,7 +4,6 @@
 #ifndef DJINNI_GENERATED_BITCOINLIKETRANSACTIONBUILDER_HPP
 #define DJINNI_GENERATED_BITCOINLIKETRANSACTIONBUILDER_HPP
 
-#include "../utils/optional.hpp"
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -124,7 +123,7 @@ public:
      * Parsing unsigned transaction.
      * parsing a tx might change depending on block height we are on (if an update is effective starting from a given hight)
      */
-    static std::shared_ptr<BitcoinLikeTransaction> parseRawUnsignedTransaction(const Currency & currency, const std::vector<uint8_t> & rawTransaction, std::experimental::optional<int32_t> currentBlockHeight);
+    static std::shared_ptr<BitcoinLikeTransaction> parseRawUnsignedTransaction(const Currency & currency, const std::vector<uint8_t> & rawTransaction, int32_t currentBlockHeight);
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/jni/jni/BitcoinLikeAccount.cpp
+++ b/core/src/jni/jni/BitcoinLikeAccount.cpp
@@ -67,12 +67,12 @@ CJNIEXPORT void JNICALL Java_co_ledger_core_BitcoinLikeAccount_00024CppProxy_nat
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeAccount_00024CppProxy_native_1buildTransaction(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jobject j_partial)
+CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeAccount_00024CppProxy_native_1buildTransaction(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jboolean j_partial)
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeAccount>(nativeRef);
-        auto r = ref->buildTransaction(::djinni::Optional<std::experimental::optional, ::djinni::Bool>::toCpp(jniEnv, j_partial));
+        auto r = ref->buildTransaction(::djinni::Bool::toCpp(jniEnv, j_partial));
         return ::djinni::release(::djinni_generated::BitcoinLikeTransactionBuilder::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }

--- a/core/src/jni/jni/BitcoinLikeTransactionBuilder.cpp
+++ b/core/src/jni/jni/BitcoinLikeTransactionBuilder.cpp
@@ -169,13 +169,13 @@ CJNIEXPORT void JNICALL Java_co_ledger_core_BitcoinLikeTransactionBuilder_00024C
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeTransactionBuilder_parseRawUnsignedTransaction(JNIEnv* jniEnv, jobject /*this*/, jobject j_currency, jbyteArray j_rawTransaction, jobject j_currentBlockHeight)
+CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeTransactionBuilder_parseRawUnsignedTransaction(JNIEnv* jniEnv, jobject /*this*/, jobject j_currency, jbyteArray j_rawTransaction, jint j_currentBlockHeight)
 {
     try {
         DJINNI_FUNCTION_PROLOGUE0(jniEnv);
         auto r = ::ledger::core::api::BitcoinLikeTransactionBuilder::parseRawUnsignedTransaction(::djinni_generated::Currency::toCpp(jniEnv, j_currency),
                                                                                                  ::djinni::Binary::toCpp(jniEnv, j_rawTransaction),
-                                                                                                 ::djinni::Optional<std::experimental::optional, ::djinni::I32>::toCpp(jniEnv, j_currentBlockHeight));
+                                                                                                 ::djinni::I32::toCpp(jniEnv, j_currentBlockHeight));
         return ::djinni::release(::djinni_generated::BitcoinLikeTransaction::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }

--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
@@ -627,7 +627,7 @@ namespace ledger {
             broadcastRawTransaction(transaction->serialize(), callback);
         }
 
-        std::shared_ptr<api::BitcoinLikeTransactionBuilder> BitcoinLikeAccount::buildTransaction(std::experimental::optional<bool> partial) {
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder> BitcoinLikeAccount::buildTransaction(bool partial) {
             auto self = std::dynamic_pointer_cast<BitcoinLikeAccount>(shared_from_this());
             auto getUTXO = [=]() -> Future<std::vector<BitcoinLikeUtxo>> {
                 return Future<std::vector<BitcoinLikeUtxo>>::async(getContext(), [=]() {
@@ -660,7 +660,7 @@ namespace ledger {
                                               _keychain,
                                               lastBlockHeight,
                                               logger(),
-                                              partial.value_or(false))
+                                              partial)
             );
         }
 

--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.hpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.hpp
@@ -116,7 +116,7 @@ namespace ledger {
             void broadcastTransaction(const std::shared_ptr<api::BitcoinLikeTransaction> &transaction,
                                       const std::shared_ptr<api::StringCallback> &callback) override;
 
-            std::shared_ptr<api::BitcoinLikeTransactionBuilder> buildTransaction(std::experimental::optional<bool> partial) override;
+            std::shared_ptr<api::BitcoinLikeTransactionBuilder> buildTransaction(bool partial) override;
 
             std::shared_ptr<api::OperationQuery> queryOperations() override;
 

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp
@@ -465,21 +465,21 @@ namespace ledger {
         std::shared_ptr<api::BitcoinLikeTransaction>
         api::BitcoinLikeTransactionBuilder::parseRawUnsignedTransaction(const api::Currency &currency,
                                                                         const std::vector<uint8_t> &rawTransaction,
-                                                                        std::experimental::optional<int32_t> currentBlockHeight) {
+                                                                        int32_t currentBlockHeight) {
             return BitcoinLikeTransactionApi::parseRawTransaction(currency, rawTransaction, currentBlockHeight, false);
         }
 
         std::shared_ptr<api::BitcoinLikeTransaction>
         BitcoinLikeTransactionApi::parseRawSignedTransaction(const api::Currency &currency,
                                                              const std::vector<uint8_t> &rawTransaction,
-                                                             std::experimental::optional<int32_t> currentBlockHeight) {
+                                                             int32_t currentBlockHeight) {
             return BitcoinLikeTransactionApi::parseRawTransaction(currency, rawTransaction, currentBlockHeight, true);
         }
 
         std::shared_ptr<api::BitcoinLikeTransaction>
         BitcoinLikeTransactionApi::parseRawTransaction(const api::Currency &currency,
                                                        const std::vector<uint8_t> &rawTransaction,
-                                                       std::experimental::optional<int32_t> currentBlockHeight,
+                                                       int32_t currentBlockHeight,
                                                        bool isSigned) {
             BytesReader reader(rawTransaction);
             // Parse version
@@ -490,10 +490,10 @@ namespace ledger {
             //Parse additionalBIPs if there are any
             auto &additionalBIPs = params.AdditionalBIPs;
             auto it = std::find(additionalBIPs.begin(), additionalBIPs.end(), "ZIP");
-            auto zipParameters = currentBlockHeight.value_or(0) > networks::ZIP_SAPLING_PARAMETERS.blockHeight ?
+            auto zipParameters = currentBlockHeight > networks::ZIP_SAPLING_PARAMETERS.blockHeight ?
                                  networks::ZIP_SAPLING_PARAMETERS : networks::ZIP143_PARAMETERS;
             if (it != additionalBIPs.end() &&
-                currentBlockHeight.value_or(0) > networks::ZIP143_PARAMETERS.blockHeight) {
+                currentBlockHeight > networks::ZIP143_PARAMETERS.blockHeight) {
                 //Substract overwinterFlag
                 auto overwinterFlag = zipParameters.overwinterFlag[0];
                 version -= (~(overwinterFlag << 24) + 1);
@@ -520,7 +520,7 @@ namespace ledger {
             }
 
             auto keychainEngine = isSegwit ? api::KeychainEngines::BIP49_P2SH : api::KeychainEngines::BIP32_P2PKH;
-            auto tx = std::make_shared<BitcoinLikeTransactionApi>(currency, keychainEngine, currentBlockHeight.value_or(0));
+            auto tx = std::make_shared<BitcoinLikeTransactionApi>(currency, keychainEngine, currentBlockHeight);
             tx->setVersion(version);
             if (usesTimeStamp) {
                 tx->setTimestamp(timeStamp);

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h
@@ -132,12 +132,12 @@ namespace ledger {
 
             static std::shared_ptr<api::BitcoinLikeTransaction> parseRawTransaction(const api::Currency &currency,
                                                                                     const std::vector<uint8_t> &rawTransaction,
-                                                                                    std::experimental::optional<int32_t> currentBlockHeight,
+                                                                                    int32_t currentBlockHeight,
                                                                                     bool isSigned);
 
             static std::shared_ptr<api::BitcoinLikeTransaction> parseRawSignedTransaction(const api::Currency &currency,
                                                                                           const std::vector<uint8_t> &rawTransaction,
-                                                                                          std::experimental::optional<int32_t> currentBlockHeight);
+                                                                                          int32_t currentBlockHeight);
 
             static api::EstimatedSize estimateSize(std::size_t inputCount,
                                                    std::size_t outputCount,


### PR DESCRIPTION
In libcore Djinni APIs, change some functions parameters from optional to not optional.

The change is safe because:
- `BitcoinLikeAccount::buildTransaction` is always called by live-common with a non-optional value: https://github.com/LedgerHQ/ledger-live-common/blob/master/src/families/bitcoin/libcore-buildTransaction.js#L56

- `BitcoinLikeTransactionBuilder::parseRawUnsignedTransaction` is never used from client side, but fix it anyway.

This PR fixes a probable regression introduced by https://github.com/LedgerHQ/djinni/commit/7bd8220133a1e6fdf6dfd953d51ccf477daeb4b5

With issue shown below:
![image](https://user-images.githubusercontent.com/59644786/90545857-8963a700-e189-11ea-9b82-465e39b9bc77.png)