### PR TITLE
Switch cosmos mainnet to Stargate

### DIFF
--- a/core/idl/wallet/cosmos/wallet.djinni
+++ b/core/idl/wallet/cosmos/wallet.djinni
@@ -223,7 +223,7 @@ CosmosLikeRedelegationEntry = interface +c {
 }
 
 CosmosConfigurationDefaults = interface +c {
-        const COSMOS_DEFAULT_API_ENDPOINT: string = "https://cosmos.coin.ledger.com";
+        const COSMOS_DEFAULT_API_ENDPOINT: string = "https://cosmoshub4.coin.ledger.com";
         const COSMOS_OBSERVER_WS_ENDPOINT: string = "";
 }
 

--- a/core/src/api/CosmosConfigurationDefaults.cpp
+++ b/core/src/api/CosmosConfigurationDefaults.cpp
@@ -5,7 +5,7 @@
 
 namespace ledger { namespace core { namespace api {
 
-std::string const CosmosConfigurationDefaults::COSMOS_DEFAULT_API_ENDPOINT = {"https://cosmos.coin.ledger.com"};
+std::string const CosmosConfigurationDefaults::COSMOS_DEFAULT_API_ENDPOINT = {"https://cosmoshub4.coin.ledger.com"};
 
 std::string const CosmosConfigurationDefaults::COSMOS_OBSERVER_WS_ENDPOINT = {""};
 

--- a/core/src/config/Networks.cpp
+++ b/core/src/config/Networks.cpp
@@ -79,8 +79,7 @@ namespace ledger {
                     static const api::CosmosLikeNetworkParameters COSMOSHUB_4(
                         // The current version of the chain has the "cosmos" identifer
                         // Stargate mainnet
-                        // FIXME: change to cosmos once Stargate is the mainnet
-                        "cosmos_stargate",
+                        "cosmos",
                         "ATOM signed message:\n",
                         {0x04, 0x88, 0xB2, 0x1E},
                         {0xEB, 0x5A, 0xE9, 0x87},
@@ -91,8 +90,7 @@ namespace ledger {
                     );
 
                     static const api::CosmosLikeNetworkParameters COSMOSHUB_3(
-                        // FIXME: change to non-cosmos once Stargate is the mainnet
-                        "cosmos",
+                        "cosmos_hub3",
                         "ATOM signed message:\n",
                         {0x04, 0x88, 0xB2, 0x1E},
                         {0xEB, 0x5A, 0xE9, 0x87},

--- a/core/src/database/DatabaseSessionPool.hpp
+++ b/core/src/database/DatabaseSessionPool.hpp
@@ -60,8 +60,7 @@ namespace ledger {
                 const std::string &password = ""
             );
 
-            /// FIXME: Bump this scheme for Stargate release on mainnet in production
-            static const int CURRENT_DATABASE_SCHEME_VERSION = 23;
+            static const int CURRENT_DATABASE_SCHEME_VERSION = 24;
 
             void performDatabaseMigration();
             void performDatabaseRollback();

--- a/core/src/database/migrations.cpp
+++ b/core/src/database/migrations.cpp
@@ -1107,26 +1107,25 @@ namespace ledger {
         }
 
         template <> void migrate<24>(soci::session& sql, api::DatabaseBackendType type) {
-            sql << "CREATE TABLE cosmos_operations_pre_stargate AS SELECT * FROM cosmos_operations";
-            sql << "CREATE TABLE cosmos_multisend_io_pre_stargate AS SELECT * FROM cosmos_multisend_io";
-            sql << "CREATE TABLE cosmos_messages_pre_stargate AS SELECT * FROM cosmos_messages";
-            sql << "CREATE TABLE cosmos_transactions_pre_stargate AS SELECT * FROM cosmos_transactions";
+            sql << "UPDATE cosmos_accounts SET last_update=NULL";
+            sql << "UPDATE cosmos_currencies SET chain_id='cosmoshub-4' WHERE chain_id='cosmoshub-3'";
+            sql << "ALTER TABLE cosmos_currencies ADD COLUMN ed25519_prefix VARCHAR(255) NOT NULL DEFAULT '1624de64'";
+            sql << "UPDATE cosmos_currencies SET ed25519_prefix='1624de64'";
 
-            sql << "TRUNCATE cosmos_operations, cosmos_multisend_io, cosmos_messages, cosmos_transactions";
+            sql << "DELETE FROM cosmos_operations";
+            sql << "DELETE FROM cosmos_multisend_io";
+            sql << "DELETE FROM cosmos_messages";
+            sql << "DELETE FROM cosmos_transactions";
+
+            sql << "DELETE FROM wallets WHERE currency_name='cosmos'";
+            sql << "DELETE FROM operations WHERE currency_name='cosmos'";
         }
 
         template <> void rollback<24>(soci::session& sql, api::DatabaseBackendType type) {
-            sql << "TRUNCATE cosmos_operations, cosmos_multisend_io, cosmos_messages, cosmos_transactions";
-
-            sql << "INSERT cosmos_transactions SELECT * FROM cosmos_transactions_pre_stargate";
-            sql << "INSERT cosmos_messages SELECT * FROM cosmos_messages_pre_stargate";
-            sql << "INSERT cosmos_multisend_io SELECT * FROM cosmos_multisend_io_pre_stargate";
-            sql << "INSERT cosmos_operations SELECT * FROM cosmos_operations_pre_stargate";
-
-            sql << "DROP TABLE cosmos_multisend_io_pre_stargate";
-            sql << "DROP TABLE cosmos_operations_pre_stargate";
-            sql << "DROP TABLE cosmos_messages_pre_stargate";
-            sql << "DROP TABLE cosmos_transactions_pre_stargate";
+            sql << "DELETE FROM cosmos_operations";
+            sql << "DELETE FROM cosmos_multisend_io";
+            sql << "DELETE FROM cosmos_messages";
+            sql << "DELETE FROM cosmos_transactions";
         }
 
 

--- a/core/src/wallet/pool/database/CurrenciesDatabaseHelper.cpp
+++ b/core/src/wallet/pool/database/CurrenciesDatabaseHelper.cpp
@@ -97,12 +97,13 @@ bool ledger::core::CurrenciesDatabaseHelper::insertCurrency(soci::session &sql,
                 auto hexXPUBVersion = hex::toString(params.XPUBVersion);
                 auto hexPubKeyPrefix = hex::toString(params.PubKeyPrefix);
                 auto hexAddressPrefix = hex::toString(params.AddressPrefix);
+                auto edPubKeyPrefix = hex::toString(params.Ed25519PubKeyPrefix);
                 sql << "INSERT INTO cosmos_currencies VALUES(:name, :identifier, :xpub, "
                        ":pubkey_prefix, :address_prefix, :message_prefix, :chain_id, "
-                       ":additionalCIPs)",
+                       ":additionalCIPs, :edPrefix)",
                     use(currency.name), use(params.Identifier), use(hexXPUBVersion),
                     use(hexPubKeyPrefix), use(hexAddressPrefix), use(params.MessagePrefix),
-                    use(params.ChainId), use(CIPs);
+                    use(params.ChainId), use(CIPs), use(edPubKeyPrefix);
                 break;
             }
             case api::WalletType::ETHEREUM: {
@@ -260,7 +261,7 @@ void ledger::core::CurrenciesDatabaseHelper::getAllCurrencies(soci::session &sql
                          << "SELECT cosmos_currencies.name, cosmos_currencies.identifier, "
                             "cosmos_currencies.xpub_version, cosmos_currencies.pubkey_prefix, "
                             "cosmos_currencies.address_prefix, cosmos_currencies.message_prefix, "
-                            "cosmos_currencies.chain_id, cosmos_currencies.additional_CIPs"
+                            "cosmos_currencies.chain_id, cosmos_currencies.additional_CIPs, cosmos_currencies.ed25519_prefix"
                             " FROM cosmos_currencies "
                             " WHERE cosmos_currencies.name = :currency_name",
                      use(currency.name));
@@ -273,6 +274,7 @@ void ledger::core::CurrenciesDatabaseHelper::getAllCurrencies(soci::session &sql
                     params.MessagePrefix = cosmos_row.get<std::string>(5);
                     params.ChainId = cosmos_row.get<std::string>(6);
                     params.AdditionalCIPs = strings::split(cosmos_row.get<std::string>(7), ",");
+                    params.Ed25519PubKeyPrefix = hex::toByteArray(cosmos_row.get<std::string>(8));
                     currency.cosmosLikeNetworkParameters = params;
                 }
                 break;


### PR DESCRIPTION
- Set currency identifier of the `cosmoshub+4` chain to `cosmos`
- Trigger the migration to remove cosmos account history
- Change the default endpoint