### PR TITLE
Fix bad management of Algorand API key in Algorand tests

### DIFF
--- a/core/src/wallet/algorand/AlgorandBlockchainExplorer.cpp
+++ b/core/src/wallet/algorand/AlgorandBlockchainExplorer.cpp
@@ -73,10 +73,9 @@ namespace algorand {
     {
         setConfiguration(configuration);
         const auto apiKey = configuration->getString(api::Configuration::BLOCKCHAIN_EXPLORER_API_KEY);
-        if (!apiKey) {
-            throw make_exception(api::ErrorCode::API_ERROR, "Missing API key to access Algorand node.");
+        if (apiKey && !apiKey.value().empty()) {
+            _http->addHeader(constants::purestakeTokenHeader, apiKey.value());
         }
-        _http->addHeader(constants::purestakeTokenHeader, apiKey.value());
     }
 
     Future<api::Block> BlockchainExplorer::getBlock(uint64_t blockHeight) const

--- a/core/test/algorand/AlgorandAccountTests.cpp
+++ b/core/test/algorand/AlgorandAccountTests.cpp
@@ -220,7 +220,11 @@ public:
 
         accountInfo = api::AccountCreationInfo(1, {}, {}, { algorand::Address::toPublicKey(OBELIX) }, {});
 
-        wallet = std::dynamic_pointer_cast<algorand::Wallet>(wait(pool->createWallet("algorand", currency.name, api::DynamicObject::newInstance())));
+        // NOTE: we run the tests on the staging environment which is on the TestNet
+        auto configuration = DynamicObject::newInstance();
+        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT, "https://algorand.coin.staging.aws.ledger.com");
+
+        wallet = std::dynamic_pointer_cast<algorand::Wallet>(wait(pool->createWallet("algorand", currency.name, configuration)));
         account = createAlgorandAccount(wallet, accountInfo.index, accountInfo);
 
         accountUid = algorand::AccountDatabaseHelper::createAccountUid(wallet->getWalletUid(), accountInfo.index);

--- a/core/test/algorand/AlgorandDatabaseTests.cpp
+++ b/core/test/algorand/AlgorandDatabaseTests.cpp
@@ -59,7 +59,11 @@ class AlgorandDatabaseTest : public WalletFixture<WalletFactory> {
 
         accountInfo = api::AccountCreationInfo(1, {}, {}, { algorand::Address::toPublicKey(OBELIX_ADDRESS) }, {});
 
-        wallet = std::dynamic_pointer_cast<algorand::Wallet>(wait(pool->createWallet("algorand", currency.name, api::DynamicObject::newInstance())));
+        // NOTE: we run the tests on the staging environment which is on the TestNet
+        auto configuration = DynamicObject::newInstance();
+        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT, "https://algorand.coin.staging.aws.ledger.com");
+
+        wallet = std::dynamic_pointer_cast<algorand::Wallet>(wait(pool->createWallet("algorand", currency.name, configuration)));
         account = createAlgorandAccount(wallet, accountInfo.index, accountInfo);
 
         accountUid = algorand::AccountDatabaseHelper::createAccountUid(wallet->getWalletUid(), accountInfo.index);

--- a/core/test/algorand/AlgorandExplorerTests.cpp
+++ b/core/test/algorand/AlgorandExplorerTests.cpp
@@ -44,12 +44,10 @@ public:
         // NOTE: we run the tests on the staging environment which is on the TestNet
         auto client = std::make_shared<HttpClient>("https://algorand.coin.staging.aws.ledger.com", http, worker);
 
-        // Read API key from environment
-        auto configuration = std::make_shared<DynamicObject>();
-        if (const auto apiKey = std::getenv(api::Configuration::BLOCKCHAIN_EXPLORER_API_KEY.c_str())) {
-            configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_KEY, apiKey);
-        }
-
+        // NOTE: we run the tests on the staging environment which is on the TestNet
+        auto configuration = DynamicObject::newInstance();
+        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT, "https://algorand.coin.staging.aws.ledger.com");
+        
         explorer = std::make_shared<BlockchainExplorer>(
                         worker,
                         client,

--- a/core/test/algorand/AlgorandSynchronizationTests.cpp
+++ b/core/test/algorand/AlgorandSynchronizationTests.cpp
@@ -34,7 +34,6 @@
 #include <wallet/algorand/AlgorandLikeCurrencies.hpp>
 #include <wallet/algorand/AlgorandNetworks.hpp>
 #include <wallet/common/OperationQuery.h>
-#include <api/AlgorandBlockchainExplorerEngines.hpp>
 #include <api/Configuration.hpp>
 
 #include "../integration/WalletFixture.hpp"
@@ -54,10 +53,8 @@ public:
     void synchronizeAccount(const std::string & accountAddress) {
         registerCurrency(currencies::ALGORAND);
 
-        auto configuration = DynamicObject::newInstance();
-        configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"44'/<coin_type>'/<account>'/<node>'/<address>");
-        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, api::AlgorandBlockchainExplorerEngines::ALGORAND_NODE);
         // NOTE: we run the tests on the staging environment which is on the TestNet
+        auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT, "https://algorand.coin.staging.aws.ledger.com");
 
         auto wallet = std::dynamic_pointer_cast<Wallet>(wait(pool->createWallet("test-wallet", "algorand", configuration)));


### PR DESCRIPTION
In Algorand tests, as long as the reverse proxy was not available, Purestake API key was used from an env variable.
Now that the reverse proxy is used it manages the API key itself so we don't need to use it from an env variable anymore.

This fixes all Algorand tests currently failing in CI.