### PR TITLE
sha512256: patch portability.h to compile on ARM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix XRP incremental synchronization
 - Improve runtime performances by splitting db connections between Write pool and Read pool
 - use of tx "id" field (if present) instead of "hash" for btc explorers
+- Fix compilation on ARM
 
 ## 3.5.0
 

--- a/core/lib/sha512256/portability.h
+++ b/core/lib/sha512256/portability.h
@@ -63,7 +63,9 @@ static inline uint64_t swap_uint64(uint64_t val)
 #define FASTCALL
 #define CPPCRYPTOAPI
 
-#if defined(__clang__) || defined(__SUNPRO_CC)
+#if defined(__clang__) || defined(__SUNPRO_CC)\
+	|| defined(__arm__) || defined(__aarch32__) \
+	|| defined(__arm64__) || defined(__aarch64__)
 static inline uint32_t rotater32(uint32_t x, unsigned n)
 {
 	return (x >> n) | (x << (32 - n));


### PR DESCRIPTION
Intel's x86 intrinsics do not apply to ARM architectures (obviously!).

This patch only enables compilation: for optimum performance architecture-specific bytecode should be implemented instead.

This should probably also be backported to other branches, such as 3.5.x on which the current stable `npm` package (and, through that, Live) depends.
