### PR TITLE
Fix potential regression on Tezos account sync + Addition of unit tests 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include_what_you_use()  # add cmake conf option IWYU=ON to activate
 # The project version number.
 set(VERSION_MAJOR   4   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   1   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   3   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   4   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -531,7 +531,6 @@ namespace ledger {
 
         std::string TezosLikeAccount::computeOperationUid(const std::shared_ptr<api::TezosLikeTransaction> & transaction) const {
              
-
             // The provided transaction has not necessarily been forged already, so we have to 
             // compute the raw transaction first and parse it to make sure we can compute the 
             // required operation values, including the operation index. 
@@ -569,6 +568,9 @@ namespace ledger {
                     originatedAccountId,
                     originatedAccountAddress
                 );
+            }
+            if(opType == api::OperationType::NONE) {
+                throw make_exception(api::ErrorCode::RUNTIME_ERROR, "Failed to determine the operation type for computing the operation id");
             }
 
             std::string txIdBase = fmt::format("{}+{}", 

--- a/core/test/common/CMakeLists.txt
+++ b/core/test/common/CMakeLists.txt
@@ -2,7 +2,11 @@ cmake_minimum_required(VERSION 3.0)
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 include_directories(${CMAKE_BINARY_DIR}/include)
 
-add_executable(ledger-core-common-tests main.cpp balance_history.cpp)
+add_executable(ledger-core-common-tests 
+    main.cpp
+    balance_history.cpp
+    operation.cpp 
+)
 
 target_link_libraries(ledger-core-common-tests gtest gtest_main)
 target_link_libraries(ledger-core-common-tests ledger-core-static)

--- a/core/test/common/operation.cpp
+++ b/core/test/common/operation.cpp
@@ -1,0 +1,77 @@
+/**
+ *
+ * main
+ * ledger-core
+ *
+ * Created by Jérémy Coatelen on 28/01/2022.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <gtest/gtest.h>
+#include "wallet/common/Operation.h"
+
+using namespace ledger::core;
+
+
+TEST(Operation, TezosUidIsValid) {
+    Operation op{};
+    op.tezosTransaction = TezosLikeBlockchainExplorerTransaction{};
+    op.tezosTransaction->hash = "123";
+
+    // start as transaction type (no additional)
+    op.tezosTransaction->type = ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION;
+    EXPECT_EQ(op.uid, "");
+    op.refreshUid();
+    EXPECT_EQ(op.uid, "5b46f1084ef236091f04e257ab1902ed564dac1cad6d8fb403c007e3fe838411");
+
+    // change only type
+    op.tezosTransaction->type = ledger::core::api::TezosOperationTag::OPERATION_TAG_REVEAL;
+    op.refreshUid();
+    EXPECT_EQ(op.uid, "79ac6452f6ab4ebd0cc6bc0041b89a8954849b032f70bcb21154a0b351565c98");
+
+    // with additional
+    op.refreshUid("456");
+    EXPECT_EQ(op.uid, "c5a8f07c86e5442c58cd95c8e16de8f50c1b980cf591ab215edfb9389166843a");
+}
+
+
+TEST(Operation, TransactionIdFormat) {
+
+    const std::string baseHash = {"test"};
+    const std::string additional = {"add"};
+    const auto opType = ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION;;
+
+    // simple case
+    EXPECT_EQ(Operation::computeTransactionId(baseHash), baseHash);
+
+    // with additional
+    EXPECT_EQ(Operation::computeTransactionId(baseHash, additional), baseHash+"+"+additional);
+
+    // with operation type
+    EXPECT_EQ(Operation::computeTransactionId(baseHash, opType, additional), baseHash+"+"+api::to_string(opType)+"+"+additional);
+
+    // now without additional
+    EXPECT_EQ(Operation::computeTransactionId(baseHash, opType), baseHash+"+"+api::to_string(opType));
+}

--- a/core/test/tezos/CMakeLists.txt
+++ b/core/test/tezos/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(${TEZOS_TESTS_NAME}
     ED25519_transaction_test.cpp
     SECP256K1_transaction_test.cpp
     P256_transaction_test.cpp
+    tezos_account.cpp
     ../integration/BaseFixture.cpp
     ../integration/IntegrationEnvironment.cpp
 )

--- a/core/test/tezos/ED25519_transaction_test.cpp
+++ b/core/test/tezos/ED25519_transaction_test.cpp
@@ -194,6 +194,8 @@ TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawTransaction) {
     EXPECT_EQ(tx->getFees()->toLong(), 1294);
     EXPECT_EQ(tx->getGasLimit()->toLong(), 10407);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawTransactionWithReveal) {
@@ -212,6 +214,8 @@ TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawTransactionWithReveal) {
     EXPECT_EQ(tx->getFees()->toLong(), 1246+1233);//sum of transaction fees and reveal fees
     EXPECT_EQ(tx->getGasLimit()->toLong(), 10407+10200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 1);
 }
 
 TEST_F(ED25519TezosMakeTransaction, CreateDelegation) {
@@ -280,6 +284,8 @@ TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawDelegation) {
     EXPECT_EQ(tx->getFees()->toLong(), 370);
     EXPECT_EQ(tx->getGasLimit()->toLong(), 1200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawUndelegation) {
@@ -297,6 +303,8 @@ TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawUndelegation) {
     EXPECT_EQ(tx->getFees()->toLong(), 370);
     EXPECT_EQ(tx->getGasLimit()->toLong(), 1200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(ED25519TezosMakeTransaction, GetCurrentDelegationOnNotDelegatedAccount) {
@@ -331,4 +339,6 @@ TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawDelegationWithReveal) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 2400);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->toReveal(), true);
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 1);
 }

--- a/core/test/tezos/P256_transaction_test.cpp
+++ b/core/test/tezos/P256_transaction_test.cpp
@@ -184,6 +184,8 @@ TEST_F(P256TezosMakeTransaction, ParseUnsignedRawTransaction) {
     EXPECT_EQ(tx->getFees()->toLong(), 1294);
     EXPECT_EQ(tx->getGasLimit()->toLong(), 10407);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(P256TezosMakeTransaction, ParseUnsignedRawTransactionWithReveal) {
@@ -202,6 +204,8 @@ TEST_F(P256TezosMakeTransaction, ParseUnsignedRawTransactionWithReveal) {
     EXPECT_EQ(tx->getFees()->toLong(), 1246+1234);//sum of transaction fees and reveal fees
     EXPECT_EQ(tx->getGasLimit()->toLong(), 10407+10200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 1);
 }
 
 TEST_F(P256TezosMakeTransaction, CreateDelegation) {
@@ -270,6 +274,8 @@ TEST_F(P256TezosMakeTransaction, ParseUnsignedRawDelegation) {
     EXPECT_EQ(tx->getFees()->toLong(), 370);
     EXPECT_EQ(tx->getGasLimit()->toLong(), 1200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(P256TezosMakeTransaction, ParseUnsignedRawUndelegation) {
@@ -287,6 +293,8 @@ TEST_F(P256TezosMakeTransaction, ParseUnsignedRawUndelegation) {
     EXPECT_EQ(tx->getFees()->toLong(), 370);
     EXPECT_EQ(tx->getGasLimit()->toLong(), 1200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(P256TezosMakeTransaction, GetCurrentDelegation) {
@@ -321,4 +329,6 @@ TEST_F(P256TezosMakeTransaction, ParseUnsignedRawDelegationWithReveal) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 2400);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->toReveal(), true);
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 1);
 }

--- a/core/test/tezos/SECP256K1_transaction_test.cpp
+++ b/core/test/tezos/SECP256K1_transaction_test.cpp
@@ -187,6 +187,8 @@ TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawTransaction) {
     EXPECT_EQ(tx->getFees()->toLong(), 1294);
     EXPECT_EQ(tx->getGasLimit()->toLong(), 10407);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawTransactionWithReveal) {
@@ -205,6 +207,8 @@ TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawTransactionWithReveal) {
     EXPECT_EQ(tx->getFees()->toLong(), 1247+1234); //sum of transaction fees and reveal fees
     EXPECT_EQ(tx->getGasLimit()->toLong(), 10407+10200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 1);
 }
 
   TEST_F(SECP256K1TezosMakeTransaction, DISABLED_optimisticCounter) {
@@ -446,6 +450,8 @@ TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawDelegation) {
     EXPECT_EQ(tx->getFees()->toLong(), 370);
     EXPECT_EQ(tx->getGasLimit()->toLong(), 1200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawUndelegation) {
@@ -463,6 +469,8 @@ TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawUndelegation) {
     EXPECT_EQ(tx->getFees()->toLong(), 370);
     EXPECT_EQ(tx->getGasLimit()->toLong(), 1200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 } 
 
 TEST_F(SECP256K1TezosMakeTransaction, GetCurrentDelegation) {
@@ -497,6 +505,8 @@ TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawDelegationWithReveal) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "100");
     EXPECT_EQ(tx->toReveal(), true);
+    EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
+    EXPECT_EQ(tx->getOperationIndexInTransaction(), 1);
 }
 
 TEST_F(SECP256K1TezosMakeTransaction, CreateTxAutoFill) {

--- a/core/test/tezos/tezos_account.cpp
+++ b/core/test/tezos/tezos_account.cpp
@@ -1,0 +1,205 @@
+/*
+ *
+ * tezos_transaction_tests
+ *
+ * Created by Jeremy Coatelen on 08/02/2022.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include "Fixtures.hpp"
+#include "transaction_test.hpp"
+#include "api/BlockchainExplorerEngines.hpp"
+#include "wallet/tezos/explorers/api/TezosLikeTransactionParser.h"
+#include "wallet/currencies.hpp"
+
+/*
+
+*/
+using namespace ledger::testing::tezos;
+
+struct TezosAccount : public TezosMakeBaseTransaction {
+    void SetUpConfig() override {
+        auto configuration = DynamicObject::newInstance();
+        configuration->putString(api::TezosConfiguration::TEZOS_NODE, "https://xtz-node.api.live.ledger.com");
+        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, api::BlockchainExplorerEngines::TZSTATS_API);
+        configuration->putString(api::TezosConfiguration::TEZOS_XPUB_CURVE, api::TezosConfigurationDefaults::TEZOS_XPUB_CURVE_ED25519);
+        configuration->putString(api::TezosConfiguration::TEZOS_PROTOCOL_UPDATE, api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON);
+        testData.configuration = configuration;
+        testData.walletName = "TezosAccountTest-Wallet";
+        testData.currencyName = "tezos";
+        testData.inflate_xtz = inflate;
+    }
+};
+
+const auto tx1 = R"({
+  "row_id":17386565,
+  "hash":"ooaZnj71WWrzG2by1mAX9sGXXKk46sAg19FR1tBcY7VSMEAm1wp",
+  "type":"reveal",
+  "block":"BLsiDcDBQnqPF2fZP178iK1zzcxd1RNwEjXAdP5D1CFuX3Gcugd",
+  "time":"2019-11-06T13:21:37Z",
+  "height":682242,
+  "cycle":166,
+  "counter":2263644,
+  "op_l":3,
+  "op_p":0,
+  "op_c":0,
+  "op_i":0,
+  "status":"applied",
+  "is_success":true,
+  "is_contract":false,
+  "gas_limit":18000,
+  "gas_used":10000,
+  "gas_price":0.25,
+  "storage_limit":257,
+  "storage_size":0,
+  "storage_paid":0,
+  "volume":0,
+  "fee":0.0025,
+  "has_data":true,
+  "days_destroyed":0,
+  "data":"edpkteNnvxz171eHjTdGmgg5MNVV9mu4JsE5zHZY7tWKKPobPyoJXq",
+  "sender":"tz1Xeg8GzmCYhs5pWxwzerryDiQqFZWTJHzg",
+  "is_batch":true,
+  "confirmations":1330061
+})";
+
+const auto tx2 = R"({
+  "row_id":17386566,
+  "hash":"ooaZnj71WWrzG2by1mAX9sGXXKk46sAg19FR1tBcY7VSMEAm1wp",
+  "type":"transaction",
+  "block":"BLsiDcDBQnqPF2fZP178iK1zzcxd1RNwEjXAdP5D1CFuX3Gcugd",
+  "time":"2019-11-06T13:21:37Z",
+  "height":682242,
+  "cycle":166,
+  "counter":2263645,
+  "op_l":3,
+  "op_p":0,
+  "op_c":1,
+  "op_i":0,
+  "status":"applied",
+  "is_success":true,
+  "is_contract":false,
+  "gas_limit":18000,
+  "gas_used":10207,
+  "gas_price":0.24493,
+  "storage_limit":257,
+  "storage_size":0,
+  "storage_paid":0,
+  "volume":1.513242,
+  "fee":0.0025,
+  "burned":0.257,
+  "days_destroyed":0.099832,
+  "sender":"tz1Xeg8GzmCYhs5pWxwzerryDiQqFZWTJHzg",
+  "receiver":"tz1VUgoKvoPsczqPAJe1Lge2JBM3QSuSnhi3",
+  "is_batch":true,
+  "confirmations":1330061
+})";
+
+TEST_F(TezosAccount, InterpetTransactionWithCorrectUidWhenOriginatedAccount) {
+    std::vector<ledger::core::Operation> operations;
+
+    const std::string& accAddress = account->getAccountAddress();
+
+    // Test when sent from originated account
+    {
+      auto parsedTx = ledger::core::JSONUtils::parse<ledger::core::TezosLikeTransactionParser>(tx1);
+      parsedTx->sender = accAddress;
+      parsedTx->originatedAccountUid = "someUid";
+      parsedTx->originatedAccountAddress = accAddress;
+      account->interpretTransaction(*parsedTx, operations);
+      EXPECT_EQ(operations.size(), 1);
+      EXPECT_EQ(operations[0].uid, "082aceada20da02b93fb900884dbbe3f76ad82edb8b67815166854ca147358fa");
+    }
+
+    // Test when received in originated account
+    {
+      auto parsedTx = ledger::core::JSONUtils::parse<ledger::core::TezosLikeTransactionParser>(tx2);
+      parsedTx->receiver = accAddress;
+      parsedTx->originatedAccountUid = "someUid";
+      parsedTx->originatedAccountAddress = accAddress;
+      account->interpretTransaction(*parsedTx, operations);
+      EXPECT_EQ(operations.size(), 2);
+      EXPECT_EQ(operations[1].uid, "071404545ec745cf078aab689521a936260219096d73fb7b372ce3443b9772a4");
+    }
+}
+
+TEST_F(TezosAccount, InterpetTransactionWithCorrectUidWithoutOriginatedAccount) {
+    std::vector<ledger::core::Operation> operations;
+
+    const std::string& accAddress = account->getAccountAddress();
+
+    // Test when sent from account
+    {
+      auto parsedTx = ledger::core::JSONUtils::parse<ledger::core::TezosLikeTransactionParser>(tx1);
+      parsedTx->sender = accAddress;
+      account->interpretTransaction(*parsedTx, operations);
+      EXPECT_EQ(operations.size(), 1);
+      EXPECT_EQ(operations[0].uid, "ba40df6c41b8115ec5b50f101364c916aa360972009c780f6d0fcea4e19c1476");
+    }
+
+    // Test when received in account
+    {
+      auto parsedTx = ledger::core::JSONUtils::parse<ledger::core::TezosLikeTransactionParser>(tx2);
+      parsedTx->receiver = accAddress;
+      account->interpretTransaction(*parsedTx, operations);
+      EXPECT_EQ(operations.size(), 2);
+      EXPECT_EQ(operations[1].uid, "d7ebd2fc71fdd7a552a8bd9ce0cd696871eec2cd8050861077046e7d3b069945");
+    }
+}
+
+
+TEST_F(TezosAccount, ComputeOperationUidWithValidTransaction) {
+    auto strTx = "036e766ee0733ef0fb6385f2034cfbd437247afad4b301ebce1b929a67ce4a0b8d6c00902c5d86590a2452f0ccf9c1fa55ae679de27d398e0aee94cb03a75100882700011ebab3538f6ca4223ee98b565846e47d273d112900";
+    auto txBytes = hex::toByteArray(strTx);
+    auto tx = std::dynamic_pointer_cast<TezosLikeTransactionApi>(api::TezosLikeTransactionBuilder::parseRawUnsignedTransaction(
+        ledger::core::currencies::TEZOS, txBytes, api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON));
+    tx->setRawTx(std::vector<unsigned char>{});
+    auto accAddress = ledger::core::TezosLikeAddress::fromBase58(account->getAccountAddress(), currency);
+    
+    // when sender
+    {
+      auto txTest = std::make_shared<TezosLikeTransactionApi>(*tx);
+      txTest->setSender(accAddress);
+      EXPECT_EQ(account->computeOperationUid(txTest), "7ce5bfdcb02056ffe84412ab15504cda6bd02ac38ce211826cfd1a9b6b236184");
+    }
+
+    // when receiver
+    {
+      auto txTest = std::make_shared<TezosLikeTransactionApi>(*tx);
+      txTest->setReceiver(accAddress);
+      EXPECT_EQ(account->computeOperationUid(txTest), "01f1f96874f5ea39ad4eec831d4291b249b95f2ebc4672884124ebc0f47a260e");
+    }
+
+}
+
+
+TEST_F(TezosAccount, ComputeOperationUidWithInvalidTransaction) {
+    auto strTx = "036e766ee0733ef0fb6385f2034cfbd437247afad4b301ebce1b929a67ce4a0b8d6c00902c5d86590a2452f0ccf9c1fa55ae679de27d398e0aee94cb03a75100882700011ebab3538f6ca4223ee98b565846e47d273d112900";
+    auto txBytes = hex::toByteArray(strTx);
+    auto tx = std::dynamic_pointer_cast<TezosLikeTransactionApi>(api::TezosLikeTransactionBuilder::parseRawUnsignedTransaction(
+        ledger::core::currencies::TEZOS, txBytes, api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON));
+    tx->setRawTx(std::vector<unsigned char>{});
+    EXPECT_ANY_THROW(account->computeOperationUid(tx));
+}

--- a/core/test/tezos/tezos_account.cpp
+++ b/core/test/tezos/tezos_account.cpp
@@ -130,7 +130,7 @@ TEST_F(TezosAccount, InterpetTransactionWithCorrectUidWhenOriginatedAccount) {
       parsedTx->originatedAccountAddress = accAddress;
       account->interpretTransaction(*parsedTx, operations);
       EXPECT_EQ(operations.size(), 1);
-      EXPECT_EQ(operations[0].uid, "082aceada20da02b93fb900884dbbe3f76ad82edb8b67815166854ca147358fa");
+      EXPECT_EQ(operations[0].uid, OperationDatabaseHelper::createUid(account->getAccountUid(), "2263644+0+OPERATION_TAG_REVEAL+someUid", api::OperationType::SEND));
     }
 
     // Test when received in originated account
@@ -141,7 +141,7 @@ TEST_F(TezosAccount, InterpetTransactionWithCorrectUidWhenOriginatedAccount) {
       parsedTx->originatedAccountAddress = accAddress;
       account->interpretTransaction(*parsedTx, operations);
       EXPECT_EQ(operations.size(), 2);
-      EXPECT_EQ(operations[1].uid, "071404545ec745cf078aab689521a936260219096d73fb7b372ce3443b9772a4");
+      EXPECT_EQ(operations[1].uid, OperationDatabaseHelper::createUid(account->getAccountUid(), "2263645+1+OPERATION_TAG_TRANSACTION+someUid", api::OperationType::RECEIVE));
     }
 }
 
@@ -156,7 +156,7 @@ TEST_F(TezosAccount, InterpetTransactionWithCorrectUidWithoutOriginatedAccount) 
       parsedTx->sender = accAddress;
       account->interpretTransaction(*parsedTx, operations);
       EXPECT_EQ(operations.size(), 1);
-      EXPECT_EQ(operations[0].uid, "ba40df6c41b8115ec5b50f101364c916aa360972009c780f6d0fcea4e19c1476");
+      EXPECT_EQ(operations[0].uid, OperationDatabaseHelper::createUid(account->getAccountUid(), "2263644+0+OPERATION_TAG_REVEAL", api::OperationType::SEND));
     }
 
     // Test when received in account
@@ -165,7 +165,7 @@ TEST_F(TezosAccount, InterpetTransactionWithCorrectUidWithoutOriginatedAccount) 
       parsedTx->receiver = accAddress;
       account->interpretTransaction(*parsedTx, operations);
       EXPECT_EQ(operations.size(), 2);
-      EXPECT_EQ(operations[1].uid, "d7ebd2fc71fdd7a552a8bd9ce0cd696871eec2cd8050861077046e7d3b069945");
+      EXPECT_EQ(operations[1].uid, OperationDatabaseHelper::createUid(account->getAccountUid(), "2263645+1+OPERATION_TAG_TRANSACTION", api::OperationType::RECEIVE));
     }
 }
 


### PR DESCRIPTION
## Changes:
* Fix potential regression on Tezos account sync
* Addition of unit tests to cover changes from previous PRs #848 & #849 
* Bump patch version

## References
* [VG-3094](https://ledgerhq.atlassian.net/browse/VG-3094)