### PR TITLE
Fix operation queries when it involves block_height

### DIFF
--- a/core/src/database/query/QueryBuilder.cpp
+++ b/core/src/database/query/QueryBuilder.cpp
@@ -52,14 +52,10 @@ namespace ledger {
             }
 
             if (!_order.empty()) {
-                // Add table name in case of _outerJoins to avoid ambiguity
-                // We assume that added order is always on main table
-                const auto specifier = _outerJoins.empty() ? "" :
-                                       fmt::format("{}.", _output.empty() ? _table : _output);
                 query << " ORDER BY ";
                 for (auto it = _order.begin(); it != _order.end(); it++) {
                     auto& order = *it;
-                    query << specifier << std::get<0>(order) << (std::get<1>(order) ? " DESC" : " ASC");
+                    query << std::get<2>(order) << "." << std::get<0>(order) << (std::get<1>(order) ? " DESC" : " ASC");
 
                     if (std::distance(it, _order.end()) > 1) {
                         query << ",";
@@ -117,8 +113,8 @@ namespace ledger {
             return *this;
         }
 
-        QueryBuilder &QueryBuilder::order(std::string &&keys, bool&& descending) {
-            _order.push_back(std::move(std::make_tuple(keys, descending)));
+        QueryBuilder &QueryBuilder::order(std::string &&keys, bool&& descending, std::string&& table) {
+            _order.push_back(std::move(std::make_tuple(keys, descending, table)));
             return *this;
         }
 

--- a/core/src/database/query/QueryBuilder.h
+++ b/core/src/database/query/QueryBuilder.h
@@ -52,7 +52,7 @@ namespace ledger {
             QueryBuilder& to(std::string&& output);
             QueryBuilder& where(const std::shared_ptr<api::QueryFilter>& filter);
             QueryBuilder& outerJoin(const std::string& table, const std::string& condition);
-            QueryBuilder& order(std::string&& keys, bool&& descending);
+            QueryBuilder& order(std::string&& keys, bool&& descending, std::string&& table);
             QueryBuilder& limit(int32_t limit);
             QueryBuilder& offset(int32_t offset);
             soci::details::prepare_temp_type execute(soci::session& sql);
@@ -63,7 +63,7 @@ namespace ledger {
             std::string _keys;
             std::string _table;
             std::string _output;
-            std::list<std::tuple<std::string, bool>> _order;
+            std::list<std::tuple<std::string, bool, std::string>> _order;
             std::vector<Option<LeftOuterJoin>> _outerJoins;
             std::shared_ptr<QueryFilter> _filter;
             Option<int32_t> _limit;

--- a/core/src/database/query/filters_impl.cpp
+++ b/core/src/database/query/filters_impl.cpp
@@ -151,31 +151,31 @@ namespace ledger {
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::blockHeightEq(int64_t blockHeight) {
-            return std::make_shared<ConditionQueryFilter<int64_t>>("block_height", "=", blockHeight, "o");
+            return std::make_shared<ConditionQueryFilter<int64_t>>("height", "=", blockHeight, "b");
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::blockHeightNeq(int64_t blockHeight) {
-            return std::make_shared<ConditionQueryFilter<int64_t>>("block_height", "<>", blockHeight, "o");
+            return std::make_shared<ConditionQueryFilter<int64_t>>("height", "<>", blockHeight, "b");
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::blockHeightLt(int64_t blockHeight) {
-            return std::make_shared<ConditionQueryFilter<int64_t>>("block_height", "<", blockHeight, "o");
+            return std::make_shared<ConditionQueryFilter<int64_t>>("height", "<", blockHeight, "b");
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::blockHeightLte(int64_t blockHeight) {
-            return std::make_shared<ConditionQueryFilter<int64_t>>("block_height", "<=", blockHeight, "o");
+            return std::make_shared<ConditionQueryFilter<int64_t>>("height", "<=", blockHeight, "b");
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::blockHeightGt(int64_t blockHeight) {
-            return std::make_shared<ConditionQueryFilter<int64_t>>("block_height", ">", blockHeight, "o");
+            return std::make_shared<ConditionQueryFilter<int64_t>>("height", ">", blockHeight, "b");
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::blockHeightGte(int64_t blockHeight) {
-            return std::make_shared<ConditionQueryFilter<int64_t>>("block_height", ">=", blockHeight, "o");
+            return std::make_shared<ConditionQueryFilter<int64_t>>("height", ">=", blockHeight, "b");
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::blockHeightIsNull() {
-            return std::make_shared<PlainTextConditionQueryFilter>("o.block_height IS NULL");
+            return std::make_shared<PlainTextConditionQueryFilter>("o.block_uid IS NULL");
         }
 
         std::shared_ptr<api::QueryFilter> api::QueryFilter::operationTypeEq(api::OperationType type) {

--- a/core/src/wallet/common/OperationQuery.cpp
+++ b/core/src/wallet/common/OperationQuery.cpp
@@ -59,28 +59,28 @@ namespace ledger {
         std::shared_ptr<api::OperationQuery> OperationQuery::addOrder(api::OperationOrderKey key, bool descending) {
             switch (key) {
                 case api::OperationOrderKey::AMOUNT:
-                    _builder.order("amount", std::move(descending));
+                    _builder.order("amount", std::move(descending), "o");
                     break;
                 case api::OperationOrderKey::DATE:
-                    _builder.order("date", std::move(descending));
+                    _builder.order("date", std::move(descending), "o");
                     break;
                 case api::OperationOrderKey::SENDERS:
-                    _builder.order("senders", std::move(descending));
+                    _builder.order("senders", std::move(descending), "o");
                     break;
                 case api::OperationOrderKey::RECIPIENTS:
-                    _builder.order("recipients", std::move(descending));
+                    _builder.order("recipients", std::move(descending), "o");
                     break;
                 case api::OperationOrderKey::TYPE:
-                    _builder.order("type", std::move(descending));
+                    _builder.order("type", std::move(descending), "o");
                     break;
                 case api::OperationOrderKey::CURRENCY_NAME:
-                    _builder.order("currency_name", std::move(descending));
+                    _builder.order("currency_name", std::move(descending), "o");
                     break;
                 case api::OperationOrderKey::FEES:
-                    _builder.order("fees", std::move(descending));
+                    _builder.order("fees", std::move(descending), "o");
                     break;
                 case api::OperationOrderKey::BLOCK_HEIGHT:
-                    _builder.order("block_height", std::move(descending));
+                    _builder.order("height", std::move(descending), "b");
                     break;
             }
             return shared_from_this();

--- a/core/test/database/query_filters_tests.cpp
+++ b/core/test/database/query_filters_tests.cpp
@@ -42,7 +42,7 @@ TEST(QueryFilters, SimpleFilter) {
 
 TEST(QueryFilters, DoubleConditionFilter) {
     auto filter = api::QueryFilter::accountEq("my_account")->op_and(api::QueryFilter::blockHeightGt(12000));
-    EXPECT_EQ(std::dynamic_pointer_cast<QueryFilter>(filter)->getHead()->toString(), "o.account_uid = :account_uid AND o.block_height > :block_height");
+    EXPECT_EQ(std::dynamic_pointer_cast<QueryFilter>(filter)->getHead()->toString(), "o.account_uid = :account_uid AND b.block_height > :block_height");
 }
 
 TEST(QueryFilters, DoubleConditionWithCompoundFilter) {
@@ -50,5 +50,5 @@ TEST(QueryFilters, DoubleConditionWithCompoundFilter) {
             ->op_and(api::QueryFilter::blockHeightGt(12000))
             ->op_or_not(api::QueryFilter::trustEq(api::TrustLevel::TRUSTED)->op_and(api::QueryFilter::containsSender("toto")));
     EXPECT_EQ(std::dynamic_pointer_cast<QueryFilter>(filter)->getHead()->toString(),
-              "o.account_uid = :account_uid AND o.block_height > :block_height OR NOT (o.trust LIKE :trust AND o.senders LIKE :senders)");
+              "o.account_uid = :account_uid AND b.block_height > :block_height OR NOT (o.trust LIKE :trust AND o.senders LIKE :senders)");
 }

--- a/core/test/integration/synchronization/synchronization_tests.cpp
+++ b/core/test/integration/synchronization/synchronization_tests.cpp
@@ -607,3 +607,97 @@ TEST_F(BitcoinLikeWalletSynchronization, SynchronizeOnFakeExplorer) {
         }
     }
 }
+
+TEST_F(BitcoinLikeWalletSynchronization, SynchronizeAndFilterOperationsByBlockHeight) {
+    auto pool = newDefaultPool();
+    auto wallet = wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a62", "bitcoin",
+                                          api::DynamicObject::newInstance()));
+    auto nextIndex = wait(wallet->getNextAccountIndex());
+    EXPECT_EQ(nextIndex, 0);
+    auto account = createBitcoinLikeAccount(wallet, nextIndex, P2PKH_MEDIUM_XPUB_INFO);
+    auto bus = account->synchronize();
+    bus->subscribe(dispatcher->getMainExecutionContext(),
+                   make_receiver([=](const std::shared_ptr<api::Event> &event) {
+                       if (event->getCode() == api::EventCode::SYNCHRONIZATION_STARTED)
+                           return;
+                       EXPECT_NE(event->getCode(), api::EventCode::SYNCHRONIZATION_FAILED);
+                       EXPECT_EQ(event->getCode(),
+                                 api::EventCode::SYNCHRONIZATION_SUCCEED_ON_PREVIOUSLY_EMPTY_ACCOUNT);
+                       dispatcher->stop();
+                   }));
+    EXPECT_EQ(bus, account->synchronize());
+    dispatcher->waitUntilStopped();
+
+    enum QueryType {
+        EQ, NEQ, LT, GT, GTE, LTE, NIL
+    };
+
+    const auto queryOperations = [=] (int blockHeight, QueryType queryType) -> std::vector<std::shared_ptr<api::Operation>> {
+
+        auto query = account->queryOperations()->complete()->addOrder(api::OperationOrderKey::BLOCK_HEIGHT, true);
+        auto filter = query->filter();
+        switch (queryType) {
+            case EQ:
+                filter->op_and(filter->blockHeightEq(blockHeight));
+                break;
+            case NEQ:
+                filter->op_and(filter->blockHeightNeq(blockHeight));
+                break;
+            case LT:
+                filter->op_and(filter->blockHeightLt(blockHeight));
+                break;
+            case GT:
+                filter->op_and(filter->blockHeightGt(blockHeight));
+                break;
+            case GTE:
+                filter->op_and(filter->blockHeightGte(blockHeight));
+                break;
+            case LTE:
+                filter->op_and(filter->blockHeightLte(blockHeight));
+                break;
+            case NIL:
+                filter->op_and(filter->blockHeightIsNull());
+                break;
+        }
+        return ::wait(std::dynamic_pointer_cast<OperationQuery>(query)->execute());
+    };
+
+    const auto testOperations = [=] (int blockHeight, QueryType queryType) {
+        auto ops = queryOperations(blockHeight, queryType);
+
+        for (const auto& op : ops) {
+            switch (queryType) {
+                case EQ:
+                    EXPECT_TRUE(op->getBlockHeight().value_or(0) == blockHeight);
+                    break;
+                case NEQ:
+                    EXPECT_TRUE(op->getBlockHeight().value_or(0) != blockHeight);
+                    break;
+                case LT:
+                    EXPECT_TRUE(op->getBlockHeight().value_or(0) < blockHeight);
+                    break;
+                case GT:
+                    EXPECT_TRUE(op->getBlockHeight().value_or(0) > blockHeight);
+                    break;
+                case GTE:
+                    EXPECT_TRUE(op->getBlockHeight().value_or(0) >= blockHeight);
+                    break;
+                case LTE:
+                    EXPECT_TRUE(op->getBlockHeight().value_or(0) <= blockHeight);
+                    break;
+                case NIL:
+                    EXPECT_TRUE(!op->getBlockHeight());
+                    break;
+            }
+        }
+    };
+
+    const auto blockHeight = 500347;
+    testOperations(blockHeight, QueryType::EQ);
+    testOperations(blockHeight, QueryType::NEQ);
+    testOperations(blockHeight, QueryType::LT);
+    testOperations(blockHeight, QueryType::GT);
+    testOperations(blockHeight, QueryType::LTE);
+    testOperations(blockHeight, QueryType::GTE);
+    testOperations(blockHeight, QueryType::NIL);
+}


### PR DESCRIPTION
Current version of the libcore considers that block_height is a field of operations table. Block height is however get from a outer join with the block tables. This PR fixes the query filter and ordering when it involves block height. It also adds some tests around it.