### PR TITLE
[BTC] Update fees in optimistic update before insertion

### DIFF
--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
@@ -36,6 +36,7 @@
 #include <collections/functional.hpp>
 
 #include <algorithm>
+#include <numeric>
 
 #include <memory>
 #include <utils/DateUtils.hpp>
@@ -162,6 +163,27 @@ void inflateOptimisticUpdateOutputs(
     out.address = output->getAddress().value_or("");
     toFillTx.outputs.push_back(out);
   }
+}
+
+/// Fill the fees of an optimistic update transaction
+/// from its current inputs and outputs
+void inflateOptimisticUpdateFees(
+    BitcoinLikeBlockchainExplorerTransaction &toFillTx) {
+    auto outputValue = std::accumulate(
+        toFillTx.outputs.cbegin(),
+        toFillTx.outputs.cend(),
+        BigInt::ZERO,
+        [](BigInt acc, BitcoinLikeBlockchainExplorerOutput new_val) {
+            return std::move(acc) + new_val.value;
+        });
+    auto inputValue = std::accumulate(
+        toFillTx.inputs.cbegin(),
+        toFillTx.inputs.cend(),
+        BigInt::ZERO,
+        [](BigInt acc, BitcoinLikeBlockchainExplorerInput new_val) {
+            return std::move(acc) + new_val.value.getValueOr(BigInt::ZERO);
+        });
+    toFillTx.fees = inputValue - outputValue;
 }
 } // namespace
 
@@ -723,6 +745,9 @@ namespace ledger {
 
                     //Outputs
                     inflateOptimisticUpdateOutputs(txExplorer, tx);
+
+                    // Fees
+                    inflateOptimisticUpdateFees(txExplorer);
 
                     //Store in DB
                     std::vector<Operation> operations;


### PR DESCRIPTION
#807 didn't update the fees at all, so at that point it's just a guess. The error is
```
Core Warn: 2021-09-01T12:05:29Z+00:00 W: ledger.correlation_id=1551013d-9c85-45e0-9134-3769a8c32191 Optimistic update failed for broadcasted transaction [hash: fdbb2051fdedb281d808af62b3840a28bba91ca55c7d6876219d35e4dc34e07c] with errcode RUNTIME_ERROR: Dynamic exception type: std::experimental::bad_optional_access
std::exception::what: bad optional access
```

and this is the first suspect `getValue()` I found by manually following the code