### PR TITLE
Enable nix-based builds and CI

### DIFF
--- a/.github/workflows/nix_release_builds.yml
+++ b/.github/workflows/nix_release_builds.yml
@@ -1,0 +1,99 @@
+name: "Nix Release builds"
+on:
+  pull_request:
+    branches:
+      - release/4.0.0
+      - release/4.1.0
+      - release/4.2.0
+      - develop
+  push:
+    branches:
+      - release/4.0.0
+      - release/4.1.0
+      - release/4.2.0
+      - develop
+jobs:
+  libcore_version:
+    runs-on: ubuntu-latest
+    outputs:
+      lib_version: ${{ steps.lib_version.outputs.lib_version }}
+      deploy_jar: ${{ steps.lib_version.outputs.deploy_jar }}
+      deploy_dynlibs: ${{ steps.lib_version.outputs.deploy_dynlibs }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Set version slug and push_to_S3 flags
+        id: lib_version
+        run: bash nix/scripts/export_libcore_version.sh
+  Ubuntu_jni:
+    needs: libcore_version
+    runs-on: ubuntu-latest
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v2.3.4
+      with:
+        submodules: 'recursive'
+    - uses: cachix/install-nix-action@v13
+      with:
+        nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/5f746317f10f7206f1dbb8dfcfc2257b04507eee.tar.gz
+    - run: nix-build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ needs.libcore_version.outputs.lib_version }}-linux-libledgercore
+        path: result/lib/libledger-core.so
+        retention-days: 5
+  MacOS_jni:
+    needs: libcore_version
+    runs-on: macos-latest
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v2.3.4
+      with:
+        submodules: 'recursive'
+    - uses: cachix/install-nix-action@v13
+      with:
+        nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/5f746317f10f7206f1dbb8dfcfc2257b04507eee.tar.gz
+    - run: nix-build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ needs.libcore_version.outputs.lib_version }}-macos-libledgercore
+        path: result/lib/libledger-core.dylib
+        retention-days: 5
+  JAR:
+    needs: [Ubuntu_jni, MacOS_jni, libcore_version]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v2.3.4
+      with:
+        submodules: 'recursive'
+    - uses: cachix/install-nix-action@v13
+      with:
+        nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/5f746317f10f7206f1dbb8dfcfc2257b04507eee.tar.gz
+    - run: mkdir -p jar_build/src/main/resources/resources/djinni_native_libs
+    - name: Fetch Linux so
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ needs.libcore_version.outputs.lib_version }}-linux-libledgercore
+        path: jar_build/src/main/resources/resources/djinni_native_libs
+    - name: Fetch MacOS dylib
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ needs.libcore_version.outputs.lib_version }}-macos-libledgercore
+        path: jar_build/src/main/resources/resources/djinni_native_libs
+    - run: nix-shell --run "bash nix/scripts/build_jar_on_gha.sh" nix/gha-libcore-jar.nix
+      env:
+        LIB_VERSION: ${{ needs.libcore_version.outputs.lib_version }}
+        DEPLOY_JAR: ${{ needs.libcore_version.outputs.deploy_jar }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ needs.libcore_version.outputs.lib_version }}-ledger-lib-core.jar
+        path: jar_build/artifact/ledger-lib-core.jar

--- a/.github/workflows/nix_release_builds.yml
+++ b/.github/workflows/nix_release_builds.yml
@@ -12,6 +12,8 @@ on:
       - release/4.1.0
       - release/4.2.0
       - develop
+    tags:
+      - '*'
 jobs:
   libcore_version:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: "Nix Tests"
+on:
+  pull_request:
+    branches:
+      - release/4.0.0
+      - release/4.1.0
+      - release/4.2.0
+      - develop
+  push:
+    branches:
+      - release/4.0.0
+      - release/4.1.0
+      - release/4.2.0
+      - develop
+jobs:
+  Ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v2.3.4
+      with:
+        submodules: 'recursive'
+    - uses: cachix/install-nix-action@v13
+      with:
+        nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/5f746317f10f7206f1dbb8dfcfc2257b04507eee.tar.gz
+    - name: Build and run tests
+      run: nix-shell --run "bash nix/scripts/build_run_tests.sh" nix/test-shell.nix
+      env:
+        BUILD_LOAD_LIMIT: 3

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ nix-build
 Otherwise to run tests locally against your changes
 
 ``` sh
-nix-build --arg runTests true
+nix-build --arg runTests true --arg jni false
 ```
 
 ### Non nix builds
@@ -254,7 +254,13 @@ Libcore can be built for following OSes:
 
 ### Local tests
 
-The best way to run tests locally is to use Nix. If you don't want to, you can also provision the postgres
+The best way to run tests locally is to use Nix:
+
+``` sh
+nix-build --arg runTests true --arg jni false
+```
+
+If you don't want to, you can also provision the postgres
 test database if necessary, and then run `ctest`.
 
 ### CI

--- a/README.md
+++ b/README.md
@@ -1,29 +1,31 @@
 # Ledger Core Library
 
-* [Clone project](#clone-project)
-* [Dependencies](#dependencies)
-    * [Build](#build)
-    * [External dependencies:](#external-dependencies)
-* [Build of C++ library](#build-of-c-library)
-    * [Building for JNI](#building-for-jni)
-    * [Build library with PostgreSQL](#build-library-with-postgresql)
-* [Documentation](#documentation)
-* [Binding to node.js](#binding-to-nodejs)
-    * [Using the node module](#using-the-node-module)
-    * [Generating a new node module for your system](#generating-a-new-node-module-for-your-system)
-* [Support](#support)
-    * [Libcore:](#libcore)
-    * [Bindings:](#bindings)
-* [Developement guidelines](#developement-guidelines)
-    * [CI](#ci)
-* [Q/A and troubleshooting](#qa-and-troubleshooting)
-    * [I have updated an include file and test code doesn’t see the changes!](#i-have-updated-an-include-file-and-test-code-doesnt-see-the-changes)
-    * [I have upgraded my macOSX system and now I can’t compile anymore.](#i-have-upgraded-my-macosx-system-and-now-i-cant-compile-anymore)
-
 Core library which will be used by Ledger applications.
 
-> If you’re a developer and want to contribute, please refer to our [contribution guidelines]
-> specific documentation.
+> This project is considered "legacy", and no new coin support will arrive in the repo;
+> only updates related to currently supported protocols.
+
+  - [Clone project](#clone-project)
+  - [Dependencies](#dependencies)
+    - [Build](#build)
+    - [External dependencies:](#external-dependencies)
+  - [Build of C++ library](#build-of-c-library)
+    - [Nix build](#nix-build)
+    - [Non nix builds](#non-nix-builds)
+    - [Build library with PostgreSQL](#build-library-with-postgresql)
+  - [Documentation](#documentation)
+  - [Binding to node.js](#binding-to-nodejs)
+    - [Using the node module](#using-the-node-module)
+    - [Generating a new node module for your system](#generating-a-new-node-module-for-your-system)
+  - [Support](#support)
+    - [Libcore:](#libcore)
+    - [Bindings:](#bindings)
+  - [Developement guidelines](#developement-guidelines)
+    - [Local tests](#local-tests)
+    - [CI](#ci)
+  - [Q/A and troubleshooting](#qa-and-troubleshooting)
+    - [I have updated an include file and test code doesn’t see the changes!](#i-have-updated-an-include-file-and-test-code-doesnt-see-the-changes)
+    - [I have upgraded my macOSX system and now I can’t compile anymore.](#i-have-upgraded-my-macosx-system-and-now-i-cant-compile-anymore)
 
 ## Clone project
 
@@ -42,6 +44,8 @@ git submodule update
 
 ## Dependencies
 
+You can skip this dependencies step if you have [nix](https://nixos.org) installed.
+
 ### Build
 
 This project is based on **_cmake_** as a build system so you should install it before starting (at least version 3.7).
@@ -53,6 +57,39 @@ This project is based on **_cmake_** as a build system so you should install it 
 * Build on multiple Operating Systems is based on [polly](https://github.com/ruslo/polly) toolchains.
 
 ## Build of C++ library
+
+### Nix build
+
+If you have remote builders you can use them with the nix derivation [bundled in the repo](./default.nix)
+
+#### Using `nix-shell`
+
+The repository provides a [shell.nix](./shell.nix) that allows to get into an environment
+ready for build.
+
+``` sh
+nix-shell
+mkdir _build
+cd _build
+cmake .. -DSYS_OPENSSL=ON -DSYS_SECP256K1=ON -DPG_SUPPORT=ON
+make
+```
+
+#### Using `nix-build`
+
+If you just need the artifact you can build the derivation directly
+
+``` sh
+nix-build
+```
+
+Otherwise to run tests locally against your changes
+
+``` sh
+nix-build --arg runTests true
+```
+
+### Non nix builds
 
 **_cmake_** is building out of source, you should create a build directory (e.g. `lib-ledger-core-build`):
 
@@ -95,7 +132,7 @@ Several CMake arguments might interest you there:
   - `-G Xcode`: build libcore with Xcode on Mac
   - `-DBUILD_TESTS=OFF`: build libcore without unit tests. In this case, openssl arguments are not needed
 
-### Building for JNI
+#### Building for JNI
 
 Building with JNI (Java Native Interface), allows you to use the library with Java based software. In order to enable JNI mode use
 
@@ -112,6 +149,8 @@ This will add JNI files to the library compilation and remove tests. You need at
 Make sure that your have `PostgreSQL` installed on your machine, otherwise the `CMake` 
 command `find_package(PostgreSQL REQUIRED)` will fail during configuration.
 
+All Nix builds currently build with Postgres support by default.
+
 #### Build
 
 To compile libcore with PostgreSQL support, you should add `-DPG_SUPPORT=ON` to your 
@@ -119,6 +158,8 @@ To compile libcore with PostgreSQL support, you should add `-DPG_SUPPORT=ON` to 
 
 You also need to add `-DPostgreSQL_INCLUDE_DIR=path/to/include/dir` in your configuration
 as a hint for headers' location (e.g. `/usr/include/postgresql`).
+
+All Nix builds currently build with Postgres support by default.
 
 #### Wallet Pool Configuration
 
@@ -211,7 +252,14 @@ Libcore can be built for following OSes:
 
 ## Developement guidelines
 
+### Local tests
+
+The best way to run tests locally is to use Nix. If you don't want to, you can also provision the postgres
+test database if necessary, and then run `ctest`.
+
 ### CI
+
+#### Appveyor
 
 You are advised to link your GitHub account to both [CircleCI] and [Appveyor] by signing-in. Because
 we are using shared runners and resources, we have to share CI power with other teams. It’s
@@ -230,6 +278,8 @@ title**. You could tempted to put it in the body of your message but that will n
 Finally, it’s advised to put it on every commit and rebase at the end to remove the `[skip ci]` tag
 from your commits’ messags to have the CI re-enabled, but some runners might be smart enough to do
 it for all commits in the PR.
+
+#### Rebasing
 
 Rebasing is done easily. If your PR wants to merge `feature/stuff -> develop`, you can do something
 like this — assuming you have cloned the repository with a correctly set `origin` remote:

--- a/core/lib/CMakeLists.txt
+++ b/core/lib/CMakeLists.txt
@@ -5,8 +5,17 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 #list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/leveldb")
 
-
-include(ProjectSecp256k1)
+if (SYS_SECP256K1)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(SECP256K1 REQUIRED IMPORTED_TARGET GLOBAL libsecp256k1)
+  # Manually set the target's properties to use the static lib and tweak the include directory
+  set_property(TARGET PkgConfig::SECP256K1 PROPERTY IMPORTED_CONFIGURATIONS Release)
+  set_property(TARGET PkgConfig::SECP256K1 PROPERTY IMPORTED_LOCATION_RELEASE "${SECP256K1_STATIC_LIBRARIES}")
+  # Have to add '/..'
+  set_property(TARGET PkgConfig::SECP256K1 PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${SECP256K1_INCLUDEDIR}/..")
+else()
+  include(ProjectSecp256k1)
+endif()
 add_subdirectory(bigd)
 add_subdirectory(fmt)
 if (SYS_OPENSSL)

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -143,10 +143,14 @@ target_compile_definitions(ledger-core-interface INTERFACE SPDLOG_WCHAR_FILENAME
 target_link_libraries(ledger-core-interface INTERFACE spdlog)
 
 #Secp256k1
-target_link_libraries(ledger-core-interface INTERFACE
-        "${CMAKE_SOURCE_DIR}/core/lib/secp256k1/lib/${CMAKE_STATIC_LIBRARY_PREFIX}secp256k1${CMAKE_STATIC_LIBRARY_SUFFIX}")
-link_directories("${CMAKE_SOURCE_DIR}/core/lib/secp256k1/lib")
-add_dependencies(ledger-core-interface INTERFACE secp256k1)
+if (SYS_SECP256K1)
+  target_link_libraries(ledger-core-interface INTERFACE PkgConfig::SECP256K1)
+else()
+  target_link_libraries(ledger-core-interface INTERFACE
+          "${CMAKE_SOURCE_DIR}/core/lib/secp256k1/lib/${CMAKE_STATIC_LIBRARY_PREFIX}secp256k1${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  link_directories("${CMAKE_SOURCE_DIR}/core/lib/secp256k1/lib")
+  add_dependencies(ledger-core-interface INTERFACE secp256k1)
+endif()
 
 target_link_libraries(ledger-core-interface INTERFACE ethash)
 

--- a/core/src/wallet/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.cpp
+++ b/core/src/wallet/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.cpp
@@ -97,10 +97,10 @@ namespace ledger {
             }
             // Fetch inputs
             rowset<soci::row> inputRows = (sql.prepare <<
-                "SELECT  ti.input_idx, i.previous_output_idx, i.previous_tx_hash, i.amount, i.address, i.coinbase,"
+                "SELECT DISTINCT ON(ti.input_idx) ti.input_idx, i.previous_output_idx, i.previous_tx_hash, i.amount, i.address, i.coinbase,"
                         "i.sequence "
                 "FROM bitcoin_transaction_inputs AS ti "
-                "JOIN bitcoin_inputs AS i ON ti.input_uid = i.uid "
+                "INNER JOIN bitcoin_inputs AS i ON ti.input_uid = i.uid "
                 "WHERE ti.transaction_hash = :hash ORDER BY ti.input_idx", use(out.hash)
             );
             for (auto& inputRow : inputRows) {

--- a/core/test/coin-integration/stellar/create_stellar_account_tests.cpp
+++ b/core/test/coin-integration/stellar/create_stellar_account_tests.cpp
@@ -33,7 +33,7 @@
 
 TEST_F(StellarFixture, CreateAccountWithPubKey) {
     auto pool = newPool();
-    auto wallet = newWallet(pool, "my_wallet", "stellar", api::DynamicObject::newInstance());
+    auto wallet = newWallet(pool, "stellar_wallet", "stellar", api::DynamicObject::newInstance());
     auto info = uv::wait(wallet->getNextAccountCreationInfo());
     auto a = newAccount(wallet, 0, defaultAccount());
     auto account = std::static_pointer_cast<AbstractAccount>(uv::wait(wallet->getAccount(0)));

--- a/core/test/cosmos/AccountTests.cpp
+++ b/core/test/cosmos/AccountTests.cpp
@@ -46,7 +46,7 @@ TEST_F(CosmosAccounts, DISABLED_FirstATOMAccountInfo) {
     auto pool = newDefaultPool();
     backend->enableQueryLogging(true);
 
-    auto wallet = uv::wait(pool->createWallet("my_wallet", currency.name, api::DynamicObject::newInstance()));
+    auto wallet = uv::wait(pool->createWallet(randomWalletName(), currency.name, api::DynamicObject::newInstance()));
     auto info = uv::wait(wallet->getNextAccountCreationInfo());
 
     EXPECT_EQ(info.index, 0);

--- a/core/test/database/query_builder_tests.cpp
+++ b/core/test/database/query_builder_tests.cpp
@@ -58,7 +58,8 @@ class QueryBuilderTest : public BaseFixture {
 TEST_F(QueryBuilderTest, SimpleOperationQuery) {
     auto pool = newDefaultPool();
     {
-        auto wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+        const auto walletName = "my_wallet";
+        auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin", api::DynamicObject::newInstance()));
         auto nextIndex = uv::wait(wallet->getNextAccountIndex());
         EXPECT_EQ(nextIndex, 0);
         auto account = createBitcoinLikeAccount(wallet, 0, P2PKH_MEDIUM_XPUB_INFO);

--- a/core/test/integration/BaseFixture.h
+++ b/core/test/integration/BaseFixture.h
@@ -100,7 +100,7 @@ class BaseFixture : public ::testing::Test {
 public:
     virtual void SetUp() override;
     virtual void TearDown() override;
-    std::shared_ptr<WalletPool> newDefaultPool(const std::string &poolName = "my_ppol",
+    std::shared_ptr<WalletPool> newDefaultPool(const std::string &poolName = "",
                                                const std::string &password = "test",
                                                const std::shared_ptr<api::DynamicObject> &configuration = api::DynamicObject::newInstance(),
                                                bool usePostgreSQL = false, bool httpclientMultiThread = false);
@@ -154,6 +154,13 @@ public:
     std::shared_ptr<ProxyHttpClient> http;
     std::shared_ptr<FakeWebSocketClient> ws;
     std::shared_ptr<OpenSSLRandomNumberGenerator> rng;
+
+    protected:
+    std::string randomWalletName() const;
+    std::string randomDBName() const;
+
+    private:
+    std::string randomName(const std::string& prefix, uint suffix_length = 10) const;
 };
 
 #endif //LEDGER_CORE_BASEFIXTURE_H

--- a/core/test/integration/account_info_test.cpp
+++ b/core/test/integration/account_info_test.cpp
@@ -37,78 +37,85 @@ class AccountInfoTests : public BaseFixture {
 
 TEST_F(AccountInfoTests, FirstAccountInfo) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", DynamicObject::newInstance()));
+    const auto walletName = "my_wallet_firstaccountinfo";
+    auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin", DynamicObject::newInstance()));
     auto info = uv::wait(wallet->getNextAccountCreationInfo());
     EXPECT_EQ(info.index, 0);
     EXPECT_EQ(info.owners[0], "main");
     EXPECT_EQ(info.derivations[0], "44'/0'");
     EXPECT_EQ(info.owners[1], "main");
     EXPECT_EQ(info.derivations[1], "44'/0'/0'");
-    uv::wait(pool->deleteWallet("my_wallet"));
+    uv::wait(pool->deleteWallet(walletName));
 }
 
 TEST_F(AccountInfoTests, FirstEthAccountInfo) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "ethereum", DynamicObject::newInstance()));
+    const auto walletName = "my_wallet_firstaccountinfo";
+    auto wallet = uv::wait(pool->createWallet(walletName, "ethereum", DynamicObject::newInstance()));
     auto info = uv::wait(wallet->getNextAccountCreationInfo());
     EXPECT_EQ(info.index, 0);
     EXPECT_EQ(info.owners[0], "main");
     EXPECT_EQ(info.derivations[0], "44'/60'/0'");
     //api::Configuration::KEYCHAIN_DERIVATION_SCHEME, "44'/<coin_type>'/<account>'/<node>/<address>"
-    uv::wait(pool->deleteWallet("my_wallet"));
+    uv::wait(pool->deleteWallet(walletName));
 }
 
 TEST_F(AccountInfoTests, FirstXRPAccountInfo) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "ripple", DynamicObject::newInstance()));
+    const auto walletName = "my_wallet_firstaccountinfo";
+    auto wallet = uv::wait(pool->createWallet(walletName, "ripple", DynamicObject::newInstance()));
     auto info = uv::wait(wallet->getNextAccountCreationInfo());
     EXPECT_EQ(info.index, 0);
     EXPECT_EQ(info.owners.size(), 1);
     EXPECT_EQ(info.derivations.size(), 1);
     EXPECT_EQ(info.owners[0], "main");
     EXPECT_EQ(info.derivations[0], "44'/144'/0'");
-    uv::wait(pool->deleteWallet("my_wallet"));
+    uv::wait(pool->deleteWallet(walletName));
 }
 
 TEST_F(AccountInfoTests, FirstXTZAccountInfo) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "tezos", DynamicObject::newInstance()));
+    const auto walletName = "my_wallet_firstaccountinfo";
+    auto wallet = uv::wait(pool->createWallet(walletName, "tezos", DynamicObject::newInstance()));
     auto info = uv::wait(wallet->getNextAccountCreationInfo());
     EXPECT_EQ(info.index, 0);
     EXPECT_EQ(info.owners.size(), 1);
     EXPECT_EQ(info.derivations.size(), 1);
     EXPECT_EQ(info.owners[0], "main");
     EXPECT_EQ(info.derivations[0], "44'/1729'/0'");
-    uv::wait(pool->deleteWallet("my_wallet"));
+    uv::wait(pool->deleteWallet(walletName));
 }
 
 TEST_F(AccountInfoTests, FirstEthCustomDerivationAccountInfo) {
     auto config = DynamicObject::newInstance();
     config->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME, "44'/<coin_type>'/<account>'/<node>/<address>");
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "ethereum", DynamicObject::newInstance()));
+    const auto walletName = "my_wallet_firstaccountinfo";
+    auto wallet = uv::wait(pool->createWallet(walletName, "ethereum", DynamicObject::newInstance()));
     auto info = uv::wait(wallet->getNextAccountCreationInfo());
     EXPECT_EQ(info.index, 0);
     EXPECT_EQ(info.owners[0], "main");
     EXPECT_EQ(info.derivations[0], "44'/60'/0'");
-    uv::wait(pool->deleteWallet("my_wallet"));
+    uv::wait(pool->deleteWallet(walletName));
 }
 
 TEST_F(AccountInfoTests, AnotherAccountInfo) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", DynamicObject::newInstance()));
+    const auto walletName = "my_wallet_firstaccountinfo";
+    auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin", DynamicObject::newInstance()));
     auto info = uv::wait(wallet->getAccountCreationInfo(20));
     EXPECT_EQ(info.index, 20);
     EXPECT_EQ(info.owners[0], "main");
     EXPECT_EQ(info.derivations[0], "44'/0'");
     EXPECT_EQ(info.owners[1], "main");
     EXPECT_EQ(info.derivations[1], "44'/0'/20'");
-    uv::wait(pool->deleteWallet("my_wallet"));
+    uv::wait(pool->deleteWallet(walletName));
 }
 
 TEST_F(AccountInfoTests, GetAddressFromRange) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", DynamicObject::newInstance()));
+    const auto walletName = "my_wallet_addressFromRange";
+    auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin", DynamicObject::newInstance()));
     auto account = createBitcoinLikeAccount(wallet, 0, P2PKH_MEDIUM_XPUB_INFO);
 
     auto freshAddresses = uv::wait(account->getFreshPublicAddresses());
@@ -126,5 +133,5 @@ TEST_F(AccountInfoTests, GetAddressFromRange) {
     }
 
     EXPECT_EQ(addresses[2 * (to - from + 1) - 1]->toString(), "1167QbGjTWVK3etniJwua6wybBKkS7Lr8w");
-    uv::wait(pool->deleteWallet("my_wallet"));
+    uv::wait(pool->deleteWallet(walletName));
 }

--- a/core/test/integration/accounts_public_interfaces_test.cpp
+++ b/core/test/integration/accounts_public_interfaces_test.cpp
@@ -41,23 +41,25 @@ class AccountsPublicInterfaceTest : public BaseFixture {
 public:
     void SetUp() override {
         BaseFixture::SetUp();
+        walletName = randomWalletName();
         recreate();
     }
 
     void recreate() {
         pool = newDefaultPool();
-        wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", DynamicObject::newInstance()));
+        wallet = uv::wait(pool->createWallet(walletName, "bitcoin", DynamicObject::newInstance()));
     }
 
     void TearDown() override {
         BaseFixture::TearDown();
-        uv::wait(pool->deleteWallet("my_wallet"));
+        uv::wait(pool->deleteWallet(walletName));
         pool = nullptr;
         wallet = nullptr;
     }
 
     std::shared_ptr<WalletPool> pool;
     std::shared_ptr<AbstractWallet> wallet;
+    std::string walletName;
 };
 
 TEST_F(AccountsPublicInterfaceTest, GetAddressOnEmptyAccount) {

--- a/core/test/integration/pool_tests.cpp
+++ b/core/test/integration/pool_tests.cpp
@@ -157,17 +157,17 @@ TEST_F(WalletPoolTest, RemoveCurrency) {
 }
 
 TEST_F(WalletPoolTest, CreateAndGetWallet) {
+    auto pool = newDefaultPool();
+    const auto walletName = randomWalletName();
     {
-        auto pool = newDefaultPool();
-        auto wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", DynamicObject::newInstance()));
-        auto getWallet = uv::wait(pool->getWallet("my_wallet"));
+        auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin", DynamicObject::newInstance()));
+        auto getWallet = uv::wait(pool->getWallet(walletName));
         EXPECT_TRUE(wallet.get() == getWallet.get());
     }
     {
-        auto pool = newDefaultPool();
-        auto getWallet = uv::wait(pool->getWallet("my_wallet"));
-        EXPECT_TRUE(getWallet->getName() == "my_wallet");
+        auto getWallet = uv::wait(pool->getWallet(walletName));
+        EXPECT_TRUE(getWallet->getName() == walletName);
         auto wallets = uv::wait(pool->getWallets(0, 1));
-        EXPECT_TRUE(wallets.front()->getName() == "my_wallet");
+        EXPECT_TRUE(wallets.front()->getName() == walletName);
     }
 }

--- a/core/test/integration/synchronization/synchronization_P2SH_tests.cpp
+++ b/core/test/integration/synchronization/synchronization_P2SH_tests.cpp
@@ -156,6 +156,7 @@ TEST_F(BitcoinLikeWalletP2SHSynchronization, SynchronizeFromLastBlock) {
 
 TEST_F(BitcoinLikeWalletP2SHSynchronization, EraseDataSinceAfterSynchronization) {
     auto pool = newDefaultPool();
+    const auto walletName = randomWalletName();
     {
         //Set configuration
         auto configuration = DynamicObject::newInstance();
@@ -163,7 +164,7 @@ TEST_F(BitcoinLikeWalletP2SHSynchronization, EraseDataSinceAfterSynchronization)
         configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,
                                  "49'/<coin_type>'/<account>'/<node>/<address>");
         //Create wallet
-        auto wallet = uv::wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a63", "bitcoin_testnet", configuration));
+        auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin_testnet", configuration));
         //Create account
         auto account = createBitcoinLikeAccount(wallet, 0, P2SH_XPUB_INFO);
         //Sync account

--- a/core/test/integration/synchronization/synchronization_tests.cpp
+++ b/core/test/integration/synchronization/synchronization_tests.cpp
@@ -125,10 +125,11 @@ TEST_F(BitcoinLikeWalletSynchronization, MediumXpubSynchronization) {
 
 TEST_F(BitcoinLikeWalletSynchronization, MediumDGBXpubSynchronization) {
     auto pool = newDefaultPool();
+    const auto walletName = randomWalletName();
     {
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::KEYCHAIN_ENGINE,api::KeychainEngines::BIP173_P2WPKH);
-        auto wallet = uv::wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "digibyte", configuration));
+        auto wallet = uv::wait(pool->createWallet(walletName, "digibyte", configuration));
         {
             auto nextIndex = uv::wait(wallet->getNextAccountIndex());
             EXPECT_EQ(nextIndex, 0);
@@ -154,12 +155,13 @@ TEST_F(BitcoinLikeWalletSynchronization, MediumDGBXpubSynchronization) {
 
 TEST_F(BitcoinLikeWalletSynchronization, MediumLTCXpubSynchronization) {
     auto pool = newDefaultPool();
+    const auto walletName = randomWalletName();
     {
         auto configuration = DynamicObject::newInstance();
         //configuration->putString(api::Configuration::KEYCHAIN_ENGINE,api::KeychainEngines::BIP173_P2WPKH);
         configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_VERSION, "v3");
         configuration->putBoolean(api::Configuration::DEACTIVATE_SYNC_TOKEN, true);
-        auto wallet = uv::wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "litecoin", configuration));
+        auto wallet = uv::wait(pool->createWallet(walletName, "litecoin", configuration));
         {
             auto nextIndex = uv::wait(wallet->getNextAccountIndex());
             EXPECT_EQ(nextIndex, 0);
@@ -187,10 +189,11 @@ TEST_F(BitcoinLikeWalletSynchronization, MediumLTCXpubSynchronization) {
 
 TEST_F(BitcoinLikeWalletSynchronization, SynchronizeOnceAtATime) {
     auto pool = newDefaultPool();
+    const auto walletName = randomWalletName();
     {
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_VERSION, "v3");
-        auto wallet = uv::wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a62", "bitcoin", configuration));
+        auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin", configuration));
         {
             auto nextIndex = uv::wait(wallet->getNextAccountIndex());
             EXPECT_EQ(nextIndex, 0);
@@ -223,8 +226,9 @@ TEST_F(BitcoinLikeWalletSynchronization, SynchronizeAndFreshResetAll) {
     {
         auto pool = newDefaultPool();
         auto configuration = DynamicObject::newInstance();
+        const auto walletName = randomWalletName();
         configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_VERSION, "v3");
-        auto wallet = uv::wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a62", "bitcoin", configuration));
+        auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin", configuration));
         {
             auto nextIndex = uv::wait(wallet->getNextAccountIndex());
             EXPECT_EQ(nextIndex, 0);
@@ -264,7 +268,8 @@ TEST_F(BitcoinLikeWalletSynchronization, DISABLED_SynchronizeFromLastBlock) {
     {
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_VERSION, "v3");
-        auto wallet = uv::wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a63", "bitcoin", configuration));
+        const auto walletName = randomWalletName();
+        auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin", configuration));
         createBitcoinLikeAccount(wallet, 0, P2PKH_MEDIUM_XPUB_INFO);
         auto synchronize = [wallet, pool, this] (std::shared_ptr<uv::SequentialExecutionContext> context, bool expectNewOp) {
             auto account = uv::wait(wallet->getAccount(0));
@@ -304,7 +309,8 @@ TEST_F(BitcoinLikeWalletSynchronization, DISABLED_SynchronizeFromLastBlock) {
 TEST_F(BitcoinLikeWalletSynchronization, TestNetSynchronization) {
     auto pool = newDefaultPool();
     {
-        auto wallet = uv::wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "bitcoin_testnet",
+        const auto walletName = randomWalletName();
+        auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin_testnet",
                                               api::DynamicObject::newInstance()));
         {
             auto nextIndex = uv::wait(wallet->getNextAccountIndex());
@@ -347,7 +353,8 @@ TEST_F(BitcoinLikeWalletSynchronization, TestNetSynchronization) {
 TEST_F(BitcoinLikeWalletSynchronization, MultipleSynchronization) {
     auto pool = newDefaultPool();
     {
-        auto wallet = uv::wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "bitcoin",
+        const auto walletName = randomWalletName();
+        auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin",
                                               api::DynamicObject::newInstance()));
         std::vector<std::string> xpubs = {
                 P2PKH_MEDIUM_XPUB_INFO.extendedKeys[0]
@@ -392,7 +399,8 @@ TEST_F(BitcoinLikeWalletSynchronization, MultipleSynchronization) {
 TEST_F(BitcoinLikeWalletSynchronization, SynchronizationAfterErase) {
     auto pool = newDefaultPool();
     {
-        auto wallet = uv::wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a61", "bitcoin",
+        const auto walletName = randomWalletName();
+        auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin",
                                               api::DynamicObject::newInstance()));
 
         auto nextIndex = uv::wait(wallet->getNextAccountIndex());
@@ -444,7 +452,8 @@ TEST_F(BitcoinLikeWalletSynchronization, SynchronizationAfterErase) {
 
 TEST_F(BitcoinLikeWalletSynchronization, BTCParsingAndSerialization) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("testnet_wallet", "bitcoin", DynamicObject::newInstance()));
+    const auto walletName = randomWalletName();
+    auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin", DynamicObject::newInstance()));
     {
         auto strTx = "0100000001c76ec87ab18aa0398a2cbfa68625576fdc3bf276b467fc016010ad675678157d010000006b483045022100e0c4a6449841f4a435b23dc2cd4a6c26a8e12e25783dbd02072332c794012ca202202246876625e726ef9a89f854d59d2aee1787c9807d82d953732e56dbc296657001210212b8ae5848c5ce1422643aed011c9b1cbb7da9a5feba0cad0c130a11e8c4091dffffffff02400d03000000000017a914b800848ce7130e91d55422e1f3d72e813dc250e187b9dc2b00000000001976a9140265b33d266d56c25416d493ccb42992faa3f24a88ac00000000";
         auto tx = BitcoinLikeTransactionApi::parseRawSignedTransaction(wallet->getCurrency(), hex::toByteArray(strTx), 0);
@@ -454,7 +463,8 @@ TEST_F(BitcoinLikeWalletSynchronization, BTCParsingAndSerialization) {
 
 TEST_F(BitcoinLikeWalletSynchronization, XSTParsingAndSerialization) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("testnet_wallet", "stealthcoin", DynamicObject::newInstance()));
+    const auto walletName = randomWalletName();
+    auto wallet = uv::wait(pool->createWallet(walletName, "stealthcoin", DynamicObject::newInstance()));
     {
         auto strTx = "01000000ae71115b01f9d2e90eef51048962392b2ac2cbe476aacb06d750e0794aeb5da5a2afaf19da000000006b483045022100be2faab00cc32a4f6f0249d70f3b6d1fc66bf50dcd6ae011d0287a4a581e5c7a02203cd71132619de1e8a1a84c481529f32d4e29b495f835d5b0da7655203a0a7dda01210269568d231762330f7aed9cf0acfb2512f2d7889eb18adb778589ab5cca66fb3dffffffff0200127a00000000001976a914b4949cd1e6c07826ceee84929a7c6babcccc5ec388ac6094b500000000001976a91417cb2228c292d617f98f4b89b448650e0a480e0788ac00000000";
         auto txHash = "38fcb406a0110c50465edb482bab8d6100e7f9fa7e3ae01e48145c60fd51d00b";
@@ -476,8 +486,9 @@ TEST_F(BitcoinLikeWalletSynchronization, GetSelfRecipients) {
         0, {"main"}, {"44'/0'/0'"}, {"xpub6D4waFVPfPCpRvPkQd9A6n65z3hTp6TvkjnBHG5j2MCKytMuadKgfTUHqwRH77GQqCKTTsUXSZzGYxMGpWpJBdYAYVH75x7yMnwJvra1BUJ"}
 );
     auto pool = newDefaultPool();
+    const auto walletName = randomWalletName();
     {
-        auto wallet = uv::wait(pool->createWallet("self-recipients-wallet-test", "bitcoin", api::DynamicObject::newInstance()));
+        auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin", api::DynamicObject::newInstance()));
 
         auto nextIndex = uv::wait(wallet->getNextAccountIndex());
         auto info = uv::wait(wallet->getNextExtendedKeyAccountCreationInfo());
@@ -553,7 +564,8 @@ TEST_F(BitcoinLikeWalletSynchronization, SynchronizeOnFakeExplorer) {
         nullptr
     );
     {
-        auto wallet = uv::wait(pool->createWallet("e847815f-488a-4301-b67c-378a5e9c8a62", "bitcoin",
+        const auto walletName = randomWalletName();
+        auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin",
             api::DynamicObject::newInstance()));
         {
             auto nextIndex = uv::wait(wallet->getNextAccountIndex());
@@ -678,9 +690,10 @@ TEST_F(BitcoinLikeWalletSynchronization, SynchronizeAndFilterOperationsByBlockHe
 
 TEST_F(BitcoinLikeWalletSynchronization, SynchronizeWithMultiThreading) {
     // change to auto pool = newDefaultPool("my_ppol", "test", api::DynamicObject::newInstance(), false, false); if we want to test single thread http client
-    auto pool = newDefaultPool("my_ppol", "test", api::DynamicObject::newInstance(), false, true);
+    const auto walletName = randomWalletName();
+    auto pool = newDefaultPool(randomDBName(), "test", api::DynamicObject::newInstance(), false, true);
     {
-        auto wallet = uv::wait(pool->createWallet("e847815f-488a-4301-b67c-178a5e9c8a64", "bitcoin",
+        auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin",
             api::DynamicObject::newInstance()));
         auto synchronize = [wallet, pool, this]() {
             auto account = createBitcoinLikeAccount(wallet, 0, P2PKH_MEDIUM_XPUB_INFO);

--- a/core/test/integration/transactions/bitcoin_P2PKH_transaction_tests.cpp
+++ b/core/test/integration/transactions/bitcoin_P2PKH_transaction_tests.cpp
@@ -48,7 +48,7 @@ struct BitcoinMakeP2PKHTransaction : public BitcoinMakeBaseTransaction {
     void SetUpConfig() override {
         testData.configuration = DynamicObject::newInstance();
         testData.configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_VERSION, "v3");
-        testData.walletName = "my_wallet";
+        testData.walletName = randomWalletName();
         testData.currencyName = "bitcoin";
         testData.inflate_btc = ledger::testing::medium_xpub::inflate;
     }
@@ -81,7 +81,7 @@ struct BitcoinStardustTransaction : public BitcoinMakeBaseTransaction {
 
         testData.configuration = DynamicObject::newInstance();
         testData.configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_VERSION, "v3");
-        testData.walletName = "my_wallet";
+        testData.walletName = randomWalletName();
         testData.currencyName = "bitcoin_stardust";
         testData.inflate_btc = ledger::testing::medium_xpub::inflate;
     }
@@ -181,7 +181,7 @@ TEST_F(BitcoinMakeP2PKHTransaction, CreateStandardP2PKHWithMultipleInputs) {
 }
 
 TEST_F(BitcoinMakeP2PKHTransaction, Toto) {
-    std::shared_ptr<AbstractWallet> w = uv::wait(pool->createWallet("my_btc_wallet", "bitcoin_testnet", DynamicObject::newInstance()));
+    std::shared_ptr<AbstractWallet> w = uv::wait(pool->createWallet("my_btc_wallet_toto", "bitcoin_testnet", DynamicObject::newInstance()));
     api::ExtendedKeyAccountCreationInfo info = uv::wait(w->getNextExtendedKeyAccountCreationInfo());
     info.extendedKeys.push_back("tpubDCJarhe7f951cUufTWeGKh1w6hDgdBcJfvQgyMczbxWvwvLdryxZuchuNK3KmTKXwBNH6Ze6tHGrUqvKGJd1VvSZUhTVx58DrLn9hR16DVr");
     std::shared_ptr<AbstractAccount> account = std::dynamic_pointer_cast<AbstractAccount>(uv::wait(w->newAccountWithExtendedKeyInfo(info)));
@@ -219,7 +219,7 @@ TEST_F(BitcoinMakeP2PKHTransaction, Toto) {
 struct BCHMakeP2PKHTransaction : public BitcoinMakeBaseTransaction {
     void SetUpConfig() override {
         testData.configuration = DynamicObject::newInstance();
-        testData.walletName = "my_wallet";
+        testData.walletName = randomWalletName();
         testData.currencyName = "bitcoin_cash";
         testData.inflate_btc = ledger::testing::bch_xpub::inflate;
     }
@@ -248,7 +248,7 @@ TEST_F(BCHMakeP2PKHTransaction, CreateStandardP2SHWithOneOutput) {
 struct ZCASHMakeP2PKHTransaction : public BitcoinMakeBaseTransaction {
     void SetUpConfig() override {
         testData.configuration = DynamicObject::newInstance();
-        testData.walletName = "my_wallet";
+        testData.walletName = randomWalletName();
         testData.currencyName = "zcash";
         testData.inflate_btc = ledger::testing::zec_xpub::inflate;
     }

--- a/core/test/integration/transactions/bitcoin_P2SH_transaction_tests.cpp
+++ b/core/test/integration/transactions/bitcoin_P2SH_transaction_tests.cpp
@@ -48,7 +48,7 @@ struct BitcoinMakeP2SHTransaction : public BitcoinMakeBaseTransaction {
         testData.configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_VERSION, "v3");
         testData.configuration->putString(api::Configuration::KEYCHAIN_ENGINE,api::KeychainEngines::BIP49_P2SH);
         testData.configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"49'/<coin_type>'/<account>'/<node>/<address>");
-        testData.walletName = "my_wallet";
+        testData.walletName = randomWalletName();
         testData.currencyName = "bitcoin_testnet";
         testData.inflate_btc = ledger::testing::testnet_xpub::inflate;
     }
@@ -107,7 +107,7 @@ struct BTGMakeP2SHTransaction : public BitcoinMakeBaseTransaction {
         testData.configuration = DynamicObject::newInstance();
         testData.configuration->putString(api::Configuration::KEYCHAIN_ENGINE,api::KeychainEngines::BIP49_P2SH);
         testData.configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"49'/<coin_type>'/<account>'/<node>/<address>");
-        testData.walletName = "my_wallet";
+        testData.walletName = randomWalletName();
         testData.currencyName = "bitcoin_gold";
         testData.inflate_btc = ledger::testing::btg_xpub::inflate;
     }

--- a/core/test/integration/transactions/bitcoin_P2WPKH_transaction_tests.cpp
+++ b/core/test/integration/transactions/bitcoin_P2WPKH_transaction_tests.cpp
@@ -42,7 +42,7 @@ struct BitcoinMakeP2WPKHTransaction : public BitcoinMakeBaseTransaction {
         testData.configuration->putString(api::Configuration::KEYCHAIN_ENGINE,api::KeychainEngines::BIP173_P2WPKH);
         //https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki
         testData.configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"84'/<coin_type>'/<account>'/<node>/<address>");
-        testData.walletName = "my_wallet";
+        testData.walletName = randomWalletName();
         testData.currencyName = "bitcoin";
         testData.inflate_btc = ledger::testing::medium_xpub::inflate;
     }

--- a/core/test/integration/transactions/bitcoin_P2WSH_transaction_tests.cpp
+++ b/core/test/integration/transactions/bitcoin_P2WSH_transaction_tests.cpp
@@ -40,7 +40,7 @@ struct BitcoinMakeP2WSHTransaction : public BitcoinMakeBaseTransaction {
     void SetUpConfig() override {
         testData.configuration = DynamicObject::newInstance();
         testData.configuration->putString(api::Configuration::KEYCHAIN_ENGINE,api::KeychainEngines::BIP173_P2WSH);
-        testData.walletName = "my_wallet";
+        testData.walletName = randomWalletName();
         testData.currencyName = "bitcoin";
         testData.inflate_btc = ledger::testing::medium_xpub::inflate;
     }

--- a/core/test/integration/transactions/coin_selection_P2PKH.cpp
+++ b/core/test/integration/transactions/coin_selection_P2PKH.cpp
@@ -41,7 +41,7 @@ struct CoinSelectionP2PKH : public BitcoinMakeBaseTransaction {
         testData.configuration->putString(api::Configuration::KEYCHAIN_ENGINE,api::KeychainEngines::BIP49_P2SH);
         testData.configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"49'/<coin_type>'/<account>'/<node>/<address>");
         testData.configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_VERSION, "v3");
-        testData.walletName = "my_wallet";
+        testData.walletName = randomWalletName();
         testData.currencyName = "bitcoin_testnet";
         testData.inflate_btc = ledger::testing::coin_selection_xpub::inflate;
     }

--- a/core/test/integration/transactions/ethereum_transaction_tests.cpp
+++ b/core/test/integration/transactions/ethereum_transaction_tests.cpp
@@ -45,7 +45,7 @@ struct EthereumMakeTransaction : public EthereumMakeBaseTransaction {
         auto configuration = DynamicObject::newInstance();
         configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_VERSION,"v2");
         testData.configuration = configuration;
-        testData.walletName = "my_wallet";
+        testData.walletName = randomWalletName();
         testData.currencyName = "ethereum";
         testData.inflate_eth = ledger::testing::eth_xpub::inflate;
     }

--- a/core/test/integration/transactions/optimisticupdate_xrp_tests.cpp
+++ b/core/test/integration/transactions/optimisticupdate_xrp_tests.cpp
@@ -77,7 +77,7 @@ TEST_F(RippleLikeOptimisticTransactionUpdate, BroadcastTransaction)
         configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,
                                  "44'/<coin_type>'/<account>'/<node>/<address>");
         configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT, "http://test.test");
-        auto wallet = uv::wait(pool->createWallet("my_wallet", "ripple", configuration));
+        auto wallet = uv::wait(pool->createWallet(randomWalletName(), "ripple", configuration));
         {
             auto account = createRippleLikeAccount(wallet, 0, XRP_KEYS_INFO);
             auto waiter = createSyncReceiver();

--- a/core/test/integration/transactions/ripple_transaction_tests.cpp
+++ b/core/test/integration/transactions/ripple_transaction_tests.cpp
@@ -44,7 +44,7 @@ struct RippleMakeTransaction : public RippleMakeBaseTransaction {
     void SetUpConfig() override {
         auto configuration = DynamicObject::newInstance();
         testData.configuration = configuration;
-        testData.walletName = "my_wallet";
+        testData.walletName = randomWalletName();
         testData.currencyName = "ripple";
         testData.inflate_xrp = ledger::testing::xrp::inflate;
     }

--- a/core/test/integration/transactions/tezos_transaction_tests.cpp
+++ b/core/test/integration/transactions/tezos_transaction_tests.cpp
@@ -50,7 +50,7 @@ struct TezosMakeTransaction : public TezosMakeBaseTransaction {
         configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, api::BlockchainExplorerEngines::TZSTATS_API);
         configuration->putString(api::TezosConfiguration::TEZOS_XPUB_CURVE, api::TezosConfigurationDefaults::TEZOS_XPUB_CURVE_ED25519);
         testData.configuration = configuration;
-        testData.walletName = "my_wallet";
+        testData.walletName = randomWalletName();
         testData.currencyName = "tezos";
         testData.inflate_xtz = ledger::testing::xtz::inflate;
     }

--- a/core/test/integration/wallet_tests.cpp
+++ b/core/test/integration/wallet_tests.cpp
@@ -37,7 +37,7 @@ class WalletTests : public BaseFixture {
 
 TEST_F(WalletTests, CreateNewWallet) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+    auto wallet = uv::wait(pool->createWallet(randomWalletName(), "bitcoin", api::DynamicObject::newInstance()));
     EXPECT_EQ(wallet->getCurrency().name, "bitcoin");
     EXPECT_EQ(wallet->getWalletType(), api::WalletType::BITCOIN);
     auto bitcoinWallet = std::dynamic_pointer_cast<BitcoinLikeWallet>(wallet);
@@ -46,7 +46,7 @@ TEST_F(WalletTests, CreateNewWallet) {
 
 TEST_F(WalletTests, GetAccountWithSameInstance) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+    auto wallet = uv::wait(pool->createWallet(randomWalletName(), "bitcoin", api::DynamicObject::newInstance()));
     auto account = createBitcoinLikeAccount(wallet, 0, P2PKH_MEDIUM_XPUB_INFO);
     auto fetchedAccount = std::dynamic_pointer_cast<BitcoinLikeAccount>(uv::wait(wallet->getAccount(0)));
     EXPECT_EQ(account.get(), fetchedAccount.get());
@@ -55,13 +55,13 @@ TEST_F(WalletTests, GetAccountWithSameInstance) {
 
 TEST_F(WalletTests, GetAccountOnEmptyWallet) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+    auto wallet = uv::wait(pool->createWallet(randomWalletName(), "bitcoin", api::DynamicObject::newInstance()));
     EXPECT_THROW(uv::wait(wallet->getAccount(0)), Exception);
 }
 
 TEST_F(WalletTests, GetMultipleAccounts) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+    auto wallet = uv::wait(pool->createWallet(randomWalletName(), "bitcoin", api::DynamicObject::newInstance()));
     for (auto i = 0; i < 5; i++)
         createBitcoinLikeAccount(wallet, i, P2PKH_MEDIUM_XPUB_INFO);
     auto accounts = uv::wait(wallet->getAccounts(0, 5));
@@ -70,7 +70,7 @@ TEST_F(WalletTests, GetMultipleAccounts) {
 
 TEST_F(WalletTests, GetTooManyMultipleAccounts) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+    auto wallet = uv::wait(pool->createWallet(randomWalletName(), "bitcoin", api::DynamicObject::newInstance()));
     for (auto i = 0; i < 5; i++)
         createBitcoinLikeAccount(wallet, i, P2PKH_MEDIUM_XPUB_INFO);
     EXPECT_EQ(uv::wait(wallet->getAccounts(0, 10)).size(), 5);
@@ -78,15 +78,15 @@ TEST_F(WalletTests, GetTooManyMultipleAccounts) {
 
 TEST_F(WalletTests, GetAccountAfterPoolReopen) {
     std::string addr;
+    const auto walletName = randomWalletName();
+    auto pool = newDefaultPool();
     {
-        auto pool = newDefaultPool();
-        auto wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+        auto wallet = uv::wait(pool->createWallet(walletName, "bitcoin", api::DynamicObject::newInstance()));
         auto account = createBitcoinLikeAccount(wallet, 0, P2PKH_MEDIUM_XPUB_INFO);
         addr = uv::wait(account->getFreshPublicAddresses())[0]->toString();
     }
     {
-        auto pool = newDefaultPool();
-        auto wallet = uv::wait(pool->getWallet("my_wallet"));
+        auto wallet = uv::wait(pool->getWallet(walletName));
         auto account = std::dynamic_pointer_cast<AbstractAccount>(uv::wait(wallet->getAccount(0)));
         EXPECT_EQ(uv::wait(account->getFreshPublicAddresses())[0]->toString(), addr);
     }
@@ -94,7 +94,7 @@ TEST_F(WalletTests, GetAccountAfterPoolReopen) {
 
 TEST_F(WalletTests, CreateNonContiguousAccount) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+    auto wallet = uv::wait(pool->createWallet(randomWalletName(), "bitcoin", api::DynamicObject::newInstance()));
     auto account = createBitcoinLikeAccount(wallet, 6, P2PKH_MEDIUM_XPUB_INFO);
     auto fetchedAccount = std::dynamic_pointer_cast<AbstractAccount>(uv::wait(wallet->getAccount(6)));
     EXPECT_EQ(uv::wait(account->getFreshPublicAddresses())[0]->toString(), uv::wait(fetchedAccount->getFreshPublicAddresses())[0]->toString());
@@ -106,7 +106,7 @@ TEST_F(WalletTests, CreateNonContiguousAccount) {
 
 TEST_F(WalletTests, CreateNonContiguousAccountBis) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+    auto wallet = uv::wait(pool->createWallet(randomWalletName(), "bitcoin", api::DynamicObject::newInstance()));
     auto account1 = createBitcoinLikeAccount(wallet, 0, P2PKH_MEDIUM_XPUB_INFO);
     auto account2 = createBitcoinLikeAccount(wallet, 6, P2PKH_MEDIUM_XPUB_INFO);
     auto account3 = createBitcoinLikeAccount(wallet, 4, P2PKH_MEDIUM_XPUB_INFO);
@@ -114,7 +114,7 @@ TEST_F(WalletTests, CreateNonContiguousAccountBis) {
 
 TEST_F(WalletTests, CreateAccountBug) {
     auto pool = newDefaultPool();
-    auto wallet = uv::wait(pool->createWallet("my_wallet", "bitcoin", api::DynamicObject::newInstance()));
+    auto wallet = uv::wait(pool->createWallet(randomWalletName(), "bitcoin", api::DynamicObject::newInstance()));
     auto list = [pool, this] () -> Future<Unit> {
         return pool->getWalletCount().flatMap<std::vector<std::shared_ptr<AbstractWallet>>>(dispatcher->getMainExecutionContext(), [pool] (const int64_t& count) -> Future<std::vector<std::shared_ptr<AbstractWallet>>> {
             return pool->getWallets(0, count);
@@ -151,7 +151,7 @@ TEST_F(WalletTests, CreateAccountBug) {
 
 TEST_F(WalletTests, ChangeWalletConfig) {
     auto pool = newDefaultPool();
-    auto walletName = "my_wallet";
+    auto walletName = randomWalletName();
     auto derivationScheme = "44'/<coin_type>'/<account>'/<node>/<address>";
     {
         auto oldEndpoint = "http://eth-ropsten.explorers.dev.aws.ledger.fr";

--- a/core/test/tezos/CMakeLists.txt
+++ b/core/test/tezos/CMakeLists.txt
@@ -1,8 +1,9 @@
 set( TEZOS_TESTS_NAME "ledger-core-tezos-tests" )
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.15)
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 include_directories(${CMAKE_BINARY_DIR}/include)
+include(GoogleTest)
 
 if (APPLE)
     add_definitions(-DGTEST_USE_OWN_TR1_TUPLE)
@@ -41,4 +42,5 @@ if (SYS_OPENSSL)
 else()
     copy_install_imported_targets(ledger-core-tezos-tests crypto ledger-core)
 endif()
-add_test (NAME ${TEZOS_TESTS_NAME} COMMAND ${TEZOS_TESTS_NAME})
+
+gtest_discover_tests(${TEZOS_TESTS_NAME})

--- a/core/test/tezos/ED25519_transaction_test.cpp
+++ b/core/test/tezos/ED25519_transaction_test.cpp
@@ -54,7 +54,7 @@ struct ED25519TezosMakeTransaction : public TezosMakeBaseTransaction {
         configuration->putString(api::TezosConfiguration::TEZOS_XPUB_CURVE, api::TezosConfigurationDefaults::TEZOS_XPUB_CURVE_ED25519);
         configuration->putString(api::TezosConfiguration::TEZOS_PROTOCOL_UPDATE, api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON);
         testData.configuration = configuration;
-        testData.walletName = "my_wallet";
+        testData.walletName = "my_wallet_ed25519tezos";
         testData.currencyName = "tezos";
         testData.inflate_xtz = inflate_ED25519;
     }

--- a/core/test/tezos/P256_transaction_test.cpp
+++ b/core/test/tezos/P256_transaction_test.cpp
@@ -55,7 +55,7 @@ struct P256TezosMakeTransaction : public TezosMakeBaseTransaction {
         configuration->putString(api::TezosConfiguration::TEZOS_XPUB_CURVE, api::TezosConfigurationDefaults::TEZOS_XPUB_CURVE_P256);
         configuration->putString(api::TezosConfiguration::TEZOS_PROTOCOL_UPDATE, api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON);
         testData.configuration = configuration;
-        testData.walletName = "my_wallet";
+        testData.walletName = "my_wallet_p256_tezos";
         testData.currencyName = "tezos";
         testData.inflate_xtz = inflate_P256;
     }

--- a/core/test/tezos/SECP256K1_transaction_test.cpp
+++ b/core/test/tezos/SECP256K1_transaction_test.cpp
@@ -55,7 +55,7 @@ struct SECP256K1TezosMakeTransaction : public TezosMakeBaseTransaction {
         configuration->putString(api::TezosConfiguration::TEZOS_PROTOCOL_UPDATE, api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON);
         configuration->putString(api::TezosConfiguration::TEZOS_COUNTER_STRATEGY, "OPTIMISTIC");
         testData.configuration = configuration;
-        testData.walletName = "my_wallet";
+        testData.walletName = randomWalletName();
         testData.currencyName = "tezos";
         testData.inflate_xtz = inflate_SECP256K1;
     }

--- a/core/test/tezos/address_test.cpp
+++ b/core/test/tezos/address_test.cpp
@@ -116,8 +116,9 @@ TEST_P(AddressTest, AddressValidation) {
 TEST_F(AddressFeaturesTest, isDelegate) {
     auto pool = newDefaultPool();
     auto configuration = DynamicObject::newInstance();
-    configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, api::BlockchainExplorerEngines::TZSTATS_API);    
-    auto wallet = std::dynamic_pointer_cast<TezosLikeWallet>(uv::wait(pool->createWallet("my_wallet", "tezos", configuration)));
+    configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, api::BlockchainExplorerEngines::TZSTATS_API);
+    const auto walletName = "my_wallet_isDelegate";
+    auto wallet = std::dynamic_pointer_cast<TezosLikeWallet>(uv::wait(pool->createWallet(walletName, "tezos", configuration)));
     EXPECT_EQ(uv::wait(wallet->isDelegate("tz3bnhbn7uYfL43zfXtBvCYoq6DW743mRWvc")), false);
     EXPECT_EQ(uv::wait(wallet->isDelegate("tz1PWCDnz783NNGGQjEFFsHtrcK5yBW4E2rm")), true);
     EXPECT_ANY_THROW(uv::wait(wallet->isDelegate("tz2xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")));

--- a/core/test/tezos/transaction_test.cpp
+++ b/core/test/tezos/transaction_test.cpp
@@ -89,8 +89,7 @@ std::shared_ptr<TezosLikeTransactionBuilder> TezosMakeBaseTransaction::tx_builde
 
 struct TransactionTest : public TezosBaseTest {};
 
-/*
-TEST_F(TransactionTest, ParseUnsignedRawRevealTransaction) {
+TEST_F(TransactionTest, DISABLED_ParseUnsignedRawRevealTransaction) {
     // round-trip
     auto strTx = "03a43f08f2b1d38e7c2762fc1b123b3ab772ae34669c2b541a0f7e96a104341e94070000d2e495a7ab40156d0a7c35b73d2530a3470fc870ea0902904e0000cda3081bd81219ec494b29068dcfd19e427fed9a66abcdc9e9e99ca6478f60e9";
     auto txBytes = hex::toByteArray(strTx);
@@ -107,7 +106,7 @@ TEST_F(TransactionTest, ParseUnsignedRawRevealTransaction) {
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
 }
 
-TEST_F(TransactionTest, ParseUnsignedRawOriginationTransaction) {
+TEST_F(TransactionTest, DISABLED_ParseUnsignedRawOriginationTransaction) {
     // round-trip
     auto strTx = "03a43f08f2b1d38e7c2762fc1b123b3ab772ae34669c2b541a0f7e96a104341e94090000d2e495a7ab40156d0a7c35b73d2530a3470fc870920903f44e950200d2e495a7ab40156d0a7c35b73d2530a3470fc8708094ebdc03ffff0000";
     auto txBytes = hex::toByteArray(strTx);
@@ -124,7 +123,7 @@ TEST_F(TransactionTest, ParseUnsignedRawOriginationTransaction) {
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "277");
 }
 
-TEST_F(TransactionTest, ParseUnsignedRawDelegationTransaction) {
+TEST_F(TransactionTest, DISABLED_ParseUnsignedRawDelegationTransaction) {
     // round-trip
     auto strTx = "037d8d230a91d1fb8391727f37a1bfeb332b7f249c78315ea4ae934e2103a826630a01d315f72434520d43d415f0dff4632519501d2d9400890902f44e00ff008bd703c4a2d91b8f1d79455be9b99c2693e931fd";
     auto txBytes = hex::toByteArray(strTx);
@@ -143,7 +142,7 @@ TEST_F(TransactionTest, ParseUnsignedRawDelegationTransaction) {
 }
 
 // Reference https://tzscan.io/ooPbtVVy7TZLoRirGsCgyy6Esyqm3Kj22QvEVpAmEXX3vHBGbF8
-TEST_F(TransactionTest, ParseSignedRawDelegationTransaction) {
+TEST_F(TransactionTest, DISABLED_ParseSignedRawDelegationTransaction) {
     // round-trip
     auto strTx = "4fd4dca725498e819cc4dd6a87adcfb98770f600558d5d097d1a48b2324a9a2e080000bbdd4268871d1751a601fe66603324714266bf558c0bdeff4ebc50ac02a08d0601583f106387cb85212812b738cae45b497551bf9a00007dc21f46b94d6b432c881b78e1fee917ef0fd382571a5d5f1bf1c5aa90d62a02777eeebac53e3fe9bbcf4501cc2ee0cb1dbe65ec24c869a4715d84f65cfdc101";
     auto txBytes = hex::toByteArray(strTx);
@@ -166,4 +165,3 @@ TEST_F(TransactionTest, ParseSignedRawDelegationTransaction) {
     
 
 }
-*/

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,114 @@
+{ pkgs ? import <nixpkgs> {}, release ? true, jni ? true, pushS3 ? false, runTests ? false }:
+
+with pkgs;
+let
+  gitignoreSrc = fetchFromGitHub {
+    owner = "hercules-ci";
+    repo = "gitignore.nix";
+    rev = "211907489e9f198594c0eb0ca9256a1949c9d412";
+    sha256 = "sha256:06j7wpvj54khw0z10fjyi31kpafkr6hi1k0di13k1xp8kywvfyx8";
+  };
+  inherit (import gitignoreSrc { inherit (pkgs) lib; }) gitignoreSource;
+  secp256k1-chfast = import ./nix/secp256k1.nix { inherit pkgs; };
+  buildTypeFlag = if release
+  then [
+    "-DCMAKE_BUILD_TYPE=RELEASE"
+  ]
+  else [
+    "-DCMAKE_BUILD_TYPE=DEBUG"
+  ];
+  testFlag = if jni && runTests
+  then abort "Cannot build both for JNI and run the test suite. Choose only one."
+  else if runTests
+  then [ "-DBUILD_TESTS=ON" ]
+  else [ "-DBUILD_TESTS=OFF" ];
+  jniFlag = [ (lib.optionalString jni "-DTARGET_JNI=ON") ];
+in
+
+stdenv.mkDerivation {
+  name = "libledger-core";
+  version = "4.1.1";
+  src = gitignoreSource ./.;
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    aws
+  ];
+
+  buildInputs = [
+    # Common build deps
+    postgresql_12
+    openssl_1_1
+    gcc11
+    sqlite
+    cmake
+    libkrb5
+    cryptopp
+    secp256k1-chfast
+
+    # JNI bindings deps
+    jdk8
+  ]
+  ++ lib.optionals stdenv.isLinux [ libselinux ] ;
+
+  checkInputs = [
+    libsForQt515.qt5.qtbase
+    libsForQt515.qt5.qtconnectivity
+    libsForQt515.qt5.qtwebsockets
+    libsForQt515.qt5.wrapQtAppsHook
+  ];
+
+  cmakeFlags = buildTypeFlag
+  ++ testFlag
+  ++ jniFlag
+  ++ [
+    "-DPG_SUPPORT=ON"
+    "-DSYS_OPENSSL=ON"
+    "-DSYS_SECP256K1=ON"
+  ];
+
+  doInstallCheck = runTests;
+  installCheckPhase = ''
+    echo "========= Provisioning Database"
+    initdb -D .tmp/mydb
+    pg_ctl -D .tmp/mydb -l logfile -o "--unix_socket_directories='$PWD'" start
+    createdb -p 5432 -h localhost test_db
+    echo "========= Running tests"
+    ctest --output-on-failure
+  '';
+
+  separateDebugInfo = true;
+
+  doDist = pushS3;
+  tarballs = [
+    "*.so"
+    "*.dylib"
+  ];
+  distPhase = ''
+    function match {
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -nE $*
+      else
+        sed -nr $*
+      fi
+    }
+
+    LIB_VERSION_MAJOR=`cat CMakeLists.txt | match 's/set\(VERSION_MAJOR.*([0-9]+).*\)/\1/p'`
+    LIB_VERSION_MINOR=`cat CMakeLists.txt | match 's/set\(VERSION_MINOR.*([0-9]+).*\)/\1/p'`
+    LIB_VERSION_PATCH=`cat CMakeLists.txt | match 's/set\(VERSION_PATCH.*([0-9]+).*\)/\1/p'`
+    LIB_VERSION=$LIB_VERSION_MAJOR.$LIB_VERSION_MINOR.$LIB_VERSION_PATCH
+
+    COMMIT_HASH=`echo $GITHUB_SHA | cut -c 1-6`
+    LIB_VERSION="$LIB_VERSION-rc-$COMMIT_HASH"
+
+    echo "=====> Libcore version : $LIB_VERSION"
+
+    echo "======= Pushing to S3 =========="
+    cd $out/lib
+    ls -la
+    aws s3 sync ./ s3://ledger-lib-ledger-core/$LIB_VERSION/ --acl public-read --exclude "*" --include "*.so" --include "*.dylib" && \
+    aws s3 ls s3://ledger-lib-ledger-core/$LIB_VERSION;
+    cd -
+  '';
+}

--- a/nix/gha-libcore-jar.nix
+++ b/nix/gha-libcore-jar.nix
@@ -1,0 +1,49 @@
+{ pkgs ? import <nixpkgs> {}, jdk ? "jdk8" }:
+
+let
+  gitignoreSrc = pkgs.fetchFromGitHub {
+    owner = "hercules-ci";
+    repo = "gitignore.nix";
+    rev = "211907489e9f198594c0eb0ca9256a1949c9d412";
+    sha256 = "sha256:06j7wpvj54khw0z10fjyi31kpafkr6hi1k0di13k1xp8kywvfyx8";
+  };
+  inherit (import gitignoreSrc { inherit (pkgs) lib; }) gitignoreFilter;
+
+  # the `build/` in djinni/.gitignore gets badly interpreted by gitignore, so we rebuild a
+  # proper filter.
+  gitIgnoreWithDjinniBuildFilter = src:
+    let
+      # IMPORTANT: use a let binding like this to memoize info about the git directories.
+      srcIgnored = gitignoreFilter src;
+    in
+      path: type:
+         srcIgnored path type
+           || builtins.baseNameOf path == "djinni/src/build";
+
+  name = "libledger-core-jar";
+in
+pkgs.stdenv.mkDerivation {
+  inherit name;
+  version = "4.1.1";
+  src = pkgs.lib.cleanSourceWith {
+      filter = gitIgnoreWithDjinniBuildFilter ../.;
+      src = ../.;
+      name = name + "-source";
+    };
+
+  buildInputs = (pkgs.lib.attrVals [
+      "coursier"
+      "${jdk}"
+      "sbt"
+
+      # Djinni command dependencies
+      "gcc11"
+      "bashInteractive"
+  ] pkgs);
+
+  shellHook = ''
+  export LIBCORE_LIB_DIR="jar_build/src/main/resources/resources/djinni_native_libs/"
+  '';
+
+  doCheck = false;
+}

--- a/nix/libcore-jar.nix
+++ b/nix/libcore-jar.nix
@@ -1,0 +1,51 @@
+{ pkgs ? import <nixpkgs> {}, jdk ? "jdk8" }:
+
+let
+  gitignoreSrc = pkgs.fetchFromGitHub {
+    owner = "hercules-ci";
+    repo = "gitignore.nix";
+    rev = "211907489e9f198594c0eb0ca9256a1949c9d412";
+    sha256 = "sha256:06j7wpvj54khw0z10fjyi31kpafkr6hi1k0di13k1xp8kywvfyx8";
+  };
+  inherit (import gitignoreSrc { inherit (pkgs) lib; }) gitignoreFilter;
+
+  # the `build/` in djinni/.gitignore gets badly interpreted by gitignore, so we rebuild a
+  # proper filter.
+  gitIgnoreWithDjinniBuildFilter = src:
+    let
+      # IMPORTANT: use a let binding like this to memoize info about the git directories.
+      srcIgnored = gitignoreFilter src;
+    in
+      path: type:
+         srcIgnored path type
+           || builtins.baseNameOf path == "djinni/src/build";
+
+  libledger-core = import ../default.nix { inherit pkgs; jni = true; release = true; pushS3 = false; runTests = false; };
+  name = "libledger-core-jar";
+in
+pkgs.stdenv.mkDerivation {
+  inherit name;
+  version = "4.1.1";
+  src = pkgs.lib.cleanSourceWith {
+      filter = gitIgnoreWithDjinniBuildFilter ../.;
+      src = ../.;
+      name = name + "-source";
+    };
+
+  buildInputs = (pkgs.lib.attrVals [
+      "coursier"
+      "${jdk}"
+      "sbt"
+
+      # Djinni command dependencies
+      "gcc11"
+      "bashInteractive"
+  ] pkgs)
+  ++ [ libledger-core ];
+
+  shellHook = ''
+  export LIBCORE_LIB=${libledger-core.out}/lib/${if pkgs.stdenv.isLinux then "*.so" else "*.dylib"}
+  '';
+
+  doCheck = false;
+}

--- a/nix/scripts/build_jar_on_gha.sh
+++ b/nix/scripts/build_jar_on_gha.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf "\n============ Generate Java/Scala interface files\n"
+bash tools/generate_interfaces.sh
+printf "\n============ Moving interface files\n"
+ls -la ${LIBCORE_LIB_DIR}
+cp -v ./api/core/java/* jar_build
+cp -v ./api/core/scala/* jar_build
+printf "============ Checking libs in djinni native libs dir\n"
+ls -la jar_build/src/main/resources/resources/djinni_native_libs
+printf "\n============ Packaging JAR (with ${LIBCORE_LIB_DIR})\n"
+cd jar_build
+sbt package
+printf "\n============ Showing target build, hopefully with a JAR to rename ledger-lib-core.jar\n"
+
+mkdir -p artifact
+mv target/scala-2.12/*.jar artifact/ledger-lib-core.jar
+ls -la artifact
+
+if [[ "${DEPLOY_JAR:-NO}" == "YES" ]]; then
+  printf "\n============ We push to S3\n"
+  cd -
+  echo "=====> Libcore version : $LIB_VERSION"
+
+  echo "======= Pushing to S3 =========="
+  cd jar
+  ls -la
+  aws s3 sync ./ s3://ledger-lib-ledger-core/$LIB_VERSION/ --acl public-read --exclude "*" --include "*.jar" && \
+  aws s3 ls s3://ledger-lib-ledger-core/$LIB_VERSION;
+  cd -
+else
+  printf "\n============ Skip pushing to S3\n"
+fi

--- a/nix/scripts/build_run_tests.sh
+++ b/nix/scripts/build_run_tests.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOAD_LIMIT="${BUILD_LOAD_LIMIT:-2.5}"
+
+mkdir _build_tests
+cd _build_tests
+cmake .. -DSYS_OPENSSL=ON -DSYS_SECP256K1=ON -DPG_SUPPORT=ON -DBUILD_TESTS=ON
+echo "========= Building libcore"
+make -j -l"${LOAD_LIMIT}" ledger-core-static
+make -j -l"${LOAD_LIMIT}" ledger-core
+make -j -l"${LOAD_LIMIT}"
+echo "========= Provisioning Database"
+initdb -D .tmp/mydb
+pg_ctl -D .tmp/mydb -l logfile -o "--unix_socket_directories='$PWD'" start
+createdb -p 5432 -h localhost test_db
+echo "========= Running tests"
+ctest --output-on-failure

--- a/nix/scripts/export_libcore_version.sh
+++ b/nix/scripts/export_libcore_version.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function match {
+    sed -nr $*
+}
+
+
+LIB_VERSION_MAJOR=`cat CMakeLists.txt | match 's/set\(VERSION_MAJOR.*([0-9]+).*\)/\1/p'`
+LIB_VERSION_MINOR=`cat CMakeLists.txt | match 's/set\(VERSION_MINOR.*([0-9]+).*\)/\1/p'`
+LIB_VERSION_PATCH=`cat CMakeLists.txt | match 's/set\(VERSION_PATCH.*([0-9]+).*\)/\1/p'`
+LIB_VERSION=$LIB_VERSION_MAJOR.$LIB_VERSION_MINOR.$LIB_VERSION_PATCH
+
+COMMIT_HASH=`echo $GITHUB_SHA | cut -c 1-6`
+LIB_VERSION="$LIB_VERSION-rc-$COMMIT_HASH"
+
+echo "=====> Libcore version : $LIB_VERSION"
+echo "::set-output name=lib_version::$LIB_VERSION"
+
+if [[ "${GITHUB_EVENT_NAME:-NO}" == "push" ]]; then
+    printf "\nMarking for deploy\n"
+    echo "::set-output name=deploy_jar::YES"
+    echo "::set-output name=deploy_dynlibs::YES"
+else
+    printf "\n${GITHUB_EVENT_NAME:-NO} is not \"push\", so not marking for deploy\n"
+    echo "::set-output name=deploy_jar::NO"
+    echo "::set-output name=deploy_dynlibs::NO"
+fi

--- a/nix/secp256k1.nix
+++ b/nix/secp256k1.nix
@@ -1,0 +1,50 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+stdenv.mkDerivation {
+  pname = "secp256k1-chfast";
+
+  # I can't find any version numbers, so we're just using the date of the
+  # last commit.
+  version = "ac8ccf29b8c6b2b793bc734661ce43d1f952977a";
+
+  src = fetchFromGitHub {
+    owner = "chfast";
+    repo = "secp256k1";
+    rev = "ac8ccf29b8c6b2b793bc734661ce43d1f952977a";
+    sha256 = "0kq4fyvi3mz0cggbwjrl9av16jkq7cifr3ac8b7mpi3ycw4babpf";
+  };
+
+  nativeBuildInputs = [ 
+    autoreconfHook
+    pkg-config
+  ];
+
+  configureFlags = [
+    "--enable-benchmark=no"
+    "--enable-exhaustive-tests=no"
+    "--enable-experimental"
+    "--enable-module-ecdh"
+    "--enable-module-recovery"
+    "--enable-module-schnorrsig"
+    "--enable-tests=yes"
+    "--enable-static"
+  ];
+
+  doCheck = true;
+
+  checkPhase = "./tests";
+
+  meta = with lib; {
+    description = "Optimized C library for EC operations on curve secp256k1";
+    longDescription = ''
+      Optimized C library for EC operations on curve secp256k1. Part of
+      Bitcoin Core. This library is a work in progress and is being used
+      to research best practices. Use at your own risk.
+    '';
+    homepage = "https://github.com/chfast/secp256k1";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ ];
+    platforms = with platforms; unix;
+  };
+}

--- a/nix/test-shell.nix
+++ b/nix/test-shell.nix
@@ -3,10 +3,10 @@
 
 with pkgs;
 let
-  secp256k1-chfast = import ./nix/secp256k1.nix { inherit pkgs; };
+  secp256k1-chfast = import ./secp256k1.nix { inherit pkgs; };
 in
 mkShell {
-  nativeBuildInputs = [ 
+  nativeBuildInputs = [
     pkg-config
     cmake
   ];
@@ -16,7 +16,6 @@ mkShell {
     openssl_1_1
     gcc11
     sqlite
-    cmake
     libkrb5
     cryptopp
     secp256k1-chfast
@@ -28,6 +27,7 @@ mkShell {
     libsForQt515.qt5.qtbase
     libsForQt515.qt5.qtconnectivity
     libsForQt515.qt5.qtwebsockets
+    libuv
 
     # keep this line if you use bash
     bashInteractive


### PR DESCRIPTION
The goal of this PR is to provide a nix derivation for developers to work in (through `nix-shell`) and for CI to build on any machine without needing extra CCI configuration/orbs (so that later the builds/deployments can be offloaded to the simplest self-hosted runners, with only `nix` as dependency)

TODO
- [x] check macos GHA
- [x] make a ~~postInstall script~~ a smart github workflow step that uploads to S3
- [x] ~~setup a cachix GHA~~ Not using cachix for now, instead we will use github workflows artifacts
- [x] better GHA event filters
- [x] make 2 nix-builds : 
  + 1 release without `doInstallCheck` and the matching `-DENABLE_TESTS=0`, and the postInstall script
  + 1 debug with tests but without the postInstall
- [x] pin `nixpkgs`