### PR TITLE
[VG-3785] [VG-3957] Fix Tezos delegation amount and receiver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include_what_you_use()  # add cmake conf option IWYU=ON to activate
 # The project version number.
 set(VERSION_MAJOR   4   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   1   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   6   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   7   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/core/src/tezos/TezosLikeAddress.cpp
+++ b/core/src/tezos/TezosLikeAddress.cpp
@@ -75,6 +75,9 @@ namespace ledger {
         }
 
         std::string TezosLikeAddress::toBase58() {
+            if(_hash160.empty()) {
+                return std::string();
+            }
             auto config = std::make_shared<DynamicObject>();
             config->putString("networkIdentifier", _params.Identifier);
             return Base58::encodeWithChecksum(vector::concat(getVersion(), _hash160), config);

--- a/core/src/wallet/tezos/explorers/api/TezosLikeTransactionParser.cpp
+++ b/core/src/wallet/tezos/explorers/api/TezosLikeTransactionParser.cpp
@@ -138,7 +138,9 @@ namespace ledger {
                     && _transaction->block.hasValue()) {
                     _transaction->block.getValue().height = BigInt::fromString(number).toUint64();
                 } else if (_lastKey == "amount" || _lastKey == "volume") {
-                    _transaction->value = toValue(number, _lastKey == "volume");
+                    if(_transaction->type != api::TezosOperationTag::OPERATION_TAG_DELEGATION) {
+                        _transaction->value = toValue(number, _lastKey == "volume");
+                    }
                 } else if (_lastKey == "fee") {
                     _transaction->fees = _transaction->fees + toValue(number, false);
                 } else if (_lastKey == "gas_limit") {
@@ -222,6 +224,9 @@ namespace ledger {
                     if (_lastKey == "type" &&
                             _transaction->type == api::TezosOperationTag::OPERATION_TAG_ORIGINATION) {
                         _transaction->originatedAccount = TezosLikeBlockchainExplorerOriginatedAccount();
+                    } else if(_lastKey == "type" &&
+                            _transaction->type == api::TezosOperationTag::OPERATION_TAG_DELEGATION) {
+                        _transaction->value = BigInt(0);
                     }
 
                 } else if (_lastKey == "public_key" ||

--- a/core/src/wallet/tezos/explorers/api/TezosLikeTransactionParser.cpp
+++ b/core/src/wallet/tezos/explorers/api/TezosLikeTransactionParser.cpp
@@ -195,6 +195,11 @@ namespace ledger {
                 } else if (_lastKey == "sender" ||
                         (currentObject == "src" && _lastKey == "tz")) {
                     _transaction->sender = value;
+                } else if(_lastKey == "receiver" && _transaction->type == api::TezosOperationTag::OPERATION_TAG_DELEGATION) {
+                    // For undelegation, the API returns type=delegation & receiver attribute is defined
+                    // For delegation, the API returns type=delegation but receiver is not defined ('delegate' used instead)
+                    // Receiver should be empty to differentiate delegate from undelegate in db
+                    _transaction->receiver = "";
                 } else if (_lastKey == "receiver" || _lastKey == "delegate" ||
                         ((currentObject == "destination" || currentObject == "delegate") && _lastKey == "tz")) {
                     _transaction->receiver = value;

--- a/core/test/coin-integration/stellar/horizon_explorer_tests.cpp
+++ b/core/test/coin-integration/stellar/horizon_explorer_tests.cpp
@@ -92,7 +92,7 @@ TEST_F(StellarFixture, GetLastLedger) {
     auto ledger = uv::wait(explorer->getLastLedger());
     auto t = DateUtils::toJSON(ledger->time);
     EXPECT_TRUE(!ledger->hash.empty());
-    EXPECT_TRUE(ledger->height > 69859L);
+    EXPECT_TRUE(ledger->height > 21153L);
     EXPECT_TRUE(ledger->time > DateUtils::fromJSON("2015-07-16T23:49:00Z"));
 }
 


### PR DESCRIPTION
This PR addresses two defects, see References below.

## Changes
* Tezos transaction parser now sets the value (and thus operation "amount") to 0 for (un)delegation operations
* Tezos transaction parser now sets the receiver to empty for undelegation operations. This allows one to differentiate delegation and undelegation: 
  * delegation:  type `OPERATION_TAG_DELEGATION` and receiver is non-empty
  * undelegation: type `OPERATION_TAG_DELEGATION` and receiver is empty
* Bump patch version to `4.1.7`

## References
* [VG-3785 Wrong amount for delegate/undelegate txs for tezos](https://ledgerhq.atlassian.net/browse/VG-3785)
* [VG-3957 Undelegate transactions are not reconciled](https://ledgerhq.atlassian.net/browse/VG-3957)