### PR TITLE
[VG-670] [VG-671] WIP: add corrId setters in Transaction

### DIFF
--- a/core/idl/wallet/algorand/idl.djinni
+++ b/core/idl/wallet/algorand/idl.djinni
@@ -135,13 +135,16 @@ AlgorandTransaction = interface +c {
     const getReceiverRewards(): string;
     const getCloseRewards(): string;
     const getCorrelationId(): string;
+    # Set the correlation id which can be used to debug transaction errors
+    # through the full ledger stack
+    # @return the OLD Correlation ID, if it was set (empty string if it was unset)
+    setCorrelationId(correlationId : string) : string;
 
     
 
     setSender(sender: string);
     setFee(fee: string);
     setNote(note: string);
-    setCorrelationId(correlationId : string);
 
     setPaymentInfo(info: AlgorandPaymentInfo);
     const getPaymentInfo(): AlgorandPaymentInfo;

--- a/core/idl/wallet/bitcoin/bitcoin_like_wallet.djinni
+++ b/core/idl/wallet/bitcoin/bitcoin_like_wallet.djinni
@@ -175,6 +175,10 @@ BitcoinLikeTransaction = interface +c {
     getEstimatedSize(): EstimatedSize;
     # Get the id used to track a transaction
     getCorrelationId(): string;
+    # Set the correlation id which can be used to debug transaction errors
+    # through the full ledger stack
+    # @return the OLD Correlation ID, if it was set (empty string if it was unset)
+    setCorrelationId(correlationId : string) : string;
     # Sign all inputs for given transaction. 
     # Build DER encoded signature from RSV data.
     # @return SIGNING_SUCCEED if succeed case else refers to BitcoinLikeSignatureState enumeration

--- a/core/idl/wallet/cosmos/wallet.djinni
+++ b/core/idl/wallet/cosmos/wallet.djinni
@@ -27,6 +27,10 @@ CosmosLikeTransaction = interface +c {
         const getSigningPubKey(): binary;
         # Get Signing public Key
         const getCorrelationId(): string;
+        # Set the correlation id which can be used to debug transaction errors
+        # through the full ledger stack
+        # @return the OLD Correlation ID, if it was set (empty string if it was unset)
+        setCorrelationId(correlationId : string) : string;
 
         # Serialize the transaction to be signed
         serializeForSignature(): string;

--- a/core/idl/wallet/ethereum/ethereum_like_wallet.djinni
+++ b/core/idl/wallet/ethereum/ethereum_like_wallet.djinni
@@ -38,6 +38,10 @@ EthereumLikeTransaction = interface +c {
     getStatus(): i32;
     # Get correlation id
     getCorrelationId(): string;
+    # Set the correlation id which can be used to debug transaction errors
+    # through the full ledger stack
+    # @return the OLD Correlation ID, if it was set (empty string if it was unset)
+    setCorrelationId(correlationId : string) : string;
     # Serialize the transaction to its raw format.
     serialize(): binary;
     # Set signature of transaction, when a signature is set serialize method gives back serialized Tx.

--- a/core/idl/wallet/ripple/ripple_like_wallet.djinni
+++ b/core/idl/wallet/ripple/ripple_like_wallet.djinni
@@ -44,6 +44,10 @@ RippleLikeTransaction = interface +c {
     getStatus(): i32;
     # Get the correlation id
     getCorrelationId(): string;
+    # Set the correlation id which can be used to debug transaction errors
+    # through the full ledger stack
+    # @return the OLD Correlation ID, if it was set (empty string if it was unset)
+    setCorrelationId(correlationId : string) : string;
 }
 
 #Class representing a Ripple Operation

--- a/core/idl/wallet/stellar/stellar_like_wallet.djinni
+++ b/core/idl/wallet/stellar/stellar_like_wallet.djinni
@@ -54,12 +54,23 @@ StellarLikeTransaction = interface +c {
 
     # Returns the transaction memo
     getMemo(): StellarLikeMemo;
+
+    # Get the correlation id
+    getCorrelationId(): string;
+    # Set the correlation id which can be used to debug transaction errors
+    # through the full ledger stack
+    # @return the OLD Correlation ID, if it was set (empty string if it was unset)
+    setCorrelationId(correlationId : string) : string;
 }
 
 StellarLikeTransactionBuilder = interface +c {
     addNativePayment(address: string, amount: Amount): StellarLikeTransactionBuilder;
     addCreateAccount(address: string, amount: Amount): StellarLikeTransactionBuilder;
     setBaseFee(baseFee: Amount): StellarLikeTransactionBuilder;
+
+    # Set the correlation id (used to track a transaction)
+    # @return A reference on the same builder in order to chain calls.
+    setCorrelationId(correlationId: string): StellarLikeTransactionBuilder;
 
     setTextMemo(text: string): StellarLikeTransactionBuilder;
     setNumberMemo(number: BigInt): StellarLikeTransactionBuilder;
@@ -120,6 +131,9 @@ StellarLikeAccount = interface +c {
 
     # Broadcast the given raw transaction to the network.
     broadcastRawTransaction(tx: binary, callback: Callback<string>);
+
+    # Broadcast the given raw transaction to the network.
+    broadcastTransaction(tx: StellarLikeTransaction, callback: Callback<string>);
 
     # Get base reserve of the network
     getBaseReserve(callback: Callback<Amount>);

--- a/core/idl/wallet/tezos/tezos_like_wallet.djinni
+++ b/core/idl/wallet/tezos/tezos_like_wallet.djinni
@@ -48,6 +48,10 @@ TezosLikeTransaction = interface +c {
 	getStatus(): i32;
 	# Get the correlation id
 	getCorrelationId(): string;
+        # Set the correlation id which can be used to debug transaction errors
+        # through the full ledger stack
+        # @return the OLD Correlation ID, if it was set (empty string if it was unset)
+        setCorrelationId(correlationId : string) : string;
 }
 
 #Class representing a Tezos Operation

--- a/core/src/api/AlgorandTransaction.hpp
+++ b/core/src/api/AlgorandTransaction.hpp
@@ -47,13 +47,18 @@ public:
 
     virtual std::string getCorrelationId() const = 0;
 
+    /**
+     * Set the correlation id which can be used to debug transaction errors
+     * through the full ledger stack
+     * @return the OLD Correlation ID, if it was set (empty string if it was unset)
+     */
+    virtual std::string setCorrelationId(const std::string & correlationId) = 0;
+
     virtual void setSender(const std::string & sender) = 0;
 
     virtual void setFee(const std::string & fee) = 0;
 
     virtual void setNote(const std::string & note) = 0;
-
-    virtual void setCorrelationId(const std::string & correlationId) = 0;
 
     virtual void setPaymentInfo(const AlgorandPaymentInfo & info) = 0;
 

--- a/core/src/api/BitcoinLikeTransaction.hpp
+++ b/core/src/api/BitcoinLikeTransaction.hpp
@@ -82,6 +82,13 @@ public:
     virtual std::string getCorrelationId() = 0;
 
     /**
+     * Set the correlation id which can be used to debug transaction errors
+     * through the full ledger stack
+     * @return the OLD Correlation ID, if it was set (empty string if it was unset)
+     */
+    virtual std::string setCorrelationId(const std::string & correlationId) = 0;
+
+    /**
      * Sign all inputs for given transaction. 
      * Build DER encoded signature from RSV data.
      * @return SIGNING_SUCCEED if succeed case else refers to BitcoinLikeSignatureState enumeration

--- a/core/src/api/CosmosLikeTransaction.hpp
+++ b/core/src/api/CosmosLikeTransaction.hpp
@@ -58,6 +58,13 @@ public:
     /** Get Signing public Key */
     virtual std::string getCorrelationId() const = 0;
 
+    /**
+     * Set the correlation id which can be used to debug transaction errors
+     * through the full ledger stack
+     * @return the OLD Correlation ID, if it was set (empty string if it was unset)
+     */
+    virtual std::string setCorrelationId(const std::string & correlationId) = 0;
+
     /** Serialize the transaction to be signed */
     virtual std::string serializeForSignature() = 0;
 

--- a/core/src/api/EthereumLikeTransaction.hpp
+++ b/core/src/api/EthereumLikeTransaction.hpp
@@ -62,6 +62,13 @@ public:
     /** Get correlation id */
     virtual std::string getCorrelationId() = 0;
 
+    /**
+     * Set the correlation id which can be used to debug transaction errors
+     * through the full ledger stack
+     * @return the OLD Correlation ID, if it was set (empty string if it was unset)
+     */
+    virtual std::string setCorrelationId(const std::string & correlationId) = 0;
+
     /** Serialize the transaction to its raw format. */
     virtual std::vector<uint8_t> serialize() = 0;
 

--- a/core/src/api/RippleLikeTransaction.hpp
+++ b/core/src/api/RippleLikeTransaction.hpp
@@ -90,6 +90,13 @@ public:
 
     /** Get the correlation id */
     virtual std::string getCorrelationId() = 0;
+
+    /**
+     * Set the correlation id which can be used to debug transaction errors
+     * through the full ledger stack
+     * @return the OLD Correlation ID, if it was set (empty string if it was unset)
+     */
+    virtual std::string setCorrelationId(const std::string & correlationId) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/StellarLikeAccount.hpp
+++ b/core/src/api/StellarLikeAccount.hpp
@@ -22,6 +22,7 @@ class BigIntCallback;
 class BoolCallback;
 class StellarLikeAccountSignerListCallback;
 class StellarLikeFeeStatsCallback;
+class StellarLikeTransaction;
 class StellarLikeTransactionBuilder;
 class StringCallback;
 
@@ -44,6 +45,9 @@ public:
 
     /** Broadcast the given raw transaction to the network. */
     virtual void broadcastRawTransaction(const std::vector<uint8_t> & tx, const std::shared_ptr<StringCallback> & callback) = 0;
+
+    /** Broadcast the given raw transaction to the network. */
+    virtual void broadcastTransaction(const std::shared_ptr<StellarLikeTransaction> & tx, const std::shared_ptr<StringCallback> & callback) = 0;
 
     /** Get base reserve of the network */
     virtual void getBaseReserve(const std::shared_ptr<AmountCallback> & callback) = 0;

--- a/core/src/api/StellarLikeTransaction.hpp
+++ b/core/src/api/StellarLikeTransaction.hpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 #ifndef LIBCORE_EXPORT
     #if defined(_MSC_VER)
@@ -45,6 +46,16 @@ public:
 
     /** Returns the transaction memo */
     virtual std::shared_ptr<StellarLikeMemo> getMemo() = 0;
+
+    /** Get the correlation id */
+    virtual std::string getCorrelationId() = 0;
+
+    /**
+     * Set the correlation id which can be used to debug transaction errors
+     * through the full ledger stack
+     * @return the OLD Correlation ID, if it was set (empty string if it was unset)
+     */
+    virtual std::string setCorrelationId(const std::string & correlationId) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/StellarLikeTransactionBuilder.hpp
+++ b/core/src/api/StellarLikeTransactionBuilder.hpp
@@ -34,6 +34,12 @@ public:
 
     virtual std::shared_ptr<StellarLikeTransactionBuilder> setBaseFee(const std::shared_ptr<Amount> & baseFee) = 0;
 
+    /**
+     * Set the correlation id (used to track a transaction)
+     * @return A reference on the same builder in order to chain calls.
+     */
+    virtual std::shared_ptr<StellarLikeTransactionBuilder> setCorrelationId(const std::string & correlationId) = 0;
+
     virtual std::shared_ptr<StellarLikeTransactionBuilder> setTextMemo(const std::string & text) = 0;
 
     virtual std::shared_ptr<StellarLikeTransactionBuilder> setNumberMemo(const std::shared_ptr<BigInt> & number) = 0;

--- a/core/src/api/TezosLikeTransaction.hpp
+++ b/core/src/api/TezosLikeTransaction.hpp
@@ -77,6 +77,13 @@ public:
 
     /** Get the correlation id */
     virtual std::string getCorrelationId() = 0;
+
+    /**
+     * Set the correlation id which can be used to debug transaction errors
+     * through the full ledger stack
+     * @return the OLD Correlation ID, if it was set (empty string if it was unset)
+     */
+    virtual std::string setCorrelationId(const std::string & correlationId) = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/jni/jni/AlgorandTransaction.cpp
+++ b/core/src/jni/jni/AlgorandTransaction.cpp
@@ -124,6 +124,16 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_AlgorandTransaction_00024CppProxy
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jstring JNICALL Java_co_ledger_core_AlgorandTransaction_00024CppProxy_native_1setCorrelationId(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_correlationId)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::AlgorandTransaction>(nativeRef);
+        auto r = ref->setCorrelationId(::djinni::String::toCpp(jniEnv, j_correlationId));
+        return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT void JNICALL Java_co_ledger_core_AlgorandTransaction_00024CppProxy_native_1setSender(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_sender)
 {
     try {
@@ -148,15 +158,6 @@ CJNIEXPORT void JNICALL Java_co_ledger_core_AlgorandTransaction_00024CppProxy_na
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::AlgorandTransaction>(nativeRef);
         ref->setNote(::djinni::String::toCpp(jniEnv, j_note));
-    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
-}
-
-CJNIEXPORT void JNICALL Java_co_ledger_core_AlgorandTransaction_00024CppProxy_native_1setCorrelationId(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_correlationId)
-{
-    try {
-        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::AlgorandTransaction>(nativeRef);
-        ref->setCorrelationId(::djinni::String::toCpp(jniEnv, j_correlationId));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/core/src/jni/jni/BitcoinLikeTransaction.cpp
+++ b/core/src/jni/jni/BitcoinLikeTransaction.cpp
@@ -166,6 +166,16 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_BitcoinLikeTransaction_00024CppPr
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jstring JNICALL Java_co_ledger_core_BitcoinLikeTransaction_00024CppProxy_native_1setCorrelationId(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_correlationId)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeTransaction>(nativeRef);
+        auto r = ref->setCorrelationId(::djinni::String::toCpp(jniEnv, j_correlationId));
+        return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeTransaction_00024CppProxy_native_1setSignatures(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jobject j_signatures, jboolean j_override)
 {
     try {

--- a/core/src/jni/jni/CosmosLikeTransaction.cpp
+++ b/core/src/jni/jni/CosmosLikeTransaction.cpp
@@ -122,6 +122,16 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_CosmosLikeTransaction_00024CppPro
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jstring JNICALL Java_co_ledger_core_CosmosLikeTransaction_00024CppProxy_native_1setCorrelationId(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_correlationId)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::CosmosLikeTransaction>(nativeRef);
+        auto r = ref->setCorrelationId(::djinni::String::toCpp(jniEnv, j_correlationId));
+        return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT jstring JNICALL Java_co_ledger_core_CosmosLikeTransaction_00024CppProxy_native_1serializeForSignature(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
 {
     try {

--- a/core/src/jni/jni/EthereumLikeTransaction.cpp
+++ b/core/src/jni/jni/EthereumLikeTransaction.cpp
@@ -132,6 +132,16 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_EthereumLikeTransaction_00024CppP
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jstring JNICALL Java_co_ledger_core_EthereumLikeTransaction_00024CppProxy_native_1setCorrelationId(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_correlationId)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::EthereumLikeTransaction>(nativeRef);
+        auto r = ref->setCorrelationId(::djinni::String::toCpp(jniEnv, j_correlationId));
+        return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT jbyteArray JNICALL Java_co_ledger_core_EthereumLikeTransaction_00024CppProxy_native_1serialize(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
 {
     try {

--- a/core/src/jni/jni/RippleLikeTransaction.cpp
+++ b/core/src/jni/jni/RippleLikeTransaction.cpp
@@ -191,4 +191,14 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_RippleLikeTransaction_00024CppPro
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jstring JNICALL Java_co_ledger_core_RippleLikeTransaction_00024CppProxy_native_1setCorrelationId(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_correlationId)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::RippleLikeTransaction>(nativeRef);
+        auto r = ref->setCorrelationId(::djinni::String::toCpp(jniEnv, j_correlationId));
+        return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 }  // namespace djinni_generated

--- a/core/src/jni/jni/StellarLikeAccount.cpp
+++ b/core/src/jni/jni/StellarLikeAccount.cpp
@@ -8,6 +8,7 @@
 #include "Marshal.hpp"
 #include "StellarLikeAccountSignerListCallback.hpp"
 #include "StellarLikeFeeStatsCallback.hpp"
+#include "StellarLikeTransaction.hpp"
 #include "StellarLikeTransactionBuilder.hpp"
 #include "StringCallback.hpp"
 
@@ -52,6 +53,16 @@ CJNIEXPORT void JNICALL Java_co_ledger_core_StellarLikeAccount_00024CppProxy_nat
         const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::StellarLikeAccount>(nativeRef);
         ref->broadcastRawTransaction(::djinni::Binary::toCpp(jniEnv, j_tx),
                                      ::djinni_generated::StringCallback::toCpp(jniEnv, j_callback));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
+}
+
+CJNIEXPORT void JNICALL Java_co_ledger_core_StellarLikeAccount_00024CppProxy_native_1broadcastTransaction(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jobject j_tx, jobject j_callback)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::StellarLikeAccount>(nativeRef);
+        ref->broadcastTransaction(::djinni_generated::StellarLikeTransaction::toCpp(jniEnv, j_tx),
+                                  ::djinni_generated::StringCallback::toCpp(jniEnv, j_callback));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/core/src/jni/jni/StellarLikeTransaction.cpp
+++ b/core/src/jni/jni/StellarLikeTransaction.cpp
@@ -93,4 +93,24 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_StellarLikeTransaction_00024CppPr
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jstring JNICALL Java_co_ledger_core_StellarLikeTransaction_00024CppProxy_native_1getCorrelationId(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::StellarLikeTransaction>(nativeRef);
+        auto r = ref->getCorrelationId();
+        return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
+CJNIEXPORT jstring JNICALL Java_co_ledger_core_StellarLikeTransaction_00024CppProxy_native_1setCorrelationId(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_correlationId)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::StellarLikeTransaction>(nativeRef);
+        auto r = ref->setCorrelationId(::djinni::String::toCpp(jniEnv, j_correlationId));
+        return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 }  // namespace djinni_generated

--- a/core/src/jni/jni/StellarLikeTransactionBuilder.cpp
+++ b/core/src/jni/jni/StellarLikeTransactionBuilder.cpp
@@ -56,6 +56,16 @@ CJNIEXPORT jobject JNICALL Java_co_ledger_core_StellarLikeTransactionBuilder_000
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jobject JNICALL Java_co_ledger_core_StellarLikeTransactionBuilder_00024CppProxy_native_1setCorrelationId(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_correlationId)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::StellarLikeTransactionBuilder>(nativeRef);
+        auto r = ref->setCorrelationId(::djinni::String::toCpp(jniEnv, j_correlationId));
+        return ::djinni::release(::djinni_generated::StellarLikeTransactionBuilder::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT jobject JNICALL Java_co_ledger_core_StellarLikeTransactionBuilder_00024CppProxy_native_1setTextMemo(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_text)
 {
     try {

--- a/core/src/jni/jni/TezosLikeTransaction.cpp
+++ b/core/src/jni/jni/TezosLikeTransaction.cpp
@@ -182,4 +182,14 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_TezosLikeTransaction_00024CppProx
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jstring JNICALL Java_co_ledger_core_TezosLikeTransaction_00024CppProxy_native_1setCorrelationId(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_correlationId)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::TezosLikeTransaction>(nativeRef);
+        auto r = ref->setCorrelationId(::djinni::String::toCpp(jniEnv, j_correlationId));
+        return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 }  // namespace djinni_generated

--- a/core/src/wallet/algorand/transactions/api_impl/AlgorandTransactionImpl.cpp
+++ b/core/src/wallet/algorand/transactions/api_impl/AlgorandTransactionImpl.cpp
@@ -205,9 +205,10 @@ namespace algorand {
         return correlationId;
     }
 
-    void AlgorandTransactionImpl::setCorrelationId(const std::string& corrId) 
-    {
-        correlationId = corrId;
+    std::string AlgorandTransactionImpl::setCorrelationId(const std::string& newId)  {
+        auto oldId = correlationId;
+        correlationId = newId;
+        return oldId;
     }
 
 } // namespace algorand

--- a/core/src/wallet/algorand/transactions/api_impl/AlgorandTransactionImpl.hpp
+++ b/core/src/wallet/algorand/transactions/api_impl/AlgorandTransactionImpl.hpp
@@ -62,10 +62,10 @@ namespace algorand {
         std::string getReceiverRewards() const override;
         std::string getCloseRewards() const override;
         std::string getCorrelationId() const override;
+        std::string setCorrelationId(const std::string& newId) override;
         void setSender(const std::string& sender) override;
         void setFee(const std::string& fee) override;
         void setNote(const std::string& note) override;
-        void setCorrelationId(const std::string& correlationId) override;
         void setPaymentInfo(const api::AlgorandPaymentInfo& info) override;
         api::AlgorandPaymentInfo getPaymentInfo() const override;
         void setParticipationInfo(const api::AlgorandParticipationInfo& info) override;

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp
@@ -130,6 +130,12 @@ namespace ledger {
             return _correlationId;
         }
 
+        std::string BitcoinLikeTransactionApi::setCorrelationId(const std::string& newId)  {
+            auto oldId = _correlationId;
+            _correlationId = newId;
+            return oldId;
+        }
+
         optional<int32_t> BitcoinLikeTransactionApi::getTimestamp() {
             return _timestamp.map<int32_t>([](const uint32_t &v) {
                 return (int32_t) v;

--- a/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h
+++ b/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h
@@ -112,6 +112,8 @@ namespace ledger {
 
             std::string getCorrelationId() override;
 
+            std::string setCorrelationId(const std::string& newId) override;
+
             std::vector<uint8_t> serializeOutputs() override;
 
             int32_t getVersion() override;

--- a/core/src/wallet/cosmos/api_impl/CosmosLikeTransactionApi.cpp
+++ b/core/src/wallet/cosmos/api_impl/CosmosLikeTransactionApi.cpp
@@ -433,10 +433,12 @@ namespace ledger {
             return _txData;
         }
 
-        void CosmosLikeTransactionApi::setCorrelationId(const std::string &correlationId)
-        {
-            _correlationId = correlationId;
+        std::string CosmosLikeTransactionApi::setCorrelationId(const std::string& newId)  {
+            auto oldId = _correlationId;
+            _correlationId = newId;
+            return oldId;
         }
+
 
         std::string CosmosLikeTransactionApi::getCorrelationId() const
         {

--- a/core/src/wallet/cosmos/api_impl/CosmosLikeTransactionApi.hpp
+++ b/core/src/wallet/cosmos/api_impl/CosmosLikeTransactionApi.hpp
@@ -63,7 +63,6 @@ class CosmosLikeTransactionApi : public api::CosmosLikeTransaction {
     void setAccountNumber(const std::string &accountNumber);
     void setMessages(const std::vector<std::shared_ptr<api::CosmosLikeMessage>> &messages);
     void setSigningPubKey(const std::vector<uint8_t> &pubKey);
-    void setCorrelationId(const std::string &correlationId);
 
     void setSignature(
         const std::vector<uint8_t> &rSignature, const std::vector<uint8_t> &sSignature) override;
@@ -79,6 +78,7 @@ class CosmosLikeTransactionApi : public api::CosmosLikeTransaction {
     std::vector<std::shared_ptr<api::CosmosLikeMessage>> getMessages() const override;
     std::vector<uint8_t> getSigningPubKey() const override;
     std::string getCorrelationId() const override;
+    std::string setCorrelationId(const std::string& newId) override;
 
     std::string serializeForSignature() override;
     std::string serializeForBroadcast(const std::string &mode) override;

--- a/core/src/wallet/ethereum/api_impl/EthereumLikeTransactionApi.cpp
+++ b/core/src/wallet/ethereum/api_impl/EthereumLikeTransactionApi.cpp
@@ -128,6 +128,12 @@ namespace ledger {
             return _correlationId;
         }
 
+        std::string EthereumLikeTransactionApi::setCorrelationId(const std::string& newId)  {
+            auto oldId = _correlationId;
+            _correlationId = newId;
+            return oldId;
+        }
+
         void EthereumLikeTransactionApi::setSignature(const std::vector<uint8_t> & vSignature, const std::vector<uint8_t> & rSignature, const std::vector<uint8_t> & sSignature) {
             _vSignature = vSignature;
             _rSignature = rSignature;

--- a/core/src/wallet/ethereum/api_impl/EthereumLikeTransactionApi.h
+++ b/core/src/wallet/ethereum/api_impl/EthereumLikeTransactionApi.h
@@ -61,6 +61,7 @@ namespace ledger {
             std::chrono::system_clock::time_point getDate() override;
             std::shared_ptr<api::EthereumLikeBlock> getBlock() override;
             std::string getCorrelationId() override;
+            std::string setCorrelationId(const std::string& newId) override;
             void setSignature(const std::vector<uint8_t> & vSignature, const std::vector<uint8_t> & rSignature, const std::vector<uint8_t> & sSignature) override ;
             void setDERSignature(const std::vector<uint8_t> & signature) override;
             void setVSignature(const std::vector<uint8_t> & vSignature) override;

--- a/core/src/wallet/ripple/api_impl/RippleLikeTransactionApi.cpp
+++ b/core/src/wallet/ripple/api_impl/RippleLikeTransactionApi.cpp
@@ -387,5 +387,11 @@ namespace ledger {
             return _correlationId;
         }
 
+        std::string RippleLikeTransactionApi::setCorrelationId(const std::string& newId)  {
+            auto oldId = _correlationId;
+            _correlationId = newId;
+            return oldId;
+        }
+
     }
 }

--- a/core/src/wallet/ripple/api_impl/RippleLikeTransactionApi.h
+++ b/core/src/wallet/ripple/api_impl/RippleLikeTransactionApi.h
@@ -74,6 +74,7 @@ namespace ledger {
             std::experimental::optional<int64_t> getDestinationTag() override;
             int32_t getStatus() override;
             std::string getCorrelationId() override;
+            std::string setCorrelationId(const std::string& newId) override;
 
         private:
             std::chrono::system_clock::time_point _time;

--- a/core/src/wallet/stellar/StellarLikeAccount.cpp
+++ b/core/src/wallet/stellar/StellarLikeAccount.cpp
@@ -439,9 +439,17 @@ namespace ledger {
             broadcastRawTransaction(tx).callback(getMainExecutionContext(), callback);
         }
 
-
         Future<std::string> StellarLikeAccount::broadcastRawTransaction(const std::vector<uint8_t> &tx) {
-            return _params.explorer->postTransaction(tx);
+            return _params.explorer->postTransaction(tx, "");
+        }
+
+        void StellarLikeAccount::broadcastTransaction(const std::shared_ptr<api::StellarLikeTransaction> &tx,
+                                                         const std::shared_ptr<api::StringCallback> &callback) {
+            broadcastTransaction(tx).callback(getMainExecutionContext(), callback);
+        }
+
+        Future<std::string> StellarLikeAccount::broadcastTransaction(const std::shared_ptr<api::StellarLikeTransaction> &tx) {
+            return _params.explorer->postTransaction(tx->toRawTransaction(), tx->getCorrelationId());
         }
 
         Future<bool> StellarLikeAccount::exists() {

--- a/core/src/wallet/stellar/StellarLikeAccount.hpp
+++ b/core/src/wallet/stellar/StellarLikeAccount.hpp
@@ -96,6 +96,10 @@ namespace ledger {
                                          const std::shared_ptr<api::StringCallback> &callback) override;
             Future<std::string> broadcastRawTransaction(const std::vector<uint8_t> &tx);
 
+            void broadcastTransaction(const std::shared_ptr<api::StellarLikeTransaction> &tx,
+                                         const std::shared_ptr<api::StringCallback> &callback) override;
+            Future<std::string> broadcastTransaction(const std::shared_ptr<api::StellarLikeTransaction> &tx);
+
             const StellarLikeAccountParams& params() const { return _params; };
 
             void getBaseReserve(const std::shared_ptr<api::AmountCallback> &callback) override;

--- a/core/src/wallet/stellar/explorers/HorizonBlockchainExplorer.cpp
+++ b/core/src/wallet/stellar/explorers/HorizonBlockchainExplorer.cpp
@@ -143,11 +143,15 @@ namespace ledger {
                     });
         }
 
-        Future<std::string> HorizonBlockchainExplorer::postTransaction(const std::vector<uint8_t> &tx) {
+        Future<std::string> HorizonBlockchainExplorer::postTransaction(const std::vector<uint8_t> &tx, const std::string& correlationId) {
             std::stringstream body;
             body << "tx=" << url::encodeUrlQuery(BaseConverter::encode(tx, BaseConverter::BASE64_RFC4648));
             auto bodyString = body.str();
-            return http->POST("/transactions", std::vector<uint8_t>(bodyString.begin(), bodyString.end()), {{"Content-Type", "application/x-www-form-urlencoded"}})
+            std::unordered_map<std::string, std::string> headers{{"Content-Type", "application/x-www-form-urlencoded"}};
+            if(!correlationId.empty()) {
+                headers["X-Correlation-ID"] = correlationId;
+            }
+            return http->POST("/transactions", std::vector<uint8_t>(bodyString.begin(), bodyString.end()), headers)
             .json().template map<std::string>(getContext(), [] (const HttpRequest::JsonResult& result) -> std::string {
                 auto& json = *std::get<1>(result);
                 return json["hash"].GetString();

--- a/core/src/wallet/stellar/explorers/HorizonBlockchainExplorer.hpp
+++ b/core/src/wallet/stellar/explorers/HorizonBlockchainExplorer.hpp
@@ -50,7 +50,7 @@ namespace ledger {
 
             Future<std::shared_ptr<stellar::Account>> getAccount(const std::string &accountId) const override;
 
-            Future<std::string> postTransaction(const std::vector<uint8_t> &tx) override;
+            Future<std::string> postTransaction(const std::vector<uint8_t> &tx, const std::string& correlationId = "") override;
         };
     }
 }

--- a/core/src/wallet/stellar/explorers/StellarLikeBlockchainExplorer.hpp
+++ b/core/src/wallet/stellar/explorers/StellarLikeBlockchainExplorer.hpp
@@ -58,7 +58,7 @@ namespace ledger {
                                                                                                const std::string& address,
                                                                                                const Option<std::string>& cursor) = 0;
             virtual Future<std::shared_ptr<stellar::Account>> getAccount(const std::string& accountId) const = 0;
-            virtual Future<std::string> postTransaction(const std::vector<uint8_t>& tx) = 0;
+            virtual Future<std::string> postTransaction(const std::vector<uint8_t>& tx, const std::string& correlationId) = 0;
 
         protected:
             std::shared_ptr<HttpClient> http;

--- a/core/src/wallet/stellar/transaction_builders/StellarLikeTransaction.cpp
+++ b/core/src/wallet/stellar/transaction_builders/StellarLikeTransaction.cpp
@@ -196,6 +196,16 @@ namespace ledger {
             return _envelope.type == stellar::xdr::EnvelopeType::ENVELOPE_TYPE_TX_V0;
         }
 
+        std::string StellarLikeTransaction::getCorrelationId() {
+            return _correlationId;
+        }
+
+        std::string StellarLikeTransaction::setCorrelationId(const std::string& newId)  {
+            auto oldId = _correlationId;
+            _correlationId = newId;
+            return oldId;
+        }
+
     }
 }
 

--- a/core/src/wallet/stellar/transaction_builders/StellarLikeTransaction.hpp
+++ b/core/src/wallet/stellar/transaction_builders/StellarLikeTransaction.hpp
@@ -80,9 +80,12 @@ namespace ledger {
             stellar::xdr::TransactionV0Envelope& getEnvelopeV0();
             stellar::xdr::TransactionV1Envelope& getEnvelopeV1();
 
+            std::string getCorrelationId() override;
+            std::string setCorrelationId(const std::string& newId) override;
         private:
             stellar::xdr::TransactionEnvelope _envelope;
             api::Currency _currency;
+            std::string _correlationId;
         };
     }
 }

--- a/core/src/wallet/stellar/transaction_builders/StellarLikeTransactionBuilder.hpp
+++ b/core/src/wallet/stellar/transaction_builders/StellarLikeTransactionBuilder.hpp
@@ -70,6 +70,9 @@ namespace ledger {
             std::shared_ptr<api::StellarLikeTransactionBuilder>
             setSequence(const std::shared_ptr<api::BigInt> &sequence) override;
 
+            std::shared_ptr<api::StellarLikeTransactionBuilder>
+            setCorrelationId(const std::string & correlationId) override;
+
             void build(const std::shared_ptr<api::StellarLikeTransactionCallback> &callback) override;
             FuturePtr<api::StellarLikeTransaction> build();
 
@@ -78,6 +81,7 @@ namespace ledger {
             stellar::xdr::TransactionV1Envelope _envelope;
             Option<uint64_t> _baseFee;
             BigInt _balanceChange;
+            std::string _correlationId;
 
         };
     }

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
@@ -436,5 +436,12 @@ namespace ledger {
         std::string TezosLikeTransactionApi::getCorrelationId() {
             return _correlationId;
         }
+
+        std::string TezosLikeTransactionApi::setCorrelationId(const std::string& newId)  {
+            auto oldId = _correlationId;
+            _correlationId = newId;
+            return oldId;
+        }
+
     }
 }

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
@@ -83,6 +83,8 @@ namespace ledger {
 
             std::string getCorrelationId() override;
 
+            std::string setCorrelationId(const std::string& newId) override;
+
             TezosLikeTransactionApi &setFees(const std::shared_ptr<BigInt> &fees);
 
             TezosLikeTransactionApi &setValue(const std::shared_ptr<BigInt> &value);


### PR DESCRIPTION
Those setters are necessary to be able to keep  a correlationId from a `POST /operations/sign` in the Wallet Daemon