### PR TITLE
[VG-3094] Add operation_id in tezos transactions and update of uid formula

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include_what_you_use()  # add cmake conf option IWYU=ON to activate
 # The project version number.
 set(VERSION_MAJOR   4   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   1   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   2   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   3   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/core/idl/wallet/tezos/tezos_like_wallet.djinni
+++ b/core/idl/wallet/tezos/tezos_like_wallet.djinni
@@ -19,9 +19,13 @@ TezosOperationTag = enum {
 #Class representing a Tezos transaction
 TezosLikeTransaction = interface +c {
 	# Get type of operation (transaction, reveal ... cf TezosOperationTag)
-	getType(): TezosOperationTag;
+	const getType(): TezosOperationTag;
 	# Get the hash of the transaction.
-	getHash(): string;
+	const getHash(): string;
+	# Get the operation index in the transaction
+	const getOperationIndexInTransaction(): i64;
+	# Get the operation type in the transaction
+	const getOperationTypeInTransaction(): TezosOperationTag;
 	# Get Fees (in drop) 
 	# It returns the sum of transaction fees and reveal fees (if it exists)
 	getFees(): Amount;
@@ -31,9 +35,9 @@ TezosLikeTransaction = interface +c {
 	getRevealFees(): Amount;
 
 	# Get destination XTZ. address
-	getReceiver(): optional<TezosLikeAddress>;
+	const getReceiver(): optional<TezosLikeAddress>;
 	# Get XTZ. sender address
-	getSender(): TezosLikeAddress;
+	const getSender(): TezosLikeAddress;
 	# Get amount of XTZ to send
 	getValue(): optional<Amount>;
 	# Serialize the transaction to its raw format.
@@ -54,10 +58,10 @@ TezosLikeTransaction = interface +c {
 	getStatus(): i32;
 	# Get the correlation id
 	getCorrelationId(): string;
-        # Set the correlation id which can be used to debug transaction errors
-        # through the full ledger stack
-        # @return the OLD Correlation ID, if it was set (empty string if it was unset)
-        setCorrelationId(correlationId : string) : string;
+	# Set the correlation id which can be used to debug transaction errors
+	# through the full ledger stack
+	# @return the OLD Correlation ID, if it was set (empty string if it was unset)
+	setCorrelationId(correlationId : string) : string;
 }
 
 #Class representing a Tezos Operation
@@ -158,9 +162,11 @@ TezosLikeAccount = interface +c {
 	getOriginatedAccounts(): list<TezosLikeOriginatedAccount>;
 	# Get current delegate
 	getCurrentDelegate(callback: Callback<string>);
-  # Get the balance of the account for a given token
-  # @param tokenAddress Address of the contract
-  getTokenBalance(tokenAddress: string, callback: Callback<BigInt>);
+	# Get the balance of the account for a given token
+	# @param tokenAddress Address of the contract
+	getTokenBalance(tokenAddress: string, callback: Callback<BigInt>);
+	# Get the deterministic operation Uid
+	const computeOperationUid(transaction: TezosLikeTransaction): string;
 }
 
 # Class representing originated accounts

--- a/core/src/api/TezosLikeAccount.hpp
+++ b/core/src/api/TezosLikeAccount.hpp
@@ -68,6 +68,9 @@ public:
      * @param tokenAddress Address of the contract
      */
     virtual void getTokenBalance(const std::string & tokenAddress, const std::shared_ptr<BigIntCallback> & callback) = 0;
+
+    /** Get the deterministic operation Uid */
+    virtual std::string computeOperationUid(const std::shared_ptr<TezosLikeTransaction> & transaction) const = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/core/src/api/TezosLikeTransaction.hpp
+++ b/core/src/api/TezosLikeTransaction.hpp
@@ -31,10 +31,16 @@ public:
     virtual ~TezosLikeTransaction() {}
 
     /** Get type of operation (transaction, reveal ... cf TezosOperationTag) */
-    virtual TezosOperationTag getType() = 0;
+    virtual TezosOperationTag getType() const = 0;
 
     /** Get the hash of the transaction. */
-    virtual std::string getHash() = 0;
+    virtual std::string getHash() const = 0;
+
+    /** Get the operation index in the transaction */
+    virtual int64_t getOperationIndexInTransaction() const = 0;
+
+    /** Get the operation type in the transaction */
+    virtual TezosOperationTag getOperationTypeInTransaction() const = 0;
 
     /**
      * Get Fees (in drop) 
@@ -49,10 +55,10 @@ public:
     virtual std::shared_ptr<Amount> getRevealFees() = 0;
 
     /** Get destination XTZ. address */
-    virtual std::shared_ptr<TezosLikeAddress> getReceiver() = 0;
+    virtual std::shared_ptr<TezosLikeAddress> getReceiver() const = 0;
 
     /** Get XTZ. sender address */
-    virtual std::shared_ptr<TezosLikeAddress> getSender() = 0;
+    virtual std::shared_ptr<TezosLikeAddress> getSender() const = 0;
 
     /** Get amount of XTZ to send */
     virtual std::shared_ptr<Amount> getValue() = 0;

--- a/core/src/jni/jni/TezosLikeAccount.cpp
+++ b/core/src/jni/jni/TezosLikeAccount.cpp
@@ -121,4 +121,14 @@ CJNIEXPORT void JNICALL Java_co_ledger_core_TezosLikeAccount_00024CppProxy_nativ
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
+CJNIEXPORT jstring JNICALL Java_co_ledger_core_TezosLikeAccount_00024CppProxy_native_1computeOperationUid(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jobject j_transaction)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::TezosLikeAccount>(nativeRef);
+        auto r = ref->computeOperationUid(::djinni_generated::TezosLikeTransaction::toCpp(jniEnv, j_transaction));
+        return ::djinni::release(::djinni::String::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 }  // namespace djinni_generated

--- a/core/src/jni/jni/TezosLikeTransaction.cpp
+++ b/core/src/jni/jni/TezosLikeTransaction.cpp
@@ -43,6 +43,26 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_TezosLikeTransaction_00024CppProx
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jlong JNICALL Java_co_ledger_core_TezosLikeTransaction_00024CppProxy_native_1getOperationIndexInTransaction(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::TezosLikeTransaction>(nativeRef);
+        auto r = ref->getOperationIndexInTransaction();
+        return ::djinni::release(::djinni::I64::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
+CJNIEXPORT jobject JNICALL Java_co_ledger_core_TezosLikeTransaction_00024CppProxy_native_1getOperationTypeInTransaction(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::TezosLikeTransaction>(nativeRef);
+        auto r = ref->getOperationTypeInTransaction();
+        return ::djinni::release(::djinni_generated::TezosOperationTag::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT jobject JNICALL Java_co_ledger_core_TezosLikeTransaction_00024CppProxy_native_1getFees(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
 {
     try {

--- a/core/src/wallet/common/Operation.h
+++ b/core/src/wallet/common/Operation.h
@@ -89,7 +89,18 @@ namespace ledger {
 
             Operation& operator=(Operation const&) = default;
             Operation& operator=(Operation&&) = default;
+
+            template <typename CoinOperationType>
+            static std::string computeTransactionId(const std::string& txHash, const CoinOperationType& coinOperationType, const std::string& additional = "");
+            static std::string computeTransactionId(const std::string& txHash, const std::string& additional = "");
+
         };
+
+        template <typename CoinOperationType>
+        std::string Operation::computeTransactionId(const std::string& txHash, const CoinOperationType& coinOperationType, const std::string& additional) {
+            auto hashAndCoinOpType = fmt::format("{}+{}", txHash, api::to_string(coinOperationType));
+            return computeTransactionId(hashAndCoinOpType, additional);
+        }
     }
 }
 

--- a/core/src/wallet/tezos/TezosLikeAccount.h
+++ b/core/src/wallet/tezos/TezosLikeAccount.h
@@ -162,9 +162,14 @@ namespace ledger {
 
             void getTokenBalance(const std::string& tokenAddress, const std::shared_ptr<api::BigIntCallback>& callback) override;
 
+            const std::string& getAccountAddress() const; 
+
             /// Return a common trace prefix for logs
             /// TODO: Upstream tracePrefix() to AbstractAccount and use that everywhere
             std::string tracePrefix() const;
+
+            std::string computeOperationUid(const std::shared_ptr<api::TezosLikeTransaction> & transaction) const override;
+        
         private:
             std::shared_ptr<TezosLikeAccount> getSelf();
             void broadcastRawTransaction(const std::vector<uint8_t> &transaction,

--- a/core/src/wallet/tezos/TezosLikeAccount.h
+++ b/core/src/wallet/tezos/TezosLikeAccount.h
@@ -176,6 +176,8 @@ namespace ledger {
                                          const std::shared_ptr<api::StringCallback> &callback,
                                          const std::string& correlationId);
 
+            std::pair<api::OperationType, std::string> getOperationTypeAndUidAdditional(const std::string& sender, const std::string& receiver, const std::string& originatedAccountId, const std::string& originatedAccountAddress) const;
+
             std::shared_ptr<TezosLikeKeychain> _keychain;
             std::string _accountAddress;
             std::shared_ptr<TezosLikeBlockchainExplorer> _explorer;

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
@@ -92,11 +92,11 @@ namespace ledger {
             _status = tx.status;
         }
 
-        api::TezosOperationTag TezosLikeTransactionApi::getType() {
+        api::TezosOperationTag TezosLikeTransactionApi::getType() const {
             return _type;
         }
 
-        std::string TezosLikeTransactionApi::getHash() {
+        std::string TezosLikeTransactionApi::getHash() const {
             return _hash;
         }
 
@@ -127,11 +127,11 @@ namespace ledger {
             return std::make_shared<Amount>(_currency, 0, BigInt(fees));
         }
 
-        std::shared_ptr<api::TezosLikeAddress> TezosLikeTransactionApi::getReceiver() {
+        std::shared_ptr<api::TezosLikeAddress> TezosLikeTransactionApi::getReceiver() const {
             return _receiver;
         }
 
-        std::shared_ptr<api::TezosLikeAddress> TezosLikeTransactionApi::getSender() {
+        std::shared_ptr<api::TezosLikeAddress> TezosLikeTransactionApi::getSender() const {
             return _sender;
         }
 
@@ -704,6 +704,22 @@ namespace ledger {
             auto oldId = _correlationId;
             _correlationId = newId;
             return oldId;
+        }
+
+        int64_t TezosLikeTransactionApi::getOperationIndexInTransaction() const {
+            return _operationIndexInTransaction;
+        }
+
+        TezosLikeTransactionApi& TezosLikeTransactionApi::setOperationIndexInTransaction(int64_t index) {
+            _operationIndexInTransaction = index;
+        }
+        
+        api::TezosOperationTag TezosLikeTransactionApi::getOperationTypeInTransaction() const {
+            return _operationTypeInTransaction;
+        }
+
+        TezosLikeTransactionApi& TezosLikeTransactionApi::setOperationTypeInTransaction(api::TezosOperationTag type) {
+            _operationTypeInTransaction = type;
         }
 
     }

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
@@ -53,9 +53,9 @@ namespace ledger {
             explicit TezosLikeTransactionApi(const std::shared_ptr<OperationApi> &operation,
                                              const std::string &protocolUpdate);
 
-            api::TezosOperationTag getType() override;
+            api::TezosOperationTag getType() const override;
 
-            std::string getHash() override;
+            std::string getHash() const override;
 
             std::shared_ptr<api::Amount> getFees() override;
 
@@ -63,9 +63,9 @@ namespace ledger {
 
             std::shared_ptr<api::Amount> getTransactionFees() override;
 
-            std::shared_ptr<api::TezosLikeAddress> getReceiver() override;
+            std::shared_ptr<api::TezosLikeAddress> getReceiver() const override;
 
-            std::shared_ptr<api::TezosLikeAddress> getSender() override;
+            std::shared_ptr<api::TezosLikeAddress> getSender() const override;
 
             std::shared_ptr<api::Amount> getValue() override;
 
@@ -135,6 +135,12 @@ namespace ledger {
 
             TezosLikeTransactionApi &reveal(bool needReveal);
             bool toReveal() const;
+
+            int64_t getOperationIndexInTransaction() const override;
+            TezosLikeTransactionApi& setOperationIndexInTransaction(int64_t index);
+
+            api::TezosOperationTag getOperationTypeInTransaction() const override;
+            TezosLikeTransactionApi& setOperationTypeInTransaction(api::TezosOperationTag type);
         private:
             std::chrono::system_clock::time_point _time;
             std::shared_ptr<TezosLikeBlockApi> _block;
@@ -163,6 +169,8 @@ namespace ledger {
             std::shared_ptr<api::Amount> _revealFees;
             std::shared_ptr<api::Amount> _revealGasLimit;
             std::string _correlationId;
+            int64_t _operationIndexInTransaction {0};
+            api::TezosOperationTag _operationTypeInTransaction {api::TezosOperationTag::OPERATION_TAG_NONE};
         };
     }
 }

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
@@ -82,6 +82,8 @@ namespace ledger {
             uint64_t status;
             std::string originatedAccountUid;
             std::string originatedAccountAddress;
+            int64_t counter{0};
+            int64_t index{0};
 
             TezosLikeBlockchainExplorerTransaction() {
                 confirmations = 0;
@@ -89,24 +91,7 @@ namespace ledger {
                 status = 0;
             }
 
-            TezosLikeBlockchainExplorerTransaction(const TezosLikeBlockchainExplorerTransaction &cpy) {
-                this->hash = cpy.hash;
-                this->receivedAt = cpy.receivedAt;
-                this->value = cpy.value;
-                this->fees = cpy.fees;
-                this->gas_limit = cpy.gas_limit;
-                this->storage_limit = cpy.storage_limit;
-                this->receiver = cpy.receiver;
-                this->sender = cpy.sender;
-                this->block = cpy.block;
-                this->confirmations = cpy.confirmations;
-                this->type = cpy.type;
-                this->publicKey = cpy.publicKey;
-                this->originatedAccount = cpy.originatedAccount;
-                this->status = cpy.status;
-                this->originatedAccountUid = cpy.originatedAccountUid; 
-                this->originatedAccountAddress = cpy.originatedAccountAddress; 
-            }
+            TezosLikeBlockchainExplorerTransaction(const TezosLikeBlockchainExplorerTransaction &cpy) = default;
 
         };
 

--- a/core/src/wallet/tezos/explorers/api/TezosLikeTransactionParser.cpp
+++ b/core/src/wallet/tezos/explorers/api/TezosLikeTransactionParser.cpp
@@ -149,6 +149,10 @@ namespace ledger {
                     _transaction->fees = _transaction->fees + toValue(number, true);
                 } else if (_lastKey == "confirmations") {
                     _transaction->confirmations = toValue(number, false).toInt64();
+                } else if (_lastKey == "op_c") {
+                    _transaction->index = toValue(number, false).toInt64();
+                } else if (_lastKey == "counter") {
+                    _transaction->counter = toValue(number, false).toInt64();
                 }
                 return true;
             }


### PR DESCRIPTION
:warning: the database has be wiped before using this new version, breaking change in operation `uid` computation  !  

## Global change:
The aim is to provide an `operation_uid` in the crafted Tezos transactions which will necessarily match with the operation `uid` computed during the account synchronization. A great description of the problem is provided on [VG-3094](https://ledgerhq.atlassian.net/browse/VG-3094). Basically, this PR updates the formula for computing the Tezos operation `uid`. A tezos account method `computeOperationUid` has been added to compute the same operation uid from a crafted transaction. 

## Changes:
* change tezos operation uid formula to `accountUId + counter + TxOpIndex + TxOpType (+ additional) + OperationType`
* add methods to tezos transaction to retrieve the non-reveal operation type / index in batch
* add method to tezos account to compute an `operation_id` from an unsigned transaction
* a bit of refactoring in Operation
* parse tezos operation index in batch and counter
* bump patch version to `4.1.3`

## References:
* [ledger-wallet-daemon#459](https://github.com/LedgerHQ/ledger-wallet-daemon/pull/459)
* [VG-3094](https://ledgerhq.atlassian.net/browse/VG-3094)