### PR TITLE
VG-1728: Remove the use of internal state in keychains

### DIFF
--- a/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.cpp
+++ b/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.cpp
@@ -72,74 +72,71 @@ namespace ledger {
                         .setNode(CHANGE).getPath();
                 _internalNodeXpub = std::static_pointer_cast<BitcoinLikeExtendedPublicKey>(_xpub)->derive(localPath);
             }
-            if(! softSyncState()) {
-                _state.maxConsecutiveReceiveIndex = 0;
-                _state.maxConsecutiveChangeIndex = 0;
-                _state.empty = true;
-            }
             _observableRange = (uint32_t) configuration->getInt(api::Configuration::KEYCHAIN_OBSERVABLE_RANGE)
                     .value_or(api::ConfigurationDefaults::KEYCHAIN_DEFAULT_OBSERVABLE_RANGE);
         }
 
-        bool CommonBitcoinLikeKeychains::softSyncState() {
-            // Try to restore the state from preferences
+        KeychainPersistentState CommonBitcoinLikeKeychains::getState() const {
+            // Try to get the state from preferences
             auto preferences = getPreferences();
             if(preferences == nullptr) {
                 throw make_exception(api::ErrorCode::NULL_POINTER, "Preferences is null.");
             }
-            auto state = preferences->getData("state", {});
-            if (!state.empty()) {
-                boost::iostreams::array_source my_vec_source(reinterpret_cast<char*>(&state[0]), state.size());
+            KeychainPersistentState state;
+            auto rawState = preferences->getData("state", {});
+            if (!rawState.empty()) {
+                
+                boost::iostreams::array_source my_vec_source(reinterpret_cast<char*>(&rawState[0]), rawState.size());
                 boost::iostreams::stream<boost::iostreams::array_source> is(my_vec_source);
                 ::cereal::BinaryInputArchive archive(is);
-                archive(_state);
-                return true;
+                archive(state);
             } 
-
-            return false;
-        }
-
-        const KeychainPersistentState& CommonBitcoinLikeKeychains::getState() const noexcept {
-            return _state;
+            return state;
         }
 
         bool CommonBitcoinLikeKeychains::markPathAsUsed(const DerivationPath &p, bool needExtendKeychain) {
+            KeychainPersistentState state = getState();
             DerivationPath path(p);
-            // VG-1975: Make sure the state is up to date before editing it 
-            softSyncState();
+
+            auto isToUpdate = [&path](const uint32_t& maxConsecutiveIndex, const std::set<uint32_t>& nonConsecutiveIndexes) {
+                return path.getLastChildNum() >= maxConsecutiveIndex && nonConsecutiveIndexes.find(path.getLastChildNum()) == nonConsecutiveIndexes.end();
+            };
+
+            auto updateState = [&path](uint32_t& maxConsecutiveIndex, std::set<uint32_t>& nonConsecutiveIndexes, bool& empty) {
+                if (path.getLastChildNum() == maxConsecutiveIndex)
+                    maxConsecutiveIndex += 1;
+                else
+                    nonConsecutiveIndexes.insert(path.getLastChildNum());
+                empty = false;
+            };
+
+
             if (path.getParent().getLastChildNum() == 0) {
-                if (path.getLastChildNum() < _state.maxConsecutiveReceiveIndex ||
-                    _state.nonConsecutiveReceiveIndexes.find(path.getLastChildNum()) != _state.nonConsecutiveReceiveIndexes.end()) {
+
+                if (!isToUpdate(state.maxConsecutiveReceiveIndex, state.nonConsecutiveReceiveIndexes)) {
                     return false;
-                } else {
-                    if (path.getLastChildNum() == _state.maxConsecutiveReceiveIndex)
-                        _state.maxConsecutiveReceiveIndex += 1;
-                    else
-                        _state.nonConsecutiveReceiveIndexes.insert(path.getLastChildNum());
-                    _state.empty = false;
-                    saveState();
-                    if (needExtendKeychain) {
-                        getAllObservableAddresses(path.getLastChildNum(), path.getLastChildNum() + _observableRange);
-                    }
-                    return true;
                 }
+
+                updateState(state.maxConsecutiveReceiveIndex, state.nonConsecutiveReceiveIndexes, state.empty);
+                saveState(std::move(state));
+                if (needExtendKeychain) {
+                    getAllObservableAddresses(path.getLastChildNum(), path.getLastChildNum() + _observableRange);
+                }
+
             } else {
-                if (path.getLastChildNum() < _state.maxConsecutiveChangeIndex ||
-                    _state.nonConsecutiveChangeIndexes.find(path.getLastChildNum()) != _state.nonConsecutiveChangeIndexes.end()) {
+
+                if (!isToUpdate(state.maxConsecutiveChangeIndex, state.nonConsecutiveChangeIndexes)) {
                     return false;
-                } else {
-                    if (path.getLastChildNum() == _state.maxConsecutiveChangeIndex)
-                        _state.maxConsecutiveChangeIndex += 1;
-                    else
-                        _state.nonConsecutiveChangeIndexes.insert(path.getLastChildNum());
-                    _state.empty = false;
-                    saveState();
-                    if (needExtendKeychain) {
-                        getAllObservableAddresses(path.getLastChildNum(), path.getLastChildNum() + _observableRange);
-                    }
-                    return true;
+                }
+
+                updateState(state.maxConsecutiveChangeIndex, state.nonConsecutiveChangeIndexes, state.empty);
+                saveState(std::move(state));
+                if (needExtendKeychain) {
+                    getAllObservableAddresses(path.getLastChildNum(), path.getLastChildNum() + _observableRange);
                 }
             }
+
+            return true;
         }
 
         //TODO the two following methods are similar. Merge them if possible
@@ -216,16 +213,18 @@ namespace ledger {
         }
 
         BitcoinLikeKeychain::Address CommonBitcoinLikeKeychains::getFreshAddress(BitcoinLikeKeychain::KeyPurpose purpose) {
-            return derive(purpose, (purpose == KeyPurpose::RECEIVE ? _state.maxConsecutiveReceiveIndex : _state.maxConsecutiveChangeIndex));
+            KeychainPersistentState state = getState();
+            return derive(purpose, (purpose == KeyPurpose::RECEIVE ? state.maxConsecutiveReceiveIndex : state.maxConsecutiveChangeIndex));
         }
 
         bool CommonBitcoinLikeKeychains::isEmpty() const {
-            return _state.empty;
+            return getState().empty;
         }
 
         std::vector<BitcoinLikeKeychain::Address>
         CommonBitcoinLikeKeychains::getFreshAddresses(BitcoinLikeKeychain::KeyPurpose purpose, size_t n) {
-            auto startOffset = (purpose == KeyPurpose::RECEIVE) ? _state.maxConsecutiveReceiveIndex : _state.maxConsecutiveChangeIndex;
+            KeychainPersistentState state = getState();
+            auto startOffset = (purpose == KeyPurpose::RECEIVE) ? state.maxConsecutiveReceiveIndex : state.maxConsecutiveChangeIndex;
             std::vector<BitcoinLikeKeychain::Address> result(n);
             for (auto i = 0; i < n; i++) {
                 result[i] = derive(purpose, startOffset + i);
@@ -258,7 +257,8 @@ namespace ledger {
         std::vector<BitcoinLikeKeychain::Address>
         CommonBitcoinLikeKeychains::getAllObservableAddresses(BitcoinLikeKeychain::KeyPurpose purpose, uint32_t from,
                                                             uint32_t to) {
-            auto maxObservableIndex = (purpose == KeyPurpose::CHANGE ? _state.maxConsecutiveChangeIndex + _state.nonConsecutiveChangeIndexes.size() : _state.maxConsecutiveReceiveIndex + _state.nonConsecutiveReceiveIndexes.size()) + _observableRange;
+            KeychainPersistentState state = getState();                                         
+            auto maxObservableIndex = (purpose == KeyPurpose::CHANGE ? state.maxConsecutiveChangeIndex + state.nonConsecutiveChangeIndexes.size() : state.maxConsecutiveReceiveIndex + state.nonConsecutiveReceiveIndexes.size()) + _observableRange;
             auto length = std::min<size_t >(to - from, maxObservableIndex - from);
             std::vector<BitcoinLikeKeychain::Address> result;
             result.reserve(length + 1);
@@ -272,20 +272,18 @@ namespace ledger {
             return result;
         }
 
-        void CommonBitcoinLikeKeychains::saveState() {
-            // VG-1975: Make sure the state is up to date before editing it 
-            softSyncState();
-            while (_state.nonConsecutiveReceiveIndexes.find(_state.maxConsecutiveReceiveIndex) != _state.nonConsecutiveReceiveIndexes.end()) {
-                _state.nonConsecutiveReceiveIndexes.erase(_state.maxConsecutiveReceiveIndex);
-                _state.maxConsecutiveReceiveIndex += 1;
+        void CommonBitcoinLikeKeychains::saveState(KeychainPersistentState state) const {
+            while (state.nonConsecutiveReceiveIndexes.find(state.maxConsecutiveReceiveIndex) != state.nonConsecutiveReceiveIndexes.end()) {
+                state.nonConsecutiveReceiveIndexes.erase(state.maxConsecutiveReceiveIndex);
+                state.maxConsecutiveReceiveIndex += 1;
             }
-            while (_state.nonConsecutiveChangeIndexes.find(_state.maxConsecutiveChangeIndex) != _state.nonConsecutiveChangeIndexes.end()) {
-                _state.nonConsecutiveChangeIndexes.erase(_state.maxConsecutiveChangeIndex);
-                _state.maxConsecutiveChangeIndex += 1;
+            while (state.nonConsecutiveChangeIndexes.find(state.maxConsecutiveChangeIndex) != state.nonConsecutiveChangeIndexes.end()) {
+                state.nonConsecutiveChangeIndexes.erase(state.maxConsecutiveChangeIndex);
+                state.maxConsecutiveChangeIndex += 1;
             }
             std::stringstream is;
             ::cereal::BinaryOutputArchive archive(is);
-            archive(_state);
+            archive(state);
             auto savedState = is.str();
             getPreferences()->edit()->putData("state", std::vector<uint8_t>((const uint8_t *)savedState.data(),(const uint8_t *)savedState.data() + savedState.size()))->commit();
         }
@@ -307,8 +305,9 @@ namespace ledger {
         }
 
         std::vector<BitcoinLikeKeychain::Address> CommonBitcoinLikeKeychains::getAllAddresses() {
+            KeychainPersistentState state = getState();
             std::vector<BitcoinLikeKeychain::Address> addresses;
-            addresses.reserve(_state.maxConsecutiveChangeIndex + 1 + _state.maxConsecutiveReceiveIndex + 1);
+            addresses.reserve(state.maxConsecutiveChangeIndex + 1 + state.maxConsecutiveReceiveIndex + 1);
 
             auto fetchAddressesFrom = [&](auto const keyPurpose, auto const maxIndex) {
                   for (auto i = 0; i <= maxIndex; ++i) {
@@ -316,8 +315,8 @@ namespace ledger {
                   }
             };
 
-            fetchAddressesFrom(KeyPurpose::CHANGE, _state.maxConsecutiveChangeIndex);
-            fetchAddressesFrom(KeyPurpose::RECEIVE, _state.maxConsecutiveReceiveIndex);
+            fetchAddressesFrom(KeyPurpose::CHANGE, state.maxConsecutiveChangeIndex);
+            fetchAddressesFrom(KeyPurpose::RECEIVE, state.maxConsecutiveReceiveIndex);
 
             return addresses;
         }

--- a/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.hpp
+++ b/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.hpp
@@ -87,6 +87,8 @@ namespace ledger {
 
             Option<std::vector<uint8_t>> getPublicKey(const std::string &address) const override;
 
+            const KeychainPersistentState& getState() const noexcept;
+
         protected:
             std::shared_ptr<api::BitcoinLikeExtendedPublicKey> _internalNodeXpub;
             std::shared_ptr<api::BitcoinLikeExtendedPublicKey> _publicNodeXpub;
@@ -96,6 +98,14 @@ namespace ledger {
         private:
             BitcoinLikeKeychain::Address derive(KeyPurpose purpose, off_t index);
             void saveState();
+            
+            /**
+             * @brief Load persistent state from preferences if any
+             * 
+             * @return true if the state has been loaded, false otherwise
+             */
+            bool softSyncState();
+            
             KeychainPersistentState _state;
             std::shared_ptr<api::BitcoinLikeExtendedPublicKey> _xpub;
         };

--- a/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.hpp
+++ b/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.hpp
@@ -40,11 +40,11 @@ namespace ledger {
     namespace core {
 
         struct KeychainPersistentState {
-            uint32_t maxConsecutiveChangeIndex;
-            uint32_t maxConsecutiveReceiveIndex;
+            uint32_t maxConsecutiveChangeIndex {0};
+            uint32_t maxConsecutiveReceiveIndex {0};
             std::set<uint32_t> nonConsecutiveChangeIndexes;
             std::set<uint32_t> nonConsecutiveReceiveIndexes;
-            bool empty;
+            bool empty {true};
 
             template <class Archive>
             void serialize(Archive& archive, std::uint32_t const version) {
@@ -87,7 +87,13 @@ namespace ledger {
 
             Option<std::vector<uint8_t>> getPublicKey(const std::string &address) const override;
 
-            const KeychainPersistentState& getState() const noexcept;
+
+            /**
+             * @brief Get the State object from user preferences
+             * 
+             * @return persisted state
+             */
+            KeychainPersistentState getState() const;
 
         protected:
             std::shared_ptr<api::BitcoinLikeExtendedPublicKey> _internalNodeXpub;
@@ -97,16 +103,8 @@ namespace ledger {
 
         private:
             BitcoinLikeKeychain::Address derive(KeyPurpose purpose, off_t index);
-            void saveState();
+            void saveState(KeychainPersistentState state) const;
             
-            /**
-             * @brief Load persistent state from preferences if any
-             * 
-             * @return true if the state has been loaded, false otherwise
-             */
-            bool softSyncState();
-            
-            KeychainPersistentState _state;
             std::shared_ptr<api::BitcoinLikeExtendedPublicKey> _xpub;
         };
     }

--- a/core/test/integration/CMakeLists.txt
+++ b/core/test/integration/CMakeLists.txt
@@ -45,7 +45,7 @@ else()
     target_link_libraries(ledger-core-integration-tests ledger-core-static)
 endif()
 
-
+target_link_libraries(ledger-core-integration-tests gmock)
 target_link_libraries(ledger-core-integration-tests ledger-test)
 target_include_directories(ledger-core-integration-tests PUBLIC ../../../core/src)
 

--- a/core/test/integration/keychains/common_bitcoin_keychain_test.cpp
+++ b/core/test/integration/keychains/common_bitcoin_keychain_test.cpp
@@ -1,0 +1,154 @@
+/*
+ *
+ * p2sh_keychain_test
+ * ledger-core
+ *
+ * Created by El Khalil Bellakrid on 01/05/2018.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "api/PreferencesChange.hpp"
+#include "api/KeychainEngines.hpp"
+#include "keychain_test_helper.h"
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::Invoke;
+
+class MockPreferencesBackend: public api::PreferencesBackend {
+ public:
+    MOCK_METHOD(std::experimental::optional<std::vector<uint8_t>>, get, (const std::vector<uint8_t> &));
+    MOCK_METHOD(bool, commit, (const std::vector<api::PreferencesChange> &));
+    MOCK_METHOD(void, setEncryption, (const std::shared_ptr<api::RandomNumberGenerator> &, const std::string &));
+    MOCK_METHOD(void, unsetEncryption, ());
+    MOCK_METHOD(bool, resetEncryption, (const std::shared_ptr<api::RandomNumberGenerator> &, const std::string &, const std::string &));
+    MOCK_METHOD(std::string, getEncryptionSalt, ());
+    MOCK_METHOD(void, clear, ());
+
+};
+
+
+class ConcreteCommonBitcoinLikeKeychains: public CommonBitcoinLikeKeychains {
+public:
+    ConcreteCommonBitcoinLikeKeychains(
+        const std::shared_ptr<api::DynamicObject> &configuration,
+        const api::Currency &params,
+        int account,
+        const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &xpub,
+        const std::shared_ptr<Preferences> &preferences) 
+        : CommonBitcoinLikeKeychains(configuration, params, account, xpub, preferences)
+        {
+          _keychainEngine = api::KeychainEngines::BIP49_P2SH;
+        }
+    int32_t getOutputSizeAsSignedTxInput() const override { return 0; }
+};
+
+class CommonBitcoinKeychains : public KeychainFixture<ConcreteCommonBitcoinLikeKeychains> {
+};
+
+template <typename T>
+std::vector<T> string2vector(const std::string& s) {
+    return std::vector<T>(s.begin(), s.end());
+} 
+
+std::string serializeStateToString(const KeychainPersistentState& state) {
+    std::stringstream is;
+    ::cereal::BinaryOutputArchive archive(is);
+    archive(state);
+    return is.str();
+}
+
+std::vector<uint8_t> serializeStateToVector(const KeychainPersistentState& state) {
+    const std::string savedState = serializeStateToString(state);
+    return std::vector<uint8_t>((const uint8_t *)savedState.data(),(const uint8_t *)savedState.data() + savedState.size());
+}
+
+TEST_F(CommonBitcoinKeychains, CorrectStateAtInitialization) {
+
+    KeychainPersistentState mockState;
+    mockState.maxConsecutiveChangeIndex = 4;
+    mockState.nonConsecutiveChangeIndexes.emplace(1);
+    mockState.nonConsecutiveChangeIndexes.emplace(2);
+    mockState.nonConsecutiveChangeIndexes.emplace(3);
+    mockState.maxConsecutiveReceiveIndex = 4;
+    mockState.nonConsecutiveReceiveIndexes.emplace(1);
+    mockState.nonConsecutiveReceiveIndexes.emplace(2);
+    mockState.nonConsecutiveReceiveIndexes.emplace(3);
+
+    auto backend = std::make_shared<MockPreferencesBackend>(); 
+    EXPECT_CALL(*backend, get(string2vector<uint8_t>("keychainstate")))
+        .Times(1)
+        .WillOnce(Return(serializeStateToVector(mockState)));
+
+    testKeychain(BTC_TESTNET_DATA, backend, [&backend, &mockState] (CommonBitcoinLikeKeychains& keychain) {
+        const KeychainPersistentState& state = keychain.getState();
+        EXPECT_EQ(mockState.maxConsecutiveChangeIndex, state.maxConsecutiveChangeIndex);
+        EXPECT_EQ(mockState.maxConsecutiveReceiveIndex, state.maxConsecutiveReceiveIndex);
+        EXPECT_EQ(mockState.nonConsecutiveChangeIndexes.size(), state.nonConsecutiveChangeIndexes.size());
+        EXPECT_EQ(mockState.nonConsecutiveReceiveIndexes.size(), state.nonConsecutiveReceiveIndexes.size());
+    });
+}
+
+
+TEST_F(CommonBitcoinKeychains, CorrectStateProducedByMarkPathAsUsed) {
+
+    testKeychain(BTC_TESTNET_DATA, [] (CommonBitcoinLikeKeychains& keychain) {
+
+        auto addresses = keychain.getAllObservableAddresses(0, 10);
+        EXPECT_TRUE(keychain.markAsUsed("2N3uTrmyNePhAbiUxi8uq7P2J7SxS2bCaji"));
+
+        const KeychainPersistentState& state = keychain.getState();
+        EXPECT_EQ(0, state.maxConsecutiveChangeIndex);
+        EXPECT_EQ(0, state.maxConsecutiveReceiveIndex);
+        EXPECT_EQ(1, state.nonConsecutiveChangeIndexes.size());
+        EXPECT_EQ(0, state.nonConsecutiveReceiveIndexes.size());
+    });
+}
+
+
+TEST_F(CommonBitcoinKeychains, CorrectStateUsedAtMarkPathAsUsed) {
+
+    testKeychain(BTC_TESTNET_DATA, [] (ConcreteCommonBitcoinLikeKeychains& keychain) {
+
+        auto addresses = keychain.getAllObservableAddresses(0, 10);
+
+        // update state from outside
+        KeychainPersistentState stateInput = keychain.getState();
+        stateInput.maxConsecutiveChangeIndex = 0;
+        stateInput.nonConsecutiveChangeIndexes.insert(0);
+        keychain.getPreferences()->edit()->putData("state", serializeStateToVector(stateInput))->commit();
+
+        EXPECT_TRUE(keychain.markAsUsed("2N3uTrmyNePhAbiUxi8uq7P2J7SxS2bCaji"));
+
+        const KeychainPersistentState& state = keychain.getState();
+        EXPECT_EQ(2, state.maxConsecutiveChangeIndex);
+        EXPECT_EQ(0, state.maxConsecutiveReceiveIndex);
+        EXPECT_EQ(0, state.nonConsecutiveChangeIndexes.size());
+        EXPECT_EQ(0, state.nonConsecutiveReceiveIndexes.size());
+    });
+}
+

--- a/core/test/integration/keychains/keychain_test_helper.h
+++ b/core/test/integration/keychains/keychain_test_helper.h
@@ -126,6 +126,10 @@ public:
                 dispatcher->getMainExecutionContext(),
                 resolver
         );
+        testKeychain(data, std::move(backend), f);
+    };
+
+    void testKeychain(const KeychainTestData &data, std::shared_ptr<api::PreferencesBackend> backend, std::function<void (Keychain&)> f) {
         auto configuration = std::make_shared<DynamicObject>();
         dispatcher->getMainExecutionContext()->execute(ledger::core::make_runnable([=]() {
             Keychain keychain(

--- a/core/test/integration/keychains/p2sh_keychain_test.cpp
+++ b/core/test/integration/keychains/p2sh_keychain_test.cpp
@@ -30,11 +30,15 @@
  */
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <iostream>
 #include <src/wallet/bitcoin/keychains/P2SHBitcoinLikeKeychain.hpp>
+#include <src/api/PreferencesChange.hpp>
 #include "keychain_test_helper.h"
 
 using namespace std;
+using ::testing::_;
+using ::testing::Return;
 
 class BitcoinP2SHKeychains : public KeychainFixture<P2SHBitcoinLikeKeychain> {
 
@@ -144,5 +148,75 @@ TEST_F(BitcoinP2SHKeychains, CheckIfEmpty) {
         EXPECT_TRUE(keychain.isEmpty());
         EXPECT_TRUE(keychain.markAsUsed(keychain.getFreshAddress(BitcoinLikeKeychain::KeyPurpose::RECEIVE)->toBase58()));
         EXPECT_FALSE(keychain.isEmpty());
+    });
+}
+
+
+class MockPreferencesBackend: public api::PreferencesBackend {
+ public:
+    //MockPreferencesBackend(const string&, const std::shared_ptr<ledger::core::api::ExecutionContext>&, const std::shared_ptr<ledger::core::api::PathResolver>&) {}
+    MOCK_METHOD(std::experimental::optional<std::vector<uint8_t>>, get, (const std::vector<uint8_t> &));
+    MOCK_METHOD(bool, commit, (const std::vector<api::PreferencesChange> &));
+    MOCK_METHOD(void, setEncryption, (const std::shared_ptr<api::RandomNumberGenerator> &, const std::string &));
+    MOCK_METHOD(void, unsetEncryption, ());
+    MOCK_METHOD(bool, resetEncryption, (const std::shared_ptr<api::RandomNumberGenerator> &, const std::string &, const std::string &));
+    MOCK_METHOD(std::string, getEncryptionSalt, ());
+    MOCK_METHOD(void, clear, ());
+
+};
+
+
+class ConcreteCommonBitcoinLikeKeychains: public CommonBitcoinLikeKeychains {
+public:
+    ConcreteCommonBitcoinLikeKeychains(const std::shared_ptr<api::DynamicObject> &configuration,
+                                                           const api::Currency &params,
+                                                           int account,
+                                                           const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &xpub,
+                                                           const std::shared_ptr<Preferences> &preferences) 
+                                                           : CommonBitcoinLikeKeychains(configuration, params, account, xpub, preferences)
+                                                           {}
+    int32_t getOutputSizeAsSignedTxInput() const override { return 0; }
+};
+
+class CommonBitcoinKeychains : public KeychainFixture<ConcreteCommonBitcoinLikeKeychains> {
+};
+
+template <typename T>
+std::vector<T> string2vector(const std::string& s) {
+    return std::vector<T>(s.begin(), s.end());
+} 
+
+std::vector<uint8_t> serializeState(const KeychainPersistentState& state) {
+    std::stringstream is;
+    ::cereal::BinaryOutputArchive archive(is);
+    archive(state);
+    auto savedState = is.str();
+    return std::vector<uint8_t>((const uint8_t *)savedState.data(),(const uint8_t *)savedState.data() + savedState.size());
+}
+
+TEST_F(CommonBitcoinKeychains, UpdatesInternalStateAtInitialization) {
+
+    auto backend = std::make_shared<MockPreferencesBackend>(); 
+
+    KeychainPersistentState mockState;
+    mockState.maxConsecutiveChangeIndex = 4;
+    mockState.nonConsecutiveChangeIndexes.emplace(1);
+    mockState.nonConsecutiveChangeIndexes.emplace(2);
+    mockState.nonConsecutiveChangeIndexes.emplace(3);
+    mockState.maxConsecutiveReceiveIndex = 4;
+    mockState.nonConsecutiveReceiveIndexes.emplace(1);
+    mockState.nonConsecutiveReceiveIndexes.emplace(2);
+    mockState.nonConsecutiveReceiveIndexes.emplace(3);
+
+    EXPECT_CALL(*backend, get(string2vector<uint8_t>("keychainstate")))
+        .Times(1)
+        .WillOnce(Return(serializeState(mockState)));
+
+    testKeychain(BTC_TESTNET_DATA, backend, [&backend, &mockState] (CommonBitcoinLikeKeychains& keychain) {
+        const KeychainPersistentState& state = keychain.getState();
+        EXPECT_EQ(mockState.maxConsecutiveChangeIndex, state.maxConsecutiveChangeIndex);
+        EXPECT_EQ(mockState.maxConsecutiveReceiveIndex, state.maxConsecutiveReceiveIndex);
+        EXPECT_EQ(mockState.nonConsecutiveChangeIndexes.size(), state.nonConsecutiveChangeIndexes.size());
+        EXPECT_EQ(mockState.nonConsecutiveReceiveIndexes.size(), state.nonConsecutiveReceiveIndexes.size());
     });
 }


### PR DESCRIPTION
### What is this about?

- Remove internal state from BTC keychains 
- Load the latest state from Redis at each use, instead

### ToDos

* [x] Functional part 
* [x] Unit testing

