### PR TITLE
repair path to libuv github repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,7 +27,7 @@
 	url = https://github.com/d-bahr/CRCpp.git
 [submodule "core/test/lib/libuv"]
 	path = core/test/lib/libuv
-	url = git@github.com:libuv/libuv.git
+	url = https://github.com/libuv/libuv.git
 [submodule "core/src/wallet/algorand/thirdparty/msgpack-c"]
 	path = core/src/wallet/algorand/thirdparty/msgpack-c
 	url = https://github.com/ledgerHQ/msgpack-c.git


### PR DESCRIPTION
corrects failure during git submodule update

```
root@capnmagneto:~/lib-ledger-core# git submodule update
Cloning into '/root/lib-ledger-core/core/test/lib/libuv'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:libuv/libuv.git' into submodule path '/root/lib-ledger-core/core/test/lib/libuv' failed
```