### PR TITLE
VG-3617: Fix some weird crash in wd integration tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include_what_you_use()  # add cmake conf option IWYU=ON to activate
 # The project version number.
 set(VERSION_MAJOR   4   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   1   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   5   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   6   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/core/src/math/Base58.cpp
+++ b/core/src/math/Base58.cpp
@@ -35,6 +35,7 @@
 #include <utils/hex.h>
 #include <functional>
 #include <crypto/Keccak.h>
+#include <vector>
 
 using namespace ledger::core;
 static const std::string DIGITS = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
@@ -62,7 +63,7 @@ std::string ledger::core::Base58::encode(const std::vector<uint8_t> &bytes,
     pend = len;
     while (pbegin != pend && !bytes[pbegin]) pbegin = ++zeros;
     const int size = 1 + iFactor * (double)(pend - pbegin);
-    unsigned char* b58 = new unsigned char[size];
+    std::vector<unsigned char> b58(size, 0);
     for (int i = 0; i < size; i++) b58[i] = 0;
     while (pbegin != pend) {
         unsigned int carry = bytes[pbegin];
@@ -82,7 +83,6 @@ std::string ledger::core::Base58::encode(const std::vector<uint8_t> &bytes,
     int ri = 0;
     while (ri < zeros) { result += base58Dictionary[0]; ri++; }
     for (; it2 < size; ++it2) result += base58Dictionary[b58[it2]];
-    delete[] b58;
     return result;
 }
 

--- a/core/src/utils/DateUtils.cpp
+++ b/core/src/utils/DateUtils.cpp
@@ -52,8 +52,8 @@ namespace {
             {"Dec", "12"},
     };
 
-    const std::regex PARSE_JSON_DATE_REGEX("([0-9]+)-([0-9]+)-([0-9]+)T([0-9]+):([0-9]+):([0-9]+)[\\.0-9]*([Z]?)");
-    const std::regex FORMAT_JSON_DATE_REGEX("([0-9]+)-([a-zA-Z]+)-([0-9]+) ([0-9]+):([0-9]+):([0-9]+)[\\.0-9]*([Z]?)");
+    constexpr auto PARSE_JSON_DATE_REGEX("([0-9]+)-([0-9]+)-([0-9]+)T([0-9]+):([0-9]+):([0-9]+)[\\.0-9]*([Z]?)");
+    constexpr auto FORMAT_JSON_DATE_REGEX("([0-9]+)-([a-zA-Z]+)-([0-9]+) ([0-9]+):([0-9]+):([0-9]+)[\\.0-9]*([Z]?)");
 }
 
 #if defined(_WIN32) || defined(_WIN64)
@@ -67,9 +67,11 @@ namespace {
 namespace ledger {
     namespace core {
         std::chrono::system_clock::time_point ledger::core::DateUtils::fromJSON(const std::string &str) {
+            static const std::regex parseJsonDateRegex {PARSE_JSON_DATE_REGEX};
+
             std::cmatch what;
 
-            if (regex_match(str.c_str(), what, PARSE_JSON_DATE_REGEX)) {
+            if (regex_match(str.c_str(), what, parseJsonDateRegex)) {
                 auto year = boost::lexical_cast<unsigned int>(std::string(what[1].first, what[1].second));
                 auto month = boost::lexical_cast<unsigned int>(std::string(what[2].first, what[2].second));
                 auto day = boost::lexical_cast<unsigned int>(std::string(what[3].first, what[3].second));
@@ -104,10 +106,11 @@ namespace ledger {
     }
 
     std::string ledger::core::DateUtils::formatDateFromJSON(const std::string &str) {
+        static const std::regex formatJsonDateRegex {FORMAT_JSON_DATE_REGEX};
 
         std::cmatch what;
 
-        if (regex_match(str.c_str(), what, FORMAT_JSON_DATE_REGEX)) {
+        if (regex_match(str.c_str(), what, formatJsonDateRegex)) {
             auto year = boost::lexical_cast<unsigned int>(std::string(what[1].first, what[1].second));
             auto month = boost::lexical_cast<std::string>(std::string(what[2].first, what[2].second));
             auto day = boost::lexical_cast<unsigned int>(std::string(what[3].first, what[3].second));

--- a/core/src/wallet/bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp
+++ b/core/src/wallet/bitcoin/explorers/BitcoinLikeBlockchainExplorer.hpp
@@ -99,17 +99,7 @@ namespace ledger {
                 confirmations = -1;
             }
 
-            BitcoinLikeBlockchainExplorerTransaction(const BitcoinLikeBlockchainExplorerTransaction &cpy) {
-                this->confirmations = cpy.confirmations;
-                this->version = cpy.version;
-                this->outputs = cpy.outputs;
-                this->inputs = cpy.inputs;
-                this->receivedAt = cpy.receivedAt;
-                this->lockTime = cpy.lockTime;
-                this->fees = cpy.fees;
-                this->hash = cpy.hash;
-                this->block = cpy.block;
-            }
+            BitcoinLikeBlockchainExplorerTransaction(const BitcoinLikeBlockchainExplorerTransaction &cpy) = default;
         };
 
         class BitcoinLikeBlockchainExplorer : public ConfigurationMatchable,

--- a/core/src/wallet/bitcoin/explorers/api/InputParser.cpp
+++ b/core/src/wallet/bitcoin/explorers/api/InputParser.cpp
@@ -88,6 +88,8 @@ namespace ledger {
                 _input->coinbase = Option<std::string>(value);
             } else if (_lastKey == "value") {
                 _input->value = Option<BigInt>(BigInt::fromString(value));
+            } else if (_lastKey == "sequence") {
+                _input->sequence = BigInt::fromString(value).toUint64();
             }
             return true;
         }

--- a/core/src/wallet/bitcoin/explorers/api/TransactionParser.cpp
+++ b/core/src/wallet/bitcoin/explorers/api/TransactionParser.cpp
@@ -169,7 +169,11 @@ namespace ledger {
                 }
                 else if (_lastKey == "received_at") {
                     _transaction->receivedAt = DateUtils::fromJSON(value);
+                } else if (_lastKey == "fees") {
+                    BigInt intValue = BigInt::fromString(value);
+                    _transaction->fees = Option<BigInt>(intValue);
                 }
+                
                 return true;
             }
         }


### PR DESCRIPTION
## Changes:
* Fix a very specific weird crash that happens when loading the libcore from the Java runtime. It happens when initializing `std::regex` in static variables.  
* Fix btc transaction parsing when the explorer returns fees as string values (not integer). 
* Fix possible memory leak in Base58  (#859)
* Bump patch version to `4.1.6`

## References: 
* [VG-3617](https://ledgerhq.atlassian.net/browse/VG-3617)