### PR TITLE
[ATOM] Wait for updateAccountFromNetwork

### DIFF
--- a/core/src/wallet/cosmos/CosmosLikeAccount.hpp
+++ b/core/src/wallet/cosmos/CosmosLikeAccount.hpp
@@ -244,7 +244,7 @@ class CosmosLikeAccount : public api::CosmosLikeAccount, public AbstractAccount 
     ///    }
     ///  }
     /// }
-    void updateAccountDataFromNetwork();
+    FuturePtr<cosmos::Account> updateAccountDataFromNetwork();
 
     // These helpers stay on CosmosLikeAccount *only* because they have to use their
     // knowledge of Address information in order to correctly map operation type.


### PR DESCRIPTION
Fixes an issue where calling "estimateGas" too quickly after a broadcast
would actually still use an old sequence number.