### PR TITLE
Fix artifacts upload

### DIFF
--- a/.github/workflows/nix_release_builds.yml
+++ b/.github/workflows/nix_release_builds.yml
@@ -31,7 +31,7 @@ jobs:
                            # https://github.com/actions/checkout/blob/v2.3.4/README.md
       - name: Set version slug and push_to_S3 flags
         id: lib_version
-        run: bash nix/scripts/export_libcore_version.sh
+        run: bash nix/scripts/export_libcore_version.sh ${{ github.event.pull_request.head.ref }}
   Ubuntu_jni:
     name: Linux (with JNI)
     needs: libcore_version

--- a/.github/workflows/nix_release_builds.yml
+++ b/.github/workflows/nix_release_builds.yml
@@ -25,7 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
         with:
-          fetch-depth: 0
+          fetch-depth: 0   # By default action fetches only a single commit.
+                           # fetch-depth=0 forces to fetch all history and tags.
+                           # nix/scripts/export_libcore_version.sh requires git history
+                           # https://github.com/actions/checkout/blob/v2.3.4/README.md
       - name: Set version slug and push_to_S3 flags
         id: lib_version
         run: bash nix/scripts/export_libcore_version.sh

--- a/.github/workflows/nix_release_builds.yml
+++ b/.github/workflows/nix_release_builds.yml
@@ -24,6 +24,8 @@ jobs:
       jar_version: ${{ steps.lib_version.outputs.jar_version }}
     steps:
       - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
       - name: Set version slug and push_to_S3 flags
         id: lib_version
         run: bash nix/scripts/export_libcore_version.sh

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ tags
 result/
 jar_build/
 artifact/
+
+# vim temporary files
+*.sw?
+

--- a/nix/scripts/build_jar.sh
+++ b/nix/scripts/build_jar.sh
@@ -19,14 +19,7 @@ ls -la jar_build/src/main/resources/resources/djinni_native_libs
 printf "\n============ Packaging JAR (with ${LIBCORE_LIB_DIR})\n"
 cd jar_build
 sbt package
-if [[ "${GITHUB_EVENT_NAME:-NO}" == "pull_request" ]]; then
-    printf "Github event matched the \"pull_request\" type\n"
-    printf "No upload being done, cause this is a pull request from a forked repository\n"
-    sbt publish
-else
-    printf "Running SBT publish\n"
-    sbt publish
-fi
+sbt publish
 printf "\n============ Showing target build, hopefully with a JAR to rename ledger-lib-core.jar\n"
 mkdir -p artifact
 for f in `ls target/scala-2.12/`

--- a/nix/scripts/build_jar.sh
+++ b/nix/scripts/build_jar.sh
@@ -22,11 +22,16 @@ sbt package
 if [[ "${GITHUB_EVENT_NAME:-NO}" == "pull_request" ]]; then
     printf "Github event matched the \"pull_request\" type\n"
     printf "No upload being done, cause this is a pull request from a forked repository\n"
+    sbt publish
 else
     printf "Running SBT publish\n"
     sbt publish
 fi
 printf "\n============ Showing target build, hopefully with a JAR to rename ledger-lib-core.jar\n"
 mkdir -p artifact
-mv target/scala-2.12/*.jar artifact/ledger-lib-core.jar
+for f in `ls target/scala-2.12/`
+do
+  dst=`echo $f | perl -pe 's/^.*?(-[a-z]+)?(\.[a-z]+)$/ledger-lib-core$1$2/'`
+  mv target/scala-2.12/$f artifact/$dst
+done
 ls -la artifact

--- a/nix/scripts/export_libcore_version.sh
+++ b/nix/scripts/export_libcore_version.sh
@@ -24,9 +24,16 @@ if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
     printf "\nMarking for deploy\n"
     echo "::set-output name=deploy_dynlibs::YES"
     echo "::set-output name=jar_version::${LIB_VERSION}"
-elif [[ "${GITHUB_EVENT_NAME}" == "push" ]] || [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] ; then
+elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
     printf "\nMarking for snapshot\n"
     echo "::set-output name=deploy_dynlibs::NO"
     echo "::set-output name=jar_version::${LIB_VERSION}-${LIBCORE_GIT_DESCRIBE}-SNAPSHOT"
+elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+    printf "\nMarking for snapshot\n"
+    BRANCH_NAME=$1
+    BRANCH_LENGTH=`git rev-list --count ^remotes/origin/${GITHUB_BASE_REF} remotes/origin/${BRANCH_NAME}`
+    ABBREV_COMMIT_HASH=`git rev-list ^remotes/origin/${GITHUB_BASE_REF} remotes/origin/${BRANCH_NAME} | head -n 1 | cut -c 1-6`
+    echo "::set-output name=deploy_dynlibs::NO"
+    echo "::set-output name=jar_version::${LIB_VERSION}-${BRANCH_NAME}-${BRANCH_LENGTH}-${ABBREV_COMMIT_HASH}-SNAPSHOT"
 fi
 

--- a/nix/scripts/export_libcore_version.sh
+++ b/nix/scripts/export_libcore_version.sh
@@ -13,23 +13,20 @@ LIB_VERSION=$LIB_VERSION_MAJOR.$LIB_VERSION_MINOR.$LIB_VERSION_PATCH
 
 COMMIT_HASH=`echo $GITHUB_SHA | cut -c 1-6`
 LIBCORE_VERSION="$LIB_VERSION-rc-$COMMIT_HASH"
-LIBCORE_GIT_DESCRIBE=`git describe --tags`
+LIBCORE_GIT_DESCRIBE=`git describe --tags --first-parent`
 
 echo "=====> Libcore version : $LIBCORE_VERSION"
-#https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
+# https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
 echo "::set-output name=lib_version::$LIBCORE_VERSION"
 
 printf "# github event is **${GITHUB_EVENT_NAME}**\n"
-if [[ "${GITHUB_EVENT_NAME:-NO}" == "release" ]]; then
+if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
     printf "\nMarking for deploy\n"
     echo "::set-output name=deploy_dynlibs::YES"
     echo "::set-output name=jar_version::${LIB_VERSION}"
-elif [[ "${GITHUB_EVENT_NAME:-NO}" == "push" ]]; then
-    printf "\n${GITHUB_EVENT_NAME:-NO} is \"push\", creating a snapshot\n"
-    echo "::set-output name=deploy_dynlibs::NO"
-    echo "::set-output name=jar_version::${LIB_VERSION}-${LIBCORE_GIT_DESCRIBE}-SNAPSHOT"
-elif [[ "${GITHUB_EVENT_NAME:-NO}" == "pull_request" ]]; then
-    printf "\n${GITHUB_EVENT_NAME:-NO} is \"pull_request\", creating a snapshot\n"
+elif [[ "${GITHUB_EVENT_NAME}" == "push" ]] || [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] ; then
+    printf "\nMarking for snapshot\n"
     echo "::set-output name=deploy_dynlibs::NO"
     echo "::set-output name=jar_version::${LIB_VERSION}-${LIBCORE_GIT_DESCRIBE}-SNAPSHOT"
 fi
+

--- a/nix/scripts/export_libcore_version.sh
+++ b/nix/scripts/export_libcore_version.sh
@@ -13,6 +13,7 @@ LIB_VERSION=$LIB_VERSION_MAJOR.$LIB_VERSION_MINOR.$LIB_VERSION_PATCH
 
 COMMIT_HASH=`echo $GITHUB_SHA | cut -c 1-6`
 LIBCORE_VERSION="$LIB_VERSION-rc-$COMMIT_HASH"
+LIBCORE_GIT_DESCRIBE=`git describe --tags`
 
 echo "=====> Libcore version : $LIBCORE_VERSION"
 #https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
@@ -26,8 +27,9 @@ if [[ "${GITHUB_EVENT_NAME:-NO}" == "release" ]]; then
 elif [[ "${GITHUB_EVENT_NAME:-NO}" == "push" ]]; then
     printf "\n${GITHUB_EVENT_NAME:-NO} is \"push\", creating a snapshot\n"
     echo "::set-output name=deploy_dynlibs::NO"
-    echo "::set-output name=jar_version::${LIB_VERSION}-SNAPSHOT"
+    echo "::set-output name=jar_version::${LIB_VERSION}-${LIBCORE_GIT_DESCRIBE}-SNAPSHOT"
 elif [[ "${GITHUB_EVENT_NAME:-NO}" == "pull_request" ]]; then
-    printf "Github event matched the \"pull_request\" type\n"
-    printf "No upload being done, cause this is a pull request from a forked repository\n"
+    printf "\n${GITHUB_EVENT_NAME:-NO} is \"pull_request\", creating a snapshot\n"
+    echo "::set-output name=deploy_dynlibs::NO"
+    echo "::set-output name=jar_version::${LIB_VERSION}-${LIBCORE_GIT_DESCRIBE}-SNAPSHOT"
 fi


### PR DESCRIPTION
Replaces libcore artifact version from "4.1.1-SNAPSHOT" to 
- for releases: ${LIB_VERSION} (from CMakeLists.txt)
- for pushes: ${LIB_VERSION}-${latest-reachable-tag}-${N}-${commit-hash}-SNAPSHOT"
- for pull requests: ${LIB_VERSION}-${BRANCH_NAME}-${BRANCH_LENGTH}-${commit_hash}-SNAPSHOT

where ${N} - number of commits from last reachable tag.