### PR TITLE
[VG-2532] Fix excessive memory usage when getting erc20 balances

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(UseBackportedModules)
 # The project version number.
 set(VERSION_MAJOR   4   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   0   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   8   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   9   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/core/src/events/ProgressNotifier.h
+++ b/core/src/events/ProgressNotifier.h
@@ -89,7 +89,7 @@ namespace ledger {
             mutable std::list<std::pair<std::shared_ptr<api::ExecutionContext>, ProgressHandler>> _handlers;
             Promise<T> _promise;
             std::string _lastStep;
-            std::mutex _mutex;
+            mutable std::mutex _mutex;
         };
     }
 }


### PR DESCRIPTION
Optimizations in memory management in method  `LedgerApiEthereumLikeBlockchainExplorer::getERC20Balances`  