### PR TITLE
[WIP] Nrt tezos get current delegate

### DIFF
--- a/core/idl/wallet/tezos/tezos_like_wallet.djinni
+++ b/core/idl/wallet/tezos/tezos_like_wallet.djinni
@@ -128,6 +128,8 @@ TezosLikeAccount = interface +c {
 	getFees(callback: Callback<BigInt>);
 	# Get originated accounts by current account
 	getOriginatedAccounts(): list<TezosLikeOriginatedAccount>;
+	# Get current delegate
+	getCurrentDelegate(callback: Callback<string>);
 }
 
 # Class representing originated accounts

--- a/core/src/api/TezosLikeAccount.hpp
+++ b/core/src/api/TezosLikeAccount.hpp
@@ -56,6 +56,9 @@ public:
 
     /** Get originated accounts by current account */
     virtual std::vector<std::shared_ptr<TezosLikeOriginatedAccount>> getOriginatedAccounts() = 0;
+
+    /** Get current delegate */
+    virtual void getCurrentDelegate(const std::shared_ptr<StringCallback> & callback) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/jni/jni/TezosLikeAccount.cpp
+++ b/core/src/jni/jni/TezosLikeAccount.cpp
@@ -93,4 +93,13 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_TezosLikeAccount_00024CppProxy_na
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT void JNICALL Java_co_ledger_core_TezosLikeAccount_00024CppProxy_native_1getCurrentDelegate(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jobject j_callback)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::TezosLikeAccount>(nativeRef);
+        ref->getCurrentDelegate(::djinni_generated::StringCallback::toCpp(jniEnv, j_callback));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
+}
+
 }  // namespace djinni_generated

--- a/core/src/wallet/tezos/TezosLikeAccount.h
+++ b/core/src/wallet/tezos/TezosLikeAccount.h
@@ -155,7 +155,7 @@ namespace ledger {
 
             void saveOptimisticCounter(const std::shared_ptr<BigInt>& counter, const std::string& txHash);
 
-            void getCurrentDelegate(const std::shared_ptr<api::StringCallback> & callback);
+            void getCurrentDelegate(const std::shared_ptr<api::StringCallback> & callback) override;
             FuturePtr<std::string> getCurrentDelegate();
         private:
             std::shared_ptr<TezosLikeAccount> getSelf();

--- a/core/src/wallet/tezos/TezosLikeAccount.h
+++ b/core/src/wallet/tezos/TezosLikeAccount.h
@@ -154,6 +154,9 @@ namespace ledger {
             void incrementOptimisticCounter(std::shared_ptr<TezosLikeTransactionApi> tx, const std::shared_ptr<BigInt>& explorerCounter);     
 
             void saveOptimisticCounter(const std::shared_ptr<BigInt>& counter, const std::string& txHash);
+
+            void getCurrentDelegate(const std::shared_ptr<std::string> & callback);
+            FuturePtr<std::string> getCurrentDelegate();
         private:
             std::shared_ptr<TezosLikeAccount> getSelf();
 

--- a/core/src/wallet/tezos/TezosLikeAccount.h
+++ b/core/src/wallet/tezos/TezosLikeAccount.h
@@ -156,7 +156,7 @@ namespace ledger {
             void saveOptimisticCounter(const std::shared_ptr<BigInt>& counter, const std::string& txHash);
 
             void getCurrentDelegate(const std::shared_ptr<api::StringCallback> & callback) override;
-            FuturePtr<std::string> getCurrentDelegate();
+            Future<std::string> getCurrentDelegate();
         private:
             std::shared_ptr<TezosLikeAccount> getSelf();
 

--- a/core/src/wallet/tezos/TezosLikeAccount.h
+++ b/core/src/wallet/tezos/TezosLikeAccount.h
@@ -155,7 +155,7 @@ namespace ledger {
 
             void saveOptimisticCounter(const std::shared_ptr<BigInt>& counter, const std::string& txHash);
 
-            void getCurrentDelegate(const std::shared_ptr<std::string> & callback);
+            void getCurrentDelegate(const std::shared_ptr<api::StringCallback> & callback);
             FuturePtr<std::string> getCurrentDelegate();
         private:
             std::shared_ptr<TezosLikeAccount> getSelf();

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -533,17 +533,11 @@ namespace ledger {
         }
 
         void TezosLikeAccount::getCurrentDelegate(const std::shared_ptr<api::StringCallback> & callback) {
-            getCurrentDelegate().mapPtr<std::string>(getMainExecutionContext(), [] (const std::shared_ptr<std::string> &delegate) -> std::shared_ptr<std::string>
-            {
-                if (!delegate) {
-                    throw make_exception(api::ErrorCode::RUNTIME_ERROR, "Failed to retrieve current delegate from network");
-                }
-                return delegate;
-            }).callback(getMainExecutionContext(), callback);
+            getCurrentDelegate().callback(getMainExecutionContext(), callback);
         }
 
-        FuturePtr<std::string> TezosLikeAccount::getCurrentDelegate() {
-            return _explorer->getCurrentDelegate(self->getKeychain()->getAddress()->toString());
+        Future<std::string> TezosLikeAccount::getCurrentDelegate() {
+            return  _explorer->getCurrentDelegate(getKeychain()->getAddress()->toString());
         }
 
         std::shared_ptr<api::Keychain> TezosLikeAccount::getAccountKeychain() {

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -538,7 +538,7 @@ namespace ledger {
                 if (!delegate) {
                     throw make_exception(api::ErrorCode::RUNTIME_ERROR, "Failed to retrieve current delegate from network");
                 }
-                return std::make_shared<std::string>(*delegate);
+                return delegate;
             }).callback(getMainExecutionContext(), callback);
         }
 

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -543,7 +543,7 @@ namespace ledger {
         }
 
         FuturePtr<std::string> TezosLikeAccount::getCurrentDelegate() {
-            return _explorer->getCurrentDelegate();
+            return _explorer->getCurrentDelegate(self->getKeychain()->getAddress()->toString());
         }
 
         std::shared_ptr<api::Keychain> TezosLikeAccount::getAccountKeychain() {

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -532,6 +532,20 @@ namespace ledger {
             return _explorer->getFees();
         }
 
+        void TezosLikeAccount::getCurrentDelegate(const std::shared_ptr<api::StringCallback> & callback) {
+            getCurrentDelegate().mapPtr<std::string>(getMainExecutionContext(), [] (const std::shared_ptr<std::string> &delegate) -> std::shared_ptr<std::string>
+            {
+                if (!delegate) {
+                    throw make_exception(api::ErrorCode::RUNTIME_ERROR, "Failed to retrieve current delegate from network");
+                }
+                return std::make_shared<std::string>(*delegate);
+            }).callback(getMainExecutionContext(), callback);
+        }
+
+        FuturePtr<std::string> TezosLikeAccount::getCurrentDelegate() {
+            return _explorer->getCurrentDelegate();
+        }
+
         std::shared_ptr<api::Keychain> TezosLikeAccount::getAccountKeychain() {
             return _keychain;
         }

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -325,7 +325,7 @@ namespace ledger {
                                                             getRPCNodeEndpoint());
         }
 
-        Future<std:string> NodeTezosLikeBlockchainExplorer::getCurrentDelegate(const std::string &address) {
+        Future<std::string> ExternalTezosLikeBlockchainExplorer::getCurrentDelegate(const std::string &address) {
             return TezosLikeBlockchainExplorer::getCurrentDelegate(address,
                                                                    getExplorerContext(),
                                                                    _http,

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -325,6 +325,13 @@ namespace ledger {
                                                             getRPCNodeEndpoint());
         }
 
+        Future<std:string> NodeTezosLikeBlockchainExplorer::getCurrentDelegate(const std::string &address) {
+            return TezosLikeBlockchainExplorer::getCurrentDelegate(address,
+                                                                   getExplorerContext(),
+                                                                   _http,
+                                                                   getRPCNodeEndpoint());
+        }
+
         Future<bool> ExternalTezosLikeBlockchainExplorer::isFunded(const std::string &address) {
             return
                 _http->GET(fmt::format("account/{}", address))

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.h
@@ -104,6 +104,8 @@ namespace ledger {
 
             Future<bool> isAllocated(const std::string &address) override;
 
+            Future<std::string> getCurrentDelegate(const std::string &address) override;
+
             Future<bool> isFunded(const std::string &address) override;
 
         private:

--- a/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.cpp
@@ -290,7 +290,7 @@ namespace ledger {
                                                             getRPCNodeEndpoint());
         }
 
-        Future<std:string> NodeTezosLikeBlockchainExplorer::getCurrentDelegate(const std::string &address) {
+        Future<std::string> NodeTezosLikeBlockchainExplorer::getCurrentDelegate(const std::string &address) {
             return TezosLikeBlockchainExplorer::getCurrentDelegate(address,
                                                                    getExplorerContext(),
                                                                    _http,

--- a/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.cpp
@@ -290,6 +290,13 @@ namespace ledger {
                                                             getRPCNodeEndpoint());
         }
 
+        Future<std:string> NodeTezosLikeBlockchainExplorer::getCurrentDelegate(const std::string &address) {
+            return TezosLikeBlockchainExplorer::getCurrentDelegate(address,
+                                                                   getExplorerContext(),
+                                                                   _http,
+                                                                   getRPCNodeEndpoint());
+        }
+
         Future<bool> NodeTezosLikeBlockchainExplorer::isFunded(const std::string &address) {
             return
                 _http->GET(fmt::format("blockchain/{}/{}/account/{}", address))

--- a/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/NodeTezosLikeBlockchainExplorer.h
@@ -101,6 +101,8 @@ namespace ledger {
 
             Future<bool> isAllocated(const std::string &address) override;
 
+            Future<std::string> getCurrentDelegate(const std::string &address) override;
+
             Future<bool> isFunded(const std::string &address) override;
 
         private:

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
@@ -158,5 +158,27 @@ namespace ledger {
                         return false;
                     });
         }
+
+        Future<std:string> TezosLikeBlockchainExplorer::getCurrentDelegate(const std::string &address,
+                                                                           const std::shared_ptr<api::ExecutionContext> &context,
+                                                                           const std::shared_ptr<HttpClient> &http,
+                                                                           const std::string &rpcNode) {
+            const bool parseNumbersAsString = true;
+
+            std::unordered_map<std::string, std::string> headers{{"Content-Type", "application/json"}};
+            return http->GET(fmt::format("/chains/main/blocks/head/context/contracts/{}/delegate", address),
+                             std::unordered_map<std::string, std::string>{},
+                             rpcNode)
+                    .json(parseNumbersAsString)
+                    .map<std::string>(context, [](const HttpRequest::JsonResult &result) {
+                        auto &json = *std::get<1>(result);
+                        if (!json.IsString()) {
+                            return "";
+                        }
+                        return json.GetString();
+                    }).recover(context, [] (const Exception &exception) {
+                        return "";
+                    });
+        }
     }
 }

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
@@ -159,7 +159,7 @@ namespace ledger {
                     });
         }
 
-        Future<std:string> TezosLikeBlockchainExplorer::getCurrentDelegate(const std::string &address,
+        Future<std::string> TezosLikeBlockchainExplorer::getCurrentDelegate(const std::string &address,
                                                                            const std::shared_ptr<api::ExecutionContext> &context,
                                                                            const std::shared_ptr<HttpClient> &http,
                                                                            const std::string &rpcNode) {

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.cpp
@@ -177,6 +177,7 @@ namespace ledger {
                         }
                         return json.GetString();
                     }).recover(context, [] (const Exception &exception) {
+                        // FIXME: throw exception to signal errors (i.e: network error)
                         return "";
                     });
         }

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
@@ -151,6 +151,12 @@ namespace ledger {
                                             const std::shared_ptr<HttpClient> &http,
                                             const std::string &rpcNode);
 
+            virtual Future<std::string> getCurrentDelegate(const std::string &address) = 0;
+            static Future<std::string> getCurrentDelegate(const std::string &address,
+                                                          const std::shared_ptr<api::ExecutionContext> &context,
+                                                          const std::shared_ptr<HttpClient> &http,
+                                                          const std::string &rpcNode);
+
             /// Check that the account is funded.
             virtual Future<bool> isFunded(const std::string &address) = 0;
 

--- a/core/test/tezos/ED25519_transaction_test.cpp
+++ b/core/test/tezos/ED25519_transaction_test.cpp
@@ -296,3 +296,19 @@ TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawUndelegation) {
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
 }
 
+  TEST_F(ED25519TezosMakeTransaction, GetCurrentDelegationOnNotDelegatedAccount) {
+     auto builder = tx_builder();
+     auto receiver = make_receiver([=](const std::shared_ptr<api::Event> &event) {
+          fmt::print("Received event {}\n", api::to_string(event->getCode()));
+          if (event->getCode() == api::EventCode::SYNCHRONIZATION_STARTED) return;
+     
+          EXPECT_NE(event->getCode(), api::EventCode::SYNCHRONIZATION_FAILED);
+          EXPECT_EQ(event->getCode(), api::EventCode::SYNCHRONIZATION_SUCCEED);
+          dispatcher->stop();
+      });
+      account->synchronize()->subscribe(dispatcher->getMainExecutionContext(), receiver);
+      dispatcher->waitUntilStopped();
+
+      auto delegate = ::wait(account->getCurrentDelegate());
+      EXPECT_EQ(delegate, "");
+ }

--- a/core/test/tezos/SECP256K1_transaction_test.cpp
+++ b/core/test/tezos/SECP256K1_transaction_test.cpp
@@ -460,3 +460,22 @@ TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawUndelegation) {
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
 } 
 
+
+  TEST_F(SECP256K1TezosMakeTransaction, GetCurrentDelegation) {
+     auto builder = tx_builder();
+     auto receiver = make_receiver([=](const std::shared_ptr<api::Event> &event) {
+          fmt::print("Received event {}\n", api::to_string(event->getCode()));
+          if (event->getCode() == api::EventCode::SYNCHRONIZATION_STARTED) return;
+     
+          EXPECT_NE(event->getCode(), api::EventCode::SYNCHRONIZATION_FAILED);
+          EXPECT_EQ(event->getCode(), api::EventCode::SYNCHRONIZATION_SUCCEED);
+          dispatcher->stop();
+      });
+      account->synchronize()->subscribe(dispatcher->getMainExecutionContext(), receiver);
+      dispatcher->waitUntilStopped();
+
+      auto delegate = ::wait(account->getCurrentDelegate());
+      EXPECT_EQ(delegate, "tz29J6gQdA4Y9Qi5AhNZGMhQUpr9TwLPNByC");
+ }
+
+


### PR DESCRIPTION
This PR adds a new function to an XTZ account: `getCurrentDelegate`
It allows the caller to retrieve the address of the current delegation, empty if none.