### PR TITLE
Fix/tzindex gas price

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include_what_you_use()  # add cmake conf option IWYU=ON to activate
 # The project version number.
 set(VERSION_MAJOR   4   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   1   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   8   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   9   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -34,8 +34,6 @@
 #include <api/TezosConfiguration.hpp>
 #include <api/TezosConfigurationDefaults.hpp>
 
-#include <iostream>
-
 namespace ledger {
     namespace core {
         ExternalTezosLikeBlockchainExplorer::ExternalTezosLikeBlockchainExplorer(

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -132,8 +132,8 @@ namespace ledger {
         ExternalTezosLikeBlockchainExplorer::getGasPrice() {
             const bool parseNumbersAsString = true;
             // Since tzindex 12.01, we don't have gas_price field anymore
-            // We have to calculate it instead from gas_used and fee
-            const auto gasUsedField = "gas_used";
+            // We have to calculate it instead from gas_limit and fee
+            const auto gasLimitField = "gas_limit";
             const auto feeField = "fee";
 
             return _http->GET("block/head")
@@ -144,11 +144,11 @@ namespace ledger {
                             throw make_exception(
                                 api::ErrorCode::HTTP_ERROR, "Failed to compute gas_price from network, block/head is not a JSON object");
                         }
-                        if (!json.HasMember(gasUsedField) || !json[gasUsedField].IsString()) {
+                        if (!json.HasMember(gasLimitField) || !json[gasLimitField].IsString()) {
                             throw make_exception(
                                 api::ErrorCode::HTTP_ERROR, fmt::format(
                                     "Failed to compute gas_price from network, no (or malformed) field \"{}\" in response",
-                                    gasUsedField));
+                                    gasLimitField));
                         }
                         if (!json.HasMember(feeField) || !json[feeField].IsString()) {
                             throw make_exception(
@@ -156,9 +156,9 @@ namespace ledger {
                                     "Failed to compute gas_price from network, no (or malformed) field \"{}\" in response",
                                     feeField));
                         }
-                        const uint64_t apiGasUsed = std::stoull(json[gasUsedField].GetString());
+                        const uint64_t apiGasLimit = std::stoull(json[gasLimitField].GetString());
                         const double apiFee = std::stod(json[feeField].GetString());
-                        const double gasPrice = apiFee / static_cast<double>(apiGasUsed);
+                        const double gasPrice = apiFee / static_cast<double>(apiGasLimit);
                         const std::string gasPriceAsString = std::to_string(gasPrice);
                         const std::string picoTezGasPrice = api::BigInt::fromDecimalString(gasPriceAsString, 6, ".")->toString(10);
                         return std::make_shared<BigInt>(std::stoi(picoTezGasPrice));

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -34,6 +34,8 @@
 #include <api/TezosConfiguration.hpp>
 #include <api/TezosConfigurationDefaults.hpp>
 
+#include <iostream>
+
 namespace ledger {
     namespace core {
         ExternalTezosLikeBlockchainExplorer::ExternalTezosLikeBlockchainExplorer(
@@ -144,25 +146,20 @@ namespace ledger {
                             throw make_exception(
                                 api::ErrorCode::HTTP_ERROR, "Failed to compute gas_price from network, block/head is not a JSON object");
                         }
-                        /*rapidjson::StringBuffer sb;
-                        rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
-                        json.Accept(writer);
-                        std::string jsonAsString = sb.GetString();*/
-                        std::string jsonAsString = "COOL";
-                        if (!json.HasMember(gasUsedField) || !json[gasUsedField].IsInt()) {
+                        if (!json.HasMember(gasUsedField) || !json[gasUsedField].IsString()) {
                             throw make_exception(
                                 api::ErrorCode::HTTP_ERROR, fmt::format(
-                                    "Failed to compute gas_price from network, no (or malformed) field \"{}\" in response \"{}\"",
-                                    gasUsedField, jsonAsString));
+                                    "Failed to compute gas_price from network, no (or malformed) field \"{}\" in response",
+                                    gasUsedField));
                         }
-                        if (!json.HasMember(feeField) || !json[feeField].IsDouble()) {
+                        if (!json.HasMember(feeField) || !json[feeField].IsString()) {
                             throw make_exception(
                                 api::ErrorCode::HTTP_ERROR, fmt::format(
                                     "Failed to compute gas_price from network, no (or malformed) field \"{}\" in response",
                                     feeField));
                         }
-                        const double apiGasUsed = json[gasUsedField].GetInt();
-                        const double apiFee = json[feeField].GetDouble();
+                        const uint64_t apiGasUsed = std::stoull(json[gasUsedField].GetString());
+                        const double apiFee = std::stod(json[feeField].GetString());
                         const double gasPrice = apiFee / static_cast<double>(apiGasUsed);
                         const std::string gasPriceAsString = std::to_string(gasPrice);
                         const std::string picoTezGasPrice = api::BigInt::fromDecimalString(gasPriceAsString, 6, ".")->toString(10);

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -135,6 +135,8 @@ namespace ledger {
             // We have to calculate it instead from gas_limit and fee
             const auto gasLimitField = "gas_limit";
             const auto feeField = "fee";
+            // We still use the legacy field in case we have a rollback
+            const auto gasPriceField = "gas_price";
 
             return _http->GET("block/head")
                     .json(parseNumbersAsString).mapPtr<BigInt>(getContext(), [=](const HttpRequest::JsonResult &result) {
@@ -144,23 +146,38 @@ namespace ledger {
                             throw make_exception(
                                 api::ErrorCode::HTTP_ERROR, "Failed to compute gas_price from network, block/head is not a JSON object");
                         }
-                        if (!json.HasMember(gasLimitField) || !json[gasLimitField].IsString()) {
-                            throw make_exception(
-                                api::ErrorCode::HTTP_ERROR, fmt::format(
-                                    "Failed to compute gas_price from network, no (or malformed) field \"{}\" in response",
-                                    gasLimitField));
+                        std::string gasPrice;
+                        // Legacy field access
+                        if (json.HasMember(gasPriceField) && json[gasPriceField].IsString()) {
+                            gasPrice = json[gasPriceField].GetString();
                         }
-                        if (!json.HasMember(feeField) || !json[feeField].IsString()) {
-                            throw make_exception(
-                                api::ErrorCode::HTTP_ERROR, fmt::format(
-                                    "Failed to compute gas_price from network, no (or malformed) field \"{}\" in response",
-                                    feeField));
+                        // OR
+                        // tzindex v12+ gas_price compute
+                        else {
+                            if (!json.HasMember(gasLimitField) || !json[gasLimitField].IsString()) {
+                                throw make_exception(
+                                    api::ErrorCode::HTTP_ERROR, fmt::format(
+                                        "Failed to compute gas_price from network, no (or malformed) field \"{}\" in response",
+                                        gasLimitField));
+                            }
+                            if (!json.HasMember(feeField) || !json[feeField].IsString()) {
+                                throw make_exception(
+                                    api::ErrorCode::HTTP_ERROR, fmt::format(
+                                        "Failed to compute gas_price from network, no (or malformed) field \"{}\" in response",
+                                        feeField));
+                            }
+                            const uint64_t apiGasLimit = std::stoull(json[gasLimitField].GetString());
+                            if (apiGasLimit == 0) {
+                                throw make_exception(
+                                    api::ErrorCode::HTTP_ERROR, "Failed to compute gas_price from network, gas_limit of HEAD block is 0"
+                                );
+                            }
+                            const double apiFee = std::stod(json[feeField].GetString());
+                            const double numericGasPrice = apiFee / static_cast<double>(apiGasLimit);
+                            gasPrice = std::to_string(numericGasPrice);
                         }
-                        const uint64_t apiGasLimit = std::stoull(json[gasLimitField].GetString());
-                        const double apiFee = std::stod(json[feeField].GetString());
-                        const double gasPrice = apiFee / static_cast<double>(apiGasLimit);
-                        const std::string gasPriceAsString = std::to_string(gasPrice);
-                        const std::string picoTezGasPrice = api::BigInt::fromDecimalString(gasPriceAsString, 6, ".")->toString(10);
+
+                        const std::string picoTezGasPrice = api::BigInt::fromDecimalString(gasPrice, 6, ".")->toString(10);
                         return std::make_shared<BigInt>(std::stoi(picoTezGasPrice));
                     });
         }

--- a/nix/scripts/build_jar.sh
+++ b/nix/scripts/build_jar.sh
@@ -19,7 +19,7 @@ ls -la jar_build/src/main/resources/resources/djinni_native_libs
 printf "\n============ Packaging JAR (with ${LIBCORE_LIB_DIR})\n"
 cd jar_build
 sbt package
-sbt publish
+# sbt publish
 printf "\n============ Showing target build, hopefully with a JAR to rename ledger-lib-core.jar\n"
 mkdir -p artifact
 for f in `ls target/scala-2.12/`

--- a/nix/scripts/build_jar.sh
+++ b/nix/scripts/build_jar.sh
@@ -19,7 +19,7 @@ ls -la jar_build/src/main/resources/resources/djinni_native_libs
 printf "\n============ Packaging JAR (with ${LIBCORE_LIB_DIR})\n"
 cd jar_build
 sbt package
-# sbt publish
+sbt publish
 printf "\n============ Showing target build, hopefully with a JAR to rename ledger-lib-core.jar\n"
 mkdir -p artifact
 for f in `ls target/scala-2.12/`


### PR DESCRIPTION
Since tzindex 12 (see [CHANGELOG](https://github.com/blockwatch-cc/tzindex/blob/master/CHANGELOG.md#v1200-api-v012-2022-03-25light)), gas_price field has been removed.

This PR aims to add the field back by computing it using the following formula : fee / gas_limit.
Note that in Tezos, gas_price does not really makes sense, the fee is paid in full, whatever how much gas was used.
The gas_limit can however be used by the baker to check whether the call is profitable or not.