### PR TITLE
LL-5485 LL-5782 [Algorand] Disable tests based on TestNet

### DIFF
--- a/core/test/algorand/AlgorandAccountTests.cpp
+++ b/core/test/algorand/AlgorandAccountTests.cpp
@@ -298,6 +298,7 @@ TEST_F(AlgorandAccountTest, assetBalanceHistory)
     }
 }
 
+/*
 TEST_F(AlgorandAccountTest, validAmount)
 {
     const auto valid = wait(account->isAmountValid(EMPTY_ADDR, "100000"));
@@ -307,3 +308,4 @@ TEST_F(AlgorandAccountTest, validAmount)
     const auto invalid = wait(account->isAmountValid(EMPTY_ADDR, "99999"));
     EXPECT_FALSE(invalid);
 }
+*/

--- a/core/test/algorand/AlgorandExplorerTests.cpp
+++ b/core/test/algorand/AlgorandExplorerTests.cpp
@@ -41,13 +41,13 @@ public:
         BaseFixture::SetUp();
 
         auto worker = dispatcher->getSerialExecutionContext("worker");
-        // NOTE: we run the tests on the staging environment which is on the TestNet
-        auto client = std::make_shared<HttpClient>("https://algorand.coin.staging.aws.ledger.com", http, worker);
 
         // NOTE: we run the tests on the staging environment which is on the TestNet
+        // UPDATE: no more TestNet available since we moved from PureStake to internal infra... all related tests disabled
+        auto client = std::make_shared<HttpClient>("https://algorand.coin.staging.aws.ledger.com", http, worker);
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT, "https://algorand.coin.staging.aws.ledger.com");
-        
+
         explorer = std::make_shared<BlockchainExplorer>(
                         worker,
                         client,

--- a/core/test/algorand/AlgorandSynchronizationTests.cpp
+++ b/core/test/algorand/AlgorandSynchronizationTests.cpp
@@ -54,6 +54,7 @@ public:
         registerCurrency(currencies::ALGORAND);
 
         // NOTE: we run the tests on the staging environment which is on the TestNet
+        // UPDATE: no more TestNet available since we moved from PureStake to internal infra... all related tests disabled
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT, "https://algorand.coin.staging.aws.ledger.com");
 

--- a/core/test/algorand/CMakeLists.txt
+++ b/core/test/algorand/CMakeLists.txt
@@ -12,9 +12,9 @@ add_executable(ledger-core-algorand-tests
     MsgpackHelpersTests.cpp
     AlgorandAccountTests.cpp
     AlgorandAddressTests.cpp
-    AlgorandExplorerTests.cpp
+#   AlgorandExplorerTests.cpp
     AlgorandDatabaseTests.cpp
-    AlgorandSynchronizationTests.cpp
+#   AlgorandSynchronizationTests.cpp
     AlgorandSerializationTests.cpp
   ../integration/BaseFixture.cpp
   ../integration/IntegrationEnvironment.cpp


### PR DESCRIPTION
**Context**: we changed our Algorand node provider from PureStake to host it ourselves with Leger infra (https://ledgerhq.atlassian.net/browse/LL-5485).
However our infra doesn't provide a TestNet anymore, so we have to disable the libcore tests that were based on the TestNet.