### PR TITLE
Add segwit tests

### DIFF
--- a/core/idl/wallet/bitcoin/bitcoin_like_wallet.djinni
+++ b/core/idl/wallet/bitcoin/bitcoin_like_wallet.djinni
@@ -181,11 +181,11 @@ BitcoinLikeTransaction = interface +c {
     # through the full ledger stack
     # @return the OLD Correlation ID, if it was set (empty string if it was unset)
     setCorrelationId(correlationId : string) : string;
-    # Sign all inputs for given transaction. 
+    # Sign all inputs for given transaction.
     # Build DER encoded signature from RSV data.
     # @return SIGNING_SUCCEED if succeed case else refers to BitcoinLikeSignatureState enumeration
     setSignatures(signatures: list<BitcoinLikeSignature>, override: bool): BitcoinLikeSignatureState;
-    # Sign all inputs for given transaction. 
+    # Sign all inputs for given transaction.
     # @return SIGNING_SUCCEED if succeed case else refers to BitcoinLikeSignatureState enumeration
     setDERSignatures(signatures: list<binary>, override: bool): BitcoinLikeSignatureState;
 }
@@ -235,13 +235,6 @@ BitcoinLikePickingStrategy = enum {
 }
 
 BitcoinLikeTransactionBuilder = interface +c {
-    # Add the given input to the final transaction.
-    # @param transactionhash The hash of the transaction in where the UTXO can be located.
-    # @params index Index of the UTXO in the previous transaction
-    # @params sequence Sequence number to add at the end of the input serialization. This can be used for RBF transaction
-    # @return A reference on the same builder in order to chain calls.
-    addInput(transactionHash: string, index: i32, sequence: i32): BitcoinLikeTransactionBuilder;
-
     # Add the given output to the final transaction.
     # @return A reference on the same builder in order to chain calls.
     addOutput(amount: Amount, script: BitcoinLikeScript): BitcoinLikeTransactionBuilder;
@@ -303,7 +296,7 @@ BitcoinLikeTransactionBuilder = interface +c {
     reset();
 
     # Set the correlation id which can be used to debug transaction errors
-    # through the full ledger stack 
+    # through the full ledger stack
     # @return A reference on the same builder in order to chain calls.
     setCorrelationId(correlationId : string) : BitcoinLikeTransactionBuilder;
 

--- a/core/src/api/BitcoinLikeTransaction.hpp
+++ b/core/src/api/BitcoinLikeTransaction.hpp
@@ -92,14 +92,14 @@ public:
     virtual std::string setCorrelationId(const std::string & correlationId) = 0;
 
     /**
-     * Sign all inputs for given transaction. 
+     * Sign all inputs for given transaction.
      * Build DER encoded signature from RSV data.
      * @return SIGNING_SUCCEED if succeed case else refers to BitcoinLikeSignatureState enumeration
      */
     virtual BitcoinLikeSignatureState setSignatures(const std::vector<BitcoinLikeSignature> & signatures, bool override) = 0;
 
     /**
-     * Sign all inputs for given transaction. 
+     * Sign all inputs for given transaction.
      * @return SIGNING_SUCCEED if succeed case else refers to BitcoinLikeSignatureState enumeration
      */
     virtual BitcoinLikeSignatureState setDERSignatures(const std::vector<std::vector<uint8_t>> & signatures, bool override) = 0;

--- a/core/src/api/BitcoinLikeTransactionBuilder.hpp
+++ b/core/src/api/BitcoinLikeTransactionBuilder.hpp
@@ -31,15 +31,6 @@ public:
     virtual ~BitcoinLikeTransactionBuilder() {}
 
     /**
-     * Add the given input to the final transaction.
-     * @param transactionhash The hash of the transaction in where the UTXO can be located.
-     * @params index Index of the UTXO in the previous transaction
-     * @params sequence Sequence number to add at the end of the input serialization. This can be used for RBF transaction
-     * @return A reference on the same builder in order to chain calls.
-     */
-    virtual std::shared_ptr<BitcoinLikeTransactionBuilder> addInput(const std::string & transactionHash, int32_t index, int32_t sequence) = 0;
-
-    /**
      * Add the given output to the final transaction.
      * @return A reference on the same builder in order to chain calls.
      */
@@ -123,7 +114,7 @@ public:
 
     /**
      * Set the correlation id which can be used to debug transaction errors
-     * through the full ledger stack 
+     * through the full ledger stack
      * @return A reference on the same builder in order to chain calls.
      */
     virtual std::shared_ptr<BitcoinLikeTransactionBuilder> setCorrelationId(const std::string & correlationId) = 0;

--- a/core/src/jni/jni/BitcoinLikeTransactionBuilder.cpp
+++ b/core/src/jni/jni/BitcoinLikeTransactionBuilder.cpp
@@ -25,18 +25,6 @@ CJNIEXPORT void JNICALL Java_co_ledger_core_BitcoinLikeTransactionBuilder_00024C
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeTransactionBuilder_00024CppProxy_native_1addInput(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jstring j_transactionHash, jint j_index, jint j_sequence)
-{
-    try {
-        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::BitcoinLikeTransactionBuilder>(nativeRef);
-        auto r = ref->addInput(::djinni::String::toCpp(jniEnv, j_transactionHash),
-                               ::djinni::I32::toCpp(jniEnv, j_index),
-                               ::djinni::I32::toCpp(jniEnv, j_sequence));
-        return ::djinni::release(::djinni_generated::BitcoinLikeTransactionBuilder::fromCpp(jniEnv, r));
-    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
-}
-
 CJNIEXPORT jobject JNICALL Java_co_ledger_core_BitcoinLikeTransactionBuilder_00024CppProxy_native_1addOutput(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jobject j_amount, jobject j_script)
 {
     try {

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeTransactionBuilder.cpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeTransactionBuilder.cpp
@@ -48,7 +48,7 @@ namespace ledger {
         )); // Max ui512
 
         BitcoinLikeTransactionBuilder::BitcoinLikeTransactionBuilder(const BitcoinLikeTransactionBuilder &cpy)
-                : _request(std::make_shared<BigInt>(cpy._currency.bitcoinLikeNetworkParameters.value().Dust)) { 
+                : _request(std::make_shared<BigInt>(cpy._currency.bitcoinLikeNetworkParameters.value().Dust)) {
             _currency = cpy._currency;
             _build = cpy._build;
             _request = cpy._request;
@@ -60,20 +60,12 @@ namespace ledger {
                 const std::shared_ptr<api::ExecutionContext> &context, const api::Currency &currency,
                 const std::shared_ptr<spdlog::logger> &logger,
                 const BitcoinLikeTransactionBuildFunction &buildFunction) :
-                _request(std::make_shared<BigInt>(currency.bitcoinLikeNetworkParameters.value().Dust)) { 
+                _request(std::make_shared<BigInt>(currency.bitcoinLikeNetworkParameters.value().Dust)) {
             _currency = currency;
             _build = buildFunction;
             _context = context;
             _logger = logger;
             _request.wipe = false;
-        }
-
-        std::shared_ptr<api::BitcoinLikeTransactionBuilder>
-        BitcoinLikeTransactionBuilder::addInput(const std::string &transactionHash, int32_t index, int32_t sequence) {
-            _request.inputs.push_back(BitcoinLikeTransactionInputDescriptor{
-                transactionHash, static_cast<uint64_t>(index), static_cast<uint64_t>(sequence)});
-
-            return shared_from_this();
         }
 
         std::shared_ptr<api::BitcoinLikeTransactionBuilder>
@@ -106,7 +98,7 @@ namespace ledger {
         std::shared_ptr<api::BitcoinLikeTransactionBuilder>
         BitcoinLikeTransactionBuilder::pickInputs(api::BitcoinLikePickingStrategy strategy, int32_t sequence, optional<int32_t> maxUtxo) {
             //Fix: use uniform initialization
-            
+
             BitcoinUtxoPickerParams new_utxo_picker{strategy, sequence, maxUtxo};
             _request.utxoPicker = Option<BitcoinUtxoPickerParams>(std::move(new_utxo_picker));
             return shared_from_this();
@@ -167,7 +159,7 @@ namespace ledger {
 
         void BitcoinLikeTransactionBuilder::reset() {
             _request = BitcoinLikeTransactionBuildRequest(std::make_shared<BigInt>(
-            _currency.bitcoinLikeNetworkParameters.value().Dust) 
+            _currency.bitcoinLikeNetworkParameters.value().Dust)
             );
         }
 

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeTransactionBuilder.h
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeTransactionBuilder.h
@@ -100,8 +100,6 @@ namespace ledger {
                     const std::shared_ptr<spdlog::logger>& logger,
                     const BitcoinLikeTransactionBuildFunction& buildFunction);
             BitcoinLikeTransactionBuilder(const BitcoinLikeTransactionBuilder& cpy);
-            std::shared_ptr<api::BitcoinLikeTransactionBuilder>
-            addInput(const std::string &transactionHash, int32_t index, int32_t sequence) override;
 
             std::shared_ptr<api::BitcoinLikeTransactionBuilder> addOutput(const std::shared_ptr<api::Amount> &amount,
                                                                           const std::shared_ptr<api::BitcoinLikeScript> &script) override;

--- a/core/test/fixtures/txes_to_wpkh._fixtures.cpp
+++ b/core/test/fixtures/txes_to_wpkh._fixtures.cpp
@@ -1,0 +1,31 @@
+#include "txes_to_wpkh_fixtures.h"
+
+namespace ledger {
+	namespace testing {
+		namespace txes_to_wpkh {
+			core::api::ExtendedKeyAccountCreationInfo XPUB_INFO(
+                0, {"main"}, {"84'/0'/0'"}, {"xpub6C2qnauSiRRR8UG9PXraYrfBtXZHzFRNgwJgwG7ZDp7SbWAdMSiMFoYDukTw4ExE95H4VkgECnhDe2uyLawoqUkoSHEDnoDafC2R44dXs7p"}
+			);
+            // xpub from https://github.com/LedgerHQ/xpub-scan/blob/master/.github/workflows/regression_tests/datasets.json
+            const std::vector<std::string> TXes =
+            {
+                "{\"hash\":\"4b3a5535d24d882233bb991a2e6fa111e64294aadcd140960cdceada2fae1bb8\",\"received_at\":\"2020-06-26T13:58:11Z\",\"lock_time\":0,\"block\":{\"hash\":\"00000000000000000003f12608c713d887fc216753ba70b264cc54379415928b\",\"height\":636436,\"time\":\"2020-06-26T14:29:17Z\"},\"inputs\":[{\"input_index\":0,\"output_hash\":\"70dcda8357d590f0cfb6cd504731d427db76fe03616f57c7af8366106af67092\",\"output_index\":1,\"value\":37471,\"address\":\"3MVXMz1zCEBScDM1pMsifuYavjzEjxCfM6\",\"script_signature\":\"160014682a7e09d3f88f56f6e9ed0a9511f064b79ab722\",\"sequence\":0,\"txinwitness\":[\"30450221009575c1fc1890db00b7cc33426954b19e516d19b03fd9fc924579e718f8437e4902203f0f5b8763c389548c910bbd7cd72a8d0bb1f35ba67f5b53f9ca1620bc86139801\",\"0378b2de4c77eaa8c1285ff73837a4b7abe9babf30e1cbc522329e0e15db2c03bc\"]}],\"outputs\":[{\"output_index\":0,\"value\":27278,\"address\":\"bc1qr500ysrg653aaplftaac753srtt2jwtfvcr5vt\",\"script_hex\":\"00141d1ef24068d523de87e95f7b8f52301ad6a93969\"},{\"output_index\":1,\"value\":9017,\"address\":\"3Nq7i7JRT7rzoKhhnxE3F8hbp1FpjN9jmV\",\"script_hex\":\"a914e7e2cc7a5d070144867183cd27b13db3b074883b87\"}],\"fees\":1176,\"amount\":36295,\"confirmations\":86334}",
+                "{\"hash\":\"673f7e1155dd2cf61c961cedd24608274c0f20cfaeaa1154c2b5ef94ec7b81d1\",\"received_at\":\"2021-09-08T12:45:21Z\",\"lock_time\":0,\"block\":{\"hash\":\"00000000000000000003fa8ebda5058dca475e65a8aaf692dc5a7449cf6e5a89\",\"height\":699622,\"time\":\"2021-09-08T12:58:43Z\"},\"inputs\":[{\"input_index\":0,\"output_hash\":\"4b3a5535d24d882233bb991a2e6fa111e64294aadcd140960cdceada2fae1bb8\",\"output_index\":0,\"value\":27278,\"address\":\"bc1qr500ysrg653aaplftaac753srtt2jwtfvcr5vt\",\"script_signature\":\"\",\"sequence\":0,\"txinwitness\":[\"304402205e18af8a590bdfd5c9e4f2e349b105ec5efb56b5fd3cf07e69786ef979d53ff4022069f8fd41fb6e9edee10d80f5bd8144a72ee1c609d93512487e362733103f78d201\",\"026f85f41f6a4ba5a1fc6819ffcfd9013e2ccd372b94e31fe867362035b38f1652\"]}],\"outputs\":[{\"output_index\":0,\"value\":1000,\"address\":\"bc1qrewjj96rjfzc9z2al0hvs2jtdc58nkgvrr6fgv\",\"script_hex\":\"00141e5d291743924582895dfbeec82a4b6e2879d90c\"},{\"output_index\":1,\"value\":25402,\"address\":\"bc1qz2z9dnhzwhveqemt9utryeucqnjuupenmfzsxv\",\"script_hex\":\"0014128456cee275d990676b2f1632679804e5ce0733\"}],\"fees\":876,\"amount\":26402,\"confirmations\":23148}",
+                "{\"hash\":\"5464631456754e6b410d5d9eb7cff4f82d1dc9aec0e2ec8fe759df6118e0112f\",\"received_at\":\"2021-11-20T12:48:08Z\",\"lock_time\":0,\"block\":{\"hash\":\"0000000000000000000b96dc8d6e75dc3eb4f995a10545f84ad1b8f1de4b9893\",\"height\":710566,\"time\":\"2021-11-20T12:52:04Z\"},\"inputs\":[{\"input_index\":0,\"output_hash\":\"4fadad2c103014ebaa3073ea63ff060b27d2d30b4e7f956727b97a44d1cf8ad7\",\"output_index\":0,\"value\":67218,\"address\":\"bc1qr500ysrg653aaplftaac753srtt2jwtfvcr5vt\",\"script_signature\":\"\",\"sequence\":4294967295,\"txinwitness\":[\"304402201668900493e07d2a4c2cf2b9c98a2b3ad1afc83da34cf727098077f34111209202202da599d4368331def39c95eab86480a9e9772fe4a393ad97d7174358becf422a01\",\"026f85f41f6a4ba5a1fc6819ffcfd9013e2ccd372b94e31fe867362035b38f1652\"]}],\"outputs\":[{\"output_index\":0,\"value\":60000,\"address\":\"1MD43R5k9qoAch5nUxk3BxNkVxpGbDS8iw\",\"script_hex\":\"76a914ddaa0bd7223bd2b5e61e8e7541fc22b9197440d288ac\"},{\"output_index\":1,\"value\":6780,\"address\":\"bc1q98csrhfkzrvkeee0k6jn70xdl2ghtewlkxva87\",\"script_hex\":\"001429f101dd3610d96ce72fb6a53f3ccdfa9175e5df\"}],\"fees\":438,\"amount\":66780,\"confirmations\":12204}",
+                "{\"hash\":\"4fadad2c103014ebaa3073ea63ff060b27d2d30b4e7f956727b97a44d1cf8ad7\",\"received_at\":\"2021-11-20T12:43:20Z\",\"lock_time\":0,\"block\":{\"hash\":\"0000000000000000000b96dc8d6e75dc3eb4f995a10545f84ad1b8f1de4b9893\",\"height\":710566,\"time\":\"2021-11-20T12:52:04Z\"},\"inputs\":[{\"input_index\":0,\"output_hash\":\"6b1c1bab2ce9a3429c4ddbbecf70d5ca2ac9a27634ebc8dd2dff347073eb1e39\",\"output_index\":0,\"value\":67554,\"address\":\"bc1qrd58306xwnpxegh76tp8gns4jxvjm7zxv3zzlc\",\"script_signature\":\"\",\"sequence\":4294967295,\"txinwitness\":[\"3045022100c27cd772986b8b82af189be7260a1e436e1a0573f8e908570b0fc55cd33541f4022059c575c3738acc502651ac0806816e91c9775cc253ee1f6798c2cf87901bb6c501\",\"0242dedafae7bdaf0c2b0ec74d2e1d83f874c11ad71e4a00031301e3aeb3322a6f\"]}],\"outputs\":[{\"output_index\":0,\"value\":67218,\"address\":\"bc1qr500ysrg653aaplftaac753srtt2jwtfvcr5vt\",\"script_hex\":\"00141d1ef24068d523de87e95f7b8f52301ad6a93969\"}],\"fees\":336,\"amount\":67218,\"confirmations\":12204}"
+            };
+			std::shared_ptr<core::BitcoinLikeAccount> inflate(const std::shared_ptr<core::WalletPool>& pool, const std::shared_ptr<core::AbstractWallet>& wallet) {
+                auto account
+                        = std::dynamic_pointer_cast<ledger::core::BitcoinLikeAccount>(
+                            uv::wait(wallet->newAccountWithExtendedKeyInfo(XPUB_INFO)));
+                for (const std::string& tx : TXes) {
+                    std::vector<ledger::core::Operation> operations;
+                    const auto parsedTx = ledger::core::JSONUtils::parse<ledger::core::TransactionParser>(tx);
+                    account->interpretTransaction(*parsedTx, operations, true);
+                    account->bulkInsert(operations);
+                }
+				return account;
+			}
+		}
+	}
+}

--- a/core/test/fixtures/txes_to_wpkh_fixtures.h
+++ b/core/test/fixtures/txes_to_wpkh_fixtures.h
@@ -1,0 +1,41 @@
+#ifndef LEDGER_FIXTURES_TXES_TO_WPKH
+#define LEDGER_FIXTURES_TXES_TO_WPKH
+#include <gtest/gtest.h>
+#include <UvThreadDispatcher.hpp>
+#include <src/database/DatabaseSessionPool.hpp>
+#include <NativePathResolver.hpp>
+#include <unordered_set>
+#include <src/wallet/pool/WalletPool.hpp>
+#include <CoutLogPrinter.hpp>
+#include <src/api/DynamicObject.hpp>
+#include <wallet/common/CurrencyBuilder.hpp>
+#include <wallet/bitcoin/BitcoinLikeWallet.hpp>
+#include <wallet/bitcoin/database/BitcoinLikeWalletDatabase.h>
+#include <wallet/bitcoin/database/BitcoinLikeTransactionDatabaseHelper.h>
+#include <wallet/common/database/AccountDatabaseHelper.h>
+#include <wallet/pool/database/PoolDatabaseHelper.hpp>
+#include <utils/JSONUtils.h>
+#include <wallet/bitcoin/explorers/api/TransactionParser.hpp>
+#include <wallet/bitcoin/BitcoinLikeAccount.hpp>
+#include <api/BitcoinLikeOperation.hpp>
+#include <api/BitcoinLikeTransaction.hpp>
+#include <api/BitcoinLikeInput.hpp>
+#include <api/BitcoinLikeOutput.hpp>
+#include <api/BigInt.hpp>
+#include <CppHttpLibClient.hpp>
+#include <events/LambdaEventReceiver.hpp>
+#include <soci.h>
+#include <api/Account.hpp>
+#include <api/BitcoinLikeAccount.hpp>
+
+namespace ledger {
+	namespace testing {
+		namespace txes_to_wpkh {
+			extern core::api::ExtendedKeyAccountCreationInfo XPUB_INFO;
+
+			std::shared_ptr<core::BitcoinLikeAccount> inflate(const std::shared_ptr<core::WalletPool>& pool, const std::shared_ptr<core::AbstractWallet>& wallet);
+		}
+	}
+}
+
+#endif // LEDGER_FIXTURES_TXES_TO_WPKH

--- a/core/test/integration/http_cache/BitcoinMakeTransactionFromLegacyToNativeSegwit.CreateStandardP2WPKHWithOneOutput
+++ b/core/test/integration/http_cache/BitcoinMakeTransactionFromLegacyToNativeSegwit.CreateStandardP2WPKHWithOneOutput
@@ -1,0 +1,10 @@
+GET https://explorers.api.live.ledger.com/blockchain/v2/btc/blocks/current
+0
+1
+{"hash":"00000000000000000008db19835048ecdd79d0974f4bd1a1d5492a5502f1d61c","height":722923,"time":"2022-02-12T11:49:27Z","txs":[]}
+
+GET https://explorers.api.live.ledger.com/timestamp
+0
+1
+{"timestamp":1644666863}
+

--- a/core/test/integration/http_cache/BitcoinMakeTransactionFromLegacyToP2WSH.CreateStandardP2WSHWithOneOutput
+++ b/core/test/integration/http_cache/BitcoinMakeTransactionFromLegacyToP2WSH.CreateStandardP2WSHWithOneOutput
@@ -1,0 +1,10 @@
+GET https://explorers.api.live.ledger.com/blockchain/v2/btc/blocks/current
+0
+1
+{"hash":"00000000000000000008db19835048ecdd79d0974f4bd1a1d5492a5502f1d61c","height":722923,"time":"2022-02-12T11:49:27Z","txs":[]}
+
+GET https://explorers.api.live.ledger.com/timestamp
+0
+1
+{"timestamp":1644666863}
+

--- a/core/test/integration/http_cache/BitcoinMakeTransactionFromNativeSegwitToNativeSegwit.CreateStandardP2WPKHWithOneOutput
+++ b/core/test/integration/http_cache/BitcoinMakeTransactionFromNativeSegwitToNativeSegwit.CreateStandardP2WPKHWithOneOutput
@@ -1,0 +1,10 @@
+GET https://explorers.api.live.ledger.com/blockchain/v2/btc/blocks/current
+0
+1
+{"hash":"00000000000000000008db19835048ecdd79d0974f4bd1a1d5492a5502f1d61c","height":722923,"time":"2022-02-12T11:49:27Z","txs":[]}
+
+GET https://explorers.api.live.ledger.com/timestamp
+0
+1
+{"timestamp":1644666863}
+

--- a/core/test/integration/http_cache/BitcoinMakeTransactionFromNativeSegwitToP2WSH.CreateStandardP2WSHWithOneOutput
+++ b/core/test/integration/http_cache/BitcoinMakeTransactionFromNativeSegwitToP2WSH.CreateStandardP2WSHWithOneOutput
@@ -1,0 +1,10 @@
+GET https://explorers.api.live.ledger.com/blockchain/v2/btc/blocks/current
+0
+1
+{"hash":"00000000000000000008db19835048ecdd79d0974f4bd1a1d5492a5502f1d61c","height":722923,"time":"2022-02-12T11:49:27Z","txs":[]}
+
+GET https://explorers.api.live.ledger.com/timestamp
+0
+1
+{"timestamp":1644666863}
+

--- a/core/test/integration/transactions/coin_selection_P2PKH.cpp
+++ b/core/test/integration/transactions/coin_selection_P2PKH.cpp
@@ -131,7 +131,7 @@ TEST_F(CoinSelectionP2PKH, HighestFirstNotEnough) {
         builder->pickInputs(api::BitcoinLikePickingStrategy::HIGHEST_FIRST_LIMIT_UTXO, 0xFFFFFFFF, optional<int32_t>(2));
         builder->setFeesPerByte(api::Amount::fromLong(currency, 0));
         auto f = builder->build();
-        EXPECT_THROW(uv::wait(f), Exception);    
+        EXPECT_THROW(uv::wait(f), Exception);
 }
 
 TEST_F(CoinSelectionP2PKH, LimitUtxoPickStrategy) {
@@ -161,7 +161,7 @@ TEST_F(CoinSelectionP2PKH, LimitUtxoPickStrategy) {
             EXPECT_EQ(tx->getOutputs().at(0)->getValue()->toLong(), 50000000);
         }
         {//test 3
-            EXPECT_THROW(build(100000000), Exception); 
+            EXPECT_THROW(build(100000000), Exception);
         }
         {//test 4
             auto tx = build(10000000);
@@ -185,7 +185,7 @@ TEST_F(CoinSelectionP2PKH, maxSpendable) {
         EXPECT_EQ(120000000, uv::wait(
                 account->getMaxSpendable(api::BitcoinLikePickingStrategy::LIMIT_UTXO, optional<int32_t>(3)))->toLong());
         EXPECT_EQ(150000000, uv::wait(
-                account->getMaxSpendable(api::BitcoinLikePickingStrategy::LIMIT_UTXO, optional<int32_t>(7)))->toLong());       
+                account->getMaxSpendable(api::BitcoinLikePickingStrategy::LIMIT_UTXO, optional<int32_t>(7)))->toLong());
 }
 
 TEST_F(CoinSelectionP2PKH, PickAllUTXO) {

--- a/core/test/integration/transactions/transaction_test_helper.h
+++ b/core/test/integration/transactions/transaction_test_helper.h
@@ -48,7 +48,6 @@
 #include <wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.h>
 #include "../BaseFixture.h"
 
-
 using namespace ledger::core;
 
 struct TransactionTestData {
@@ -69,11 +68,23 @@ struct TransactionTestData {
 
 struct BitcoinMakeBaseTransaction : public BaseFixture {
 
+    struct InputDescr {
+        std::string _tx_hash;
+        int32_t _out_idx;
+        std::shared_ptr<api::BigInt> _amount;
+    };
+
+    struct OutputDescr {
+        std::string _addr;            // for tx building
+        std::vector<uint8_t> _script; // for tx verification
+        std::shared_ptr<api::BigInt> _amount;
+    };
+
     void SetUp() override {
         BaseFixture::SetUp();
         SetUpConfig();
         recreate();
-    }
+    };
 
     virtual void recreate() {
         pool = newDefaultPool();
@@ -92,6 +103,18 @@ struct BitcoinMakeBaseTransaction : public BaseFixture {
     std::shared_ptr<BitcoinLikeTransactionBuilder> tx_builder() {
         return std::dynamic_pointer_cast<BitcoinLikeTransactionBuilder>(account->buildTransaction(false));
     }
+
+    std::shared_ptr<api::BitcoinLikeTransaction> createTransaction(const std::vector<OutputDescr>& outputs);
+
+    bool verifyTransactionInputs(std::shared_ptr<api::BitcoinLikeTransaction> tx,
+                                 const std::vector<InputDescr>& inputs);
+    bool verifyTransactionOutputs(std::shared_ptr<api::BitcoinLikeTransaction> tx,
+                                  const std::vector<OutputDescr>& outputs);
+
+    bool verifyTransaction(std::shared_ptr<api::BitcoinLikeTransaction> tx,
+                           const std::vector<InputDescr>& inputs,
+                           const std::vector<OutputDescr>& outputs);
+
     std::shared_ptr<WalletPool> pool;
     std::shared_ptr<AbstractWallet> wallet;
     std::shared_ptr<BitcoinLikeAccount> account;

--- a/core/test/tezos/tezos_account.cpp
+++ b/core/test/tezos/tezos_account.cpp
@@ -169,15 +169,24 @@ TEST_F(TezosAccount, InterpetTransactionWithCorrectUidWithoutOriginatedAccount) 
     }
 }
 
+struct TezosAccountWithFixedPoolName : public TezosAccount {
+    virtual void recreate() {
+        SetUpConfig();
+        pool = newDefaultPool("my_ppol");
+        wallet = uv::wait(pool->createWallet(testData.walletName, testData.currencyName, testData.configuration));
+        account = testData.inflate_xtz(pool, wallet);
+        currency = wallet->getCurrency();
+    }
+};
 
-TEST_F(TezosAccount, ComputeOperationUidWithValidTransaction) {
+TEST_F(TezosAccountWithFixedPoolName, ComputeOperationUidWithValidTransaction) {
     auto strTx = "036e766ee0733ef0fb6385f2034cfbd437247afad4b301ebce1b929a67ce4a0b8d6c00902c5d86590a2452f0ccf9c1fa55ae679de27d398e0aee94cb03a75100882700011ebab3538f6ca4223ee98b565846e47d273d112900";
     auto txBytes = hex::toByteArray(strTx);
     auto tx = std::dynamic_pointer_cast<TezosLikeTransactionApi>(api::TezosLikeTransactionBuilder::parseRawUnsignedTransaction(
         ledger::core::currencies::TEZOS, txBytes, api::TezosConfigurationDefaults::TEZOS_PROTOCOL_UPDATE_BABYLON));
     tx->setRawTx(std::vector<unsigned char>{});
     auto accAddress = ledger::core::TezosLikeAddress::fromBase58(account->getAccountAddress(), currency);
-    
+
     // when sender
     {
       auto txTest = std::make_shared<TezosLikeTransactionApi>(*tx);
@@ -195,7 +204,7 @@ TEST_F(TezosAccount, ComputeOperationUidWithValidTransaction) {
 }
 
 
-TEST_F(TezosAccount, ComputeOperationUidWithInvalidTransaction) {
+TEST_F(TezosAccountWithFixedPoolName, ComputeOperationUidWithInvalidTransaction) {
     auto strTx = "036e766ee0733ef0fb6385f2034cfbd437247afad4b301ebce1b929a67ce4a0b8d6c00902c5d86590a2452f0ccf9c1fa55ae679de27d398e0aee94cb03a75100882700011ebab3538f6ca4223ee98b565846e47d273d112900";
     auto txBytes = hex::toByteArray(strTx);
     auto tx = std::dynamic_pointer_cast<TezosLikeTransactionApi>(api::TezosLikeTransactionBuilder::parseRawUnsignedTransaction(

--- a/core/test/tezos/transaction_test.hpp
+++ b/core/test/tezos/transaction_test.hpp
@@ -19,17 +19,17 @@ namespace ledger {
     namespace testing {
         namespace tezos {
 
-           
 
-            
+
+
             struct TezosMakeBaseTransaction : public BaseFixture {
 
                 void SetUp() override;
 
-                void recreate();
+                virtual void recreate();
 
                 void TearDown() override;
-                            
+
                 struct Callback: public api::StringCallback {
                     Callback(std::shared_ptr<uv::UvThreadDispatcher> dispatcher): _dispatcher(dispatcher)
                     {}


### PR DESCRIPTION
- Adds CreateTransaction tests with P2WPKH and P2WSH outputs.
- Removes BitcoinLikeTransactionBuilder::addInput method (not used, probably incorrectly implemented).
- Fixes Tezos tests that require stable account id.