### PR TITLE
Remove unnecessary bitcoin_currencies_swap table in DB rollback proce…

### DIFF
--- a/core/src/database/migrations.cpp
+++ b/core/src/database/migrations.cpp
@@ -1141,28 +1141,6 @@ namespace ledger {
             if (type != api::DatabaseBackendType::SQLITE3) {
                 sql << "ALTER TABLE bitcoin_currencies DROP dust_policy";
             } else {
-                sql << "CREATE TABLE bitcoin_currencies_swap"
-                       "(name VARCHAR(255) PRIMARY KEY NOT NULL REFERENCES currencies(name) ON DELETE CASCADE ON UPDATE CASCADE,"
-                       "identifier VARCHAR(255) NOT NULL,"
-                       "p2pkh_version VARCHAR(255) NOT NULL,"
-                       "p2sh_version VARCHAR(255) NOT NULL,"
-                       "xpub_version VARCHAR(255) NOT NULL,"
-                       "dust_amount BIGINT NOT NULL,"
-                       "fee_policy VARCHAR(20) NOT NULL,"
-                       "message_prefix VARCHAR(255) NOT NULL,"
-                       "has_timestamped_transaction INTEGER NOT NULL," 
-                       "timestamp_delay BIGINT DEFAULT 0," 
-                       "sighash_type VARCHAR(255) DEFAULT 01," 
-                       "additional_BIPs TEXT DEFAULT ''"
-                       ")";
-                sql << "INSERT INTO bitcoin_currencies_swap"
-                       "SELECT identifier, p2pkh_version, p2sh_version, xpub_version,"
-                       "dust_amount, fee_policy, message_prefix,"
-                       "has_timestamped_transaction, timestamp_delay,"
-                       "sighash_type, additional_BIPs "
-                       "FROM bitcoin_currencies ";
-                sql << "DROP TABLE bitcoin_currencies";
-                sql << "ALTER TABLE bitcoin_currencies_swap RENAME TO bitcoin_currencies";
                 sql << "UPDATE bitcoin_currencies SET dust_amount = 546 WHERE identifier = 'btc'";
                 sql << "UPDATE bitcoin_currencies SET dust_amount = 546 WHERE identifier = 'btc_testnet'";
          


### PR DESCRIPTION
…ss due to the "SynchronizeAndFreshResetAll" unit test is broken. (because the bitcoin_currencies_swap and bitcoin_currencies doesn't have same schema)