### PR TITLE
VG-4357: Fix Tezos tx parser to handle new attributes from explorer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include_what_you_use()  # add cmake conf option IWYU=ON to activate
 # The project version number.
 set(VERSION_MAJOR   4   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   1   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   7   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   8   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/core/src/wallet/tezos/explorers/api/TezosLikeTransactionParser.cpp
+++ b/core/src/wallet/tezos/explorers/api/TezosLikeTransactionParser.cpp
@@ -195,15 +195,15 @@ namespace ledger {
                 } else if (_lastKey == "sender" ||
                         (currentObject == "src" && _lastKey == "tz")) {
                     _transaction->sender = value;
-                } else if(_lastKey == "receiver" && _transaction->type == api::TezosOperationTag::OPERATION_TAG_DELEGATION) {
+                } else if((_lastKey == "receiver" || _lastKey == "previous_baker") && _transaction->type == api::TezosOperationTag::OPERATION_TAG_DELEGATION) {
                     // For undelegation, the API returns type=delegation & receiver attribute is defined
                     // For delegation, the API returns type=delegation but receiver is not defined ('delegate' used instead)
                     // Receiver should be empty to differentiate delegate from undelegate in db
                     _transaction->receiver = "";
-                } else if (_lastKey == "receiver" || _lastKey == "delegate" ||
+                } else if (_lastKey == "receiver" || _lastKey == "delegate" || _lastKey == "baker" ||
                         ((currentObject == "destination" || currentObject == "delegate") && _lastKey == "tz")) {
                     _transaction->receiver = value;
-                    if (_lastKey == "receiver" &&
+                    if ((_lastKey == "receiver" || _lastKey == "baker") &&
                             _transaction->type == api::TezosOperationTag::OPERATION_TAG_ORIGINATION) {
                         _transaction->originatedAccount.getValue().address = value;
                     }


### PR DESCRIPTION
## Changes
* Fix the Tezos transaction parser to adapt to the new version of the tzstat API considering `delegation` operations. In particular:
  * now a delegation operation has a `baker` field instead of a `delegate` field
  * now a delegation withdraw operation has a `previous_baker`  field instead of a `receiver` field
* bump libcore version to `4.1.8`

## References
* [VG-4357- All delegations and undelegations are shown with the "UNDELEGATE" icon on tx list (seems to be a gate issue)](https://ledgerhq.atlassian.net/browse/VG-4357)