### PR TITLE
[VG-2280] Fix very long delete operations on sql db for bitcoin transactions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(UseBackportedModules)
 # The project version number.
 set(VERSION_MAJOR   4   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   0   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   7   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   8   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/core/src/database/DatabaseSessionPool.hpp
+++ b/core/src/database/DatabaseSessionPool.hpp
@@ -61,7 +61,7 @@ namespace ledger {
                 const std::string &password = ""
             );
 
-            static const int CURRENT_DATABASE_SCHEME_VERSION = 27;
+            static const int CURRENT_DATABASE_SCHEME_VERSION = 28;
 
             void performDatabaseMigration();
             void performDatabaseRollback();

--- a/core/src/database/migrations.cpp
+++ b/core/src/database/migrations.cpp
@@ -1191,5 +1191,19 @@ namespace ledger {
             // Do nothing
         }
 
+        template <> void migrate<28>(soci::session& sql, api::DatabaseBackendType type) {
+            sql << "CREATE INDEX bitcoin_transactions_inputs_input_uid_index ON bitcoin_transaction_inputs(input_uid);";
+            sql << "CREATE INDEX bitcoin_transactions_inputs_transaction_uid_index ON bitcoin_transaction_inputs(transaction_uid);";
+            sql << "CREATE INDEX bitcoin_transactions_outputs_transaction_uid_index ON bitcoin_outputs(transaction_uid);";
+            sql << "CREATE INDEX bitcoin_operations_transaction_uid_index ON bitcoin_operations(transaction_uid);";
+        }
+
+        template <> void rollback<28>(soci::session& sql, api::DatabaseBackendType type) {
+            sql << "DROP INDEX bitcoin_transactions_inputs_input_uid_index ;";
+            sql << "DROP INDEX bitcoin_transactions_inputs_transaction_uid_index ;";
+            sql << "DROP INDEX bitcoin_transactions_outputs_transaction_uid_index ;";
+            sql << "DROP INDEX bitcoin_operations_transaction_uid_index ;";
+        }
+
     }
 }

--- a/core/src/database/migrations.hpp
+++ b/core/src/database/migrations.hpp
@@ -211,6 +211,10 @@ namespace ledger {
         template <> void migrate<27>(soci::session& sql, api::DatabaseBackendType type);
         template <> void rollback<27>(soci::session& sql, api::DatabaseBackendType type);
 
+        // add indexes for db performance optimization
+        template <> void migrate<28>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<28>(soci::session& sql, api::DatabaseBackendType type);
+
     }
 }
 


### PR DESCRIPTION
* The fix consists in creating specific indexes in the sql db to accelerate `on delete cascade` for bitcoin transactions.
* bump patch version

This fix addresses the following defect: 
[VG-2280: CaaT reseed does not work on big account](https://ledgerhq.atlassian.net/browse/VG-2280)