### PR TITLE
VG-4576 Fix tezos reveal operation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,9 @@ clang_tidy("-checks=-*,clang-analyzer-*,-clang-analyzer-cplusplus*,cppcoreguidel
 include_what_you_use()  # add cmake conf option IWYU=ON to activate
 
 # The project version number.
-set(VERSION_MAJOR   4   CACHE STRING "Project major version number.")
-set(VERSION_MINOR   1   CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   9   CACHE STRING "Project patch version number.")
+set(VERSION_MAJOR   4    CACHE STRING "Project major version number.")
+set(VERSION_MINOR   1    CACHE STRING "Project minor version number.")
+set(VERSION_PATCH   10   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
@@ -461,7 +461,7 @@ namespace ledger {
                             pub_key.c_str(), static_cast<SizeType>(pub_key.length()), allocator);
                         revealOp.AddMember("public_key", vString, allocator);
 
-                        static const auto fee = "257000";
+                        static const auto fee = "10000";
                         vString.SetString(fee, static_cast<SizeType>(std::strlen(fee)), allocator);
                         revealOp.AddMember("fee", vString, allocator);
 

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -135,8 +135,8 @@ namespace ledger {
         ExternalTezosLikeBlockchainExplorer::getGasPrice() {
             const bool parseNumbersAsString = true;
             // Since tzindex 12.01, we don't have gas_price field anymore
-            // We have to calculate it instead from gas_limit and fee
-            const auto gasLimitField = "gas_limit";
+            // We have to calculate it instead from gas_used and fee
+            const auto gasUsedField = "gas_used";
             const auto feeField = "fee";
             // We still use the legacy field in case we have a rollback
             const auto gasPriceField = "gas_price";
@@ -172,11 +172,11 @@ namespace ledger {
                         // OR
                         // tzindex v12+ gas_price compute
                         else {
-                            if (!json.HasMember(gasLimitField) || !json[gasLimitField].IsString()) {
+                            if (!json.HasMember(gasUsedField) || !json[gasUsedField].IsString()) {
                                 throw make_exception(
                                     api::ErrorCode::HTTP_ERROR, fmt::format(
                                         "Failed to compute gas_price from network, no (or malformed) field \"{}\" in response",
-                                        gasLimitField));
+                                        gasUsedField));
                             }
                             if (!json.HasMember(feeField) || !json[feeField].IsString()) {
                                 throw make_exception(
@@ -184,15 +184,15 @@ namespace ledger {
                                         "Failed to compute gas_price from network, no (or malformed) field \"{}\" in response",
                                         feeField));
                             }
-                            const uint64_t apiGasLimit = std::stoull(json[gasLimitField].GetString());
-                            if (apiGasLimit == 0) {
+                            const uint64_t apiGasUsed = std::stoull(json[gasUsedField].GetString());
+                            if (apiGasUsed == 0) {
                                 throw make_exception(
-                                    api::ErrorCode::HTTP_ERROR, "Failed to compute gas_price from network, gas_limit of HEAD block is 0"
+                                    api::ErrorCode::HTTP_ERROR, "Failed to compute gas_price from network, gas_used of HEAD block is 0"
                                 );
                             }
 
                             double apiFee = std::stod(json[feeField].GetString());
-                            const double numericGasPrice = apiFee / static_cast<double>(apiGasLimit);
+                            const double numericGasPrice = apiFee / static_cast<double>(apiGasUsed);
                             std::ostringstream ss;
                             ss.precision(std::numeric_limits<double>::digits10);
                             ss << std::fixed << numericGasPrice;

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -191,7 +191,33 @@ namespace ledger {
                                 );
                             }
 
-                            double apiFee = std::stod(json[feeField].GetString());
+                            const auto& feeFieldStringValue = json[feeField].GetString();
+                            double apiFee = 0.;
+                            try
+                            {
+                                apiFee = std::stod(feeFieldStringValue);
+                            }
+                            catch(const std::invalid_argument& e)
+                            {
+                                throw make_exception(
+                                    api::ErrorCode::INVALID_ARGUMENT, fmt::format(
+                                        "Failed to compute gas_price from network, issue converting from string with fee of HEAD block equal to \"{}\": {}",
+                                        feeFieldStringValue,
+                                        e.what()
+                                    )
+                                );
+                            }
+                            catch(const std::out_of_range& e)
+                            {
+                                throw make_exception(
+                                    api::ErrorCode::OUT_OF_RANGE, fmt::format(
+                                        "Failed to compute gas_price from network, issue casting to double with fee of HEAD block equal to \"{}\" : {}",
+                                        feeFieldStringValue,
+                                        e.what()
+                                    )
+                                );
+                            }
+
                             const double numericGasPrice = apiFee / static_cast<double>(apiGasUsed);
                             std::ostringstream ss;
                             ss.precision(std::numeric_limits<double>::digits10);
@@ -200,7 +226,33 @@ namespace ledger {
                         }
 
                         const std::string picoTezGasPrice = api::BigInt::fromDecimalString(gasPrice, 6, ".")->toString(10);
-                        return std::make_shared<BigInt>(std::stoi(picoTezGasPrice));
+                        int intPicoTezGasPrice = 0;
+                        try
+                        {
+                            intPicoTezGasPrice = std::stoi(picoTezGasPrice);
+                        }
+                        catch(const std::invalid_argument& e)
+                        {
+                            throw make_exception(
+                                api::ErrorCode::INVALID_ARGUMENT, fmt::format(
+                                    "Failed to compute gas_price from network, issue converting from string with picoTezGasPrice equal to \"{}\": {}",
+                                    picoTezGasPrice,
+                                    e.what()
+                                )
+                            );
+                        }
+                        catch(const std::out_of_range& e)
+                        {
+                            throw make_exception(
+                                api::ErrorCode::OUT_OF_RANGE, fmt::format(
+                                    "Failed to compute gas_price from network, issue casting to int with picoTezGasPrice equal to \"{}\" : {}",
+                                    picoTezGasPrice,
+                                    e.what()
+                                )
+                            );
+                        }
+                        
+                        return std::make_shared<BigInt>(intPicoTezGasPrice);
                     });
         }
 

--- a/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/tezos/explorers/ExternalTezosLikeBlockchainExplorer.cpp
@@ -33,7 +33,7 @@
 #include <api/ErrorCode.hpp>
 #include <api/TezosConfiguration.hpp>
 #include <api/TezosConfigurationDefaults.hpp>
-#include <locale>
+#include <clocale>
 #include <sstream>
 
 


### PR DESCRIPTION
## Changes
* Fix incorrect conversions in gas price computation. This was due to incorrect locale set in the libcore, the fix consists to set the locale in function scope to make sure to use the correct character as decimal separator.
* Fix formula used to compute the gas price. The correct formula, [according to tzindex](https://github.com/blockwatch-cc/tzindex/blob/df40c4f3fc2887d1fff673a3369f069278e3447d/etl/op.go#L641), is to divide fee with gas_used and not gas_limit.
* Fix reveal fee formula used in tezos transaction crafter
* Bump patch version to `4.1.10`

## Todos
- [x] Check tests pass (waiting for the result)