### PR TITLE
Remove txopindex from operationuid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include_what_you_use()  # add cmake conf option IWYU=ON to activate
 # The project version number.
 set(VERSION_MAJOR   4    CACHE STRING "Project major version number.")
 set(VERSION_MINOR   1    CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   10   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   11   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/core/idl/wallet/tezos/tezos_like_wallet.djinni
+++ b/core/idl/wallet/tezos/tezos_like_wallet.djinni
@@ -22,8 +22,6 @@ TezosLikeTransaction = interface +c {
 	const getType(): TezosOperationTag;
 	# Get the hash of the transaction.
 	const getHash(): string;
-	# Get the operation index in the transaction
-	const getOperationIndexInTransaction(): i64;
 	# Get the operation type in the transaction
 	const getOperationTypeInTransaction(): TezosOperationTag;
 	# Get Fees (in drop) 

--- a/core/src/api/TezosLikeTransaction.hpp
+++ b/core/src/api/TezosLikeTransaction.hpp
@@ -36,9 +36,6 @@ public:
     /** Get the hash of the transaction. */
     virtual std::string getHash() const = 0;
 
-    /** Get the operation index in the transaction */
-    virtual int64_t getOperationIndexInTransaction() const = 0;
-
     /** Get the operation type in the transaction */
     virtual TezosOperationTag getOperationTypeInTransaction() const = 0;
 

--- a/core/src/jni/jni/TezosLikeTransaction.cpp
+++ b/core/src/jni/jni/TezosLikeTransaction.cpp
@@ -43,16 +43,6 @@ CJNIEXPORT jstring JNICALL Java_co_ledger_core_TezosLikeTransaction_00024CppProx
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-CJNIEXPORT jlong JNICALL Java_co_ledger_core_TezosLikeTransaction_00024CppProxy_native_1getOperationIndexInTransaction(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
-{
-    try {
-        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        const auto& ref = ::djinni::objectFromHandleAddress<::ledger::core::api::TezosLikeTransaction>(nativeRef);
-        auto r = ref->getOperationIndexInTransaction();
-        return ::djinni::release(::djinni::I64::fromCpp(jniEnv, r));
-    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
-}
-
 CJNIEXPORT jobject JNICALL Java_co_ledger_core_TezosLikeTransaction_00024CppProxy_native_1getOperationTypeInTransaction(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
 {
     try {

--- a/core/src/wallet/common/Operation.cpp
+++ b/core/src/wallet/common/Operation.cpp
@@ -51,10 +51,7 @@ namespace ledger {
             }
             else if (tezosTransaction.nonEmpty()) {
                 const auto& tx = tezosTransaction.getValue();
-                std::string txIdBase = fmt::format("{}+{}", 
-                    tx.counter, 
-                    tx.index
-                );
+                std::string txIdBase = fmt::format("{}", tx.counter);
                 txId = computeTransactionId(txIdBase, tx.type, additional);
             } else if (stellarOperation.nonEmpty()) {
                 txId = computeTransactionId(stellarOperation.getValue().operation.transactionHash);

--- a/core/src/wallet/tezos/TezosLikeAccount2.cpp
+++ b/core/src/wallet/tezos/TezosLikeAccount2.cpp
@@ -584,10 +584,7 @@ namespace ledger {
                 }
             }
             
-            std::string txIdBase = fmt::format("{}+{}", 
-                parsedTx->getCounter()->intValue(), 
-                parsedTx->getOperationIndexInTransaction()
-            );
+            std::string txIdBase = fmt::format("{}", parsedTx->getCounter()->intValue());
 
             std::string&& txId = Operation::computeTransactionId(txIdBase, parsedTx->getOperationTypeInTransaction(), additional);
 

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.cpp
@@ -705,15 +705,6 @@ namespace ledger {
             _correlationId = newId;
             return oldId;
         }
-
-        int64_t TezosLikeTransactionApi::getOperationIndexInTransaction() const {
-            return _operationIndexInTransaction;
-        }
-
-        TezosLikeTransactionApi& TezosLikeTransactionApi::setOperationIndexInTransaction(int64_t index) {
-            _operationIndexInTransaction = index;
-            return *this;
-        }
         
         api::TezosOperationTag TezosLikeTransactionApi::getOperationTypeInTransaction() const {
             return _operationTypeInTransaction;

--- a/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
+++ b/core/src/wallet/tezos/api_impl/TezosLikeTransactionApi.h
@@ -136,9 +136,6 @@ namespace ledger {
             TezosLikeTransactionApi &reveal(bool needReveal);
             bool toReveal() const;
 
-            int64_t getOperationIndexInTransaction() const override;
-            TezosLikeTransactionApi& setOperationIndexInTransaction(int64_t index);
-
             api::TezosOperationTag getOperationTypeInTransaction() const override;
             TezosLikeTransactionApi& setOperationTypeInTransaction(api::TezosOperationTag type);
         private:
@@ -169,7 +166,6 @@ namespace ledger {
             std::shared_ptr<api::Amount> _revealFees;
             std::shared_ptr<api::Amount> _revealGasLimit;
             std::string _correlationId;
-            int64_t _operationIndexInTransaction {0};
             api::TezosOperationTag _operationTypeInTransaction {api::TezosOperationTag::OPERATION_TAG_NONE};
         };
     }

--- a/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
+++ b/core/src/wallet/tezos/explorers/TezosLikeBlockchainExplorer.h
@@ -83,7 +83,6 @@ namespace ledger {
             std::string originatedAccountUid;
             std::string originatedAccountAddress;
             int64_t counter{0};
-            int64_t index{0};
 
             TezosLikeBlockchainExplorerTransaction() {
                 confirmations = 0;

--- a/core/src/wallet/tezos/explorers/api/TezosLikeTransactionParser.cpp
+++ b/core/src/wallet/tezos/explorers/api/TezosLikeTransactionParser.cpp
@@ -151,8 +151,6 @@ namespace ledger {
                     _transaction->fees = _transaction->fees + toValue(number, true);
                 } else if (_lastKey == "confirmations") {
                     _transaction->confirmations = toValue(number, false).toInt64();
-                } else if (_lastKey == "op_c") {
-                    _transaction->index = toValue(number, false).toInt64();
                 } else if (_lastKey == "counter") {
                     _transaction->counter = toValue(number, false).toInt64();
                 }

--- a/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.cpp
+++ b/core/src/wallet/tezos/transaction_builders/TezosLikeTransactionBuilder.cpp
@@ -204,7 +204,6 @@ namespace ledger {
             auto blockHash = Base58::encodeWithChecksum(vector::concat(blockPrefix, blockHashBytes), config);
             tx->setBlockHash(blockHash);
 
-            int32_t opIndex = {0};
             uint8_t OpTag;
             auto offset = static_cast<uint8_t>(isBabylonActivated ? 100 : 0);
             do {
@@ -372,13 +371,11 @@ namespace ledger {
 
                 // Sorry, I really had to do this way..
                 if(operationTag != api::TezosOperationTag::OPERATION_TAG_REVEAL) {
-                    tx->setOperationIndexInTransaction(opIndex);  
-                    tx->setOperationTypeInTransaction(operationTag);  
+                    tx->setOperationTypeInTransaction(operationTag);
                 }
-                ++opIndex;
 
             } while(isSigned ? reader.available()-64 > 0 : reader.available() > 0 );
-            
+
 
             // Parse signature
             if (isSigned) {

--- a/core/test/common/operation.cpp
+++ b/core/test/common/operation.cpp
@@ -44,16 +44,16 @@ TEST(Operation, TezosUidIsValid) {
     op.tezosTransaction->type = ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION;
     EXPECT_EQ(op.uid, "");
     op.refreshUid();
-    EXPECT_EQ(op.uid, "5b46f1084ef236091f04e257ab1902ed564dac1cad6d8fb403c007e3fe838411");
+    EXPECT_EQ(op.uid, "95d272362380dd84f330edebc776f178e12e6a637cef852512115ac182889b95");
 
     // change only type
     op.tezosTransaction->type = ledger::core::api::TezosOperationTag::OPERATION_TAG_REVEAL;
     op.refreshUid();
-    EXPECT_EQ(op.uid, "79ac6452f6ab4ebd0cc6bc0041b89a8954849b032f70bcb21154a0b351565c98");
+    EXPECT_EQ(op.uid, "98e675229d3001a50e4dd7a527643af3658b985b05f74fe4ff03305dd41ccdc2");
 
     // with additional
     op.refreshUid("456");
-    EXPECT_EQ(op.uid, "c5a8f07c86e5442c58cd95c8e16de8f50c1b980cf591ab215edfb9389166843a");
+    EXPECT_EQ(op.uid, "cdd40b9116abc9830fd12cd38a4801fadf519fc11746f66bedc0c5062eee9774");
 }
 
 

--- a/core/test/tezos/ED25519_transaction_test.cpp
+++ b/core/test/tezos/ED25519_transaction_test.cpp
@@ -195,7 +195,6 @@ TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawTransaction) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 10407);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawTransactionWithReveal) {
@@ -215,7 +214,6 @@ TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawTransactionWithReveal) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 10407+10200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 1);
 }
 
 TEST_F(ED25519TezosMakeTransaction, CreateDelegation) {
@@ -285,7 +283,6 @@ TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawDelegation) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 1200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawUndelegation) {
@@ -304,7 +301,6 @@ TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawUndelegation) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 1200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(ED25519TezosMakeTransaction, GetCurrentDelegationOnNotDelegatedAccount) {
@@ -340,5 +336,4 @@ TEST_F(ED25519TezosMakeTransaction, ParseUnsignedRawDelegationWithReveal) {
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->toReveal(), true);
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 1);
 }

--- a/core/test/tezos/P256_transaction_test.cpp
+++ b/core/test/tezos/P256_transaction_test.cpp
@@ -185,7 +185,6 @@ TEST_F(P256TezosMakeTransaction, ParseUnsignedRawTransaction) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 10407);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(P256TezosMakeTransaction, ParseUnsignedRawTransactionWithReveal) {
@@ -205,7 +204,6 @@ TEST_F(P256TezosMakeTransaction, ParseUnsignedRawTransactionWithReveal) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 10407+10200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 1);
 }
 
 TEST_F(P256TezosMakeTransaction, CreateDelegation) {
@@ -275,7 +273,6 @@ TEST_F(P256TezosMakeTransaction, ParseUnsignedRawDelegation) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 1200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(P256TezosMakeTransaction, ParseUnsignedRawUndelegation) {
@@ -294,7 +291,6 @@ TEST_F(P256TezosMakeTransaction, ParseUnsignedRawUndelegation) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 1200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(P256TezosMakeTransaction, GetCurrentDelegation) {
@@ -330,5 +326,4 @@ TEST_F(P256TezosMakeTransaction, ParseUnsignedRawDelegationWithReveal) {
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->toReveal(), true);
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 1);
 }

--- a/core/test/tezos/SECP256K1_transaction_test.cpp
+++ b/core/test/tezos/SECP256K1_transaction_test.cpp
@@ -188,7 +188,6 @@ TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawTransaction) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 10407);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawTransactionWithReveal) {
@@ -208,7 +207,6 @@ TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawTransactionWithReveal) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 10407+10200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_TRANSACTION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 1);
 }
 
   TEST_F(SECP256K1TezosMakeTransaction, DISABLED_optimisticCounter) {
@@ -451,7 +449,6 @@ TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawDelegation) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 1200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 }
 
 TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawUndelegation) {
@@ -470,7 +467,6 @@ TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawUndelegation) {
     EXPECT_EQ(tx->getGasLimit()->toLong(), 1200);
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "0");
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 0);
 } 
 
 TEST_F(SECP256K1TezosMakeTransaction, GetCurrentDelegation) {
@@ -506,7 +502,6 @@ TEST_F(SECP256K1TezosMakeTransaction, ParseUnsignedRawDelegationWithReveal) {
     EXPECT_EQ(tx->getStorageLimit()->toString(10), "100");
     EXPECT_EQ(tx->toReveal(), true);
     EXPECT_EQ(tx->getOperationTypeInTransaction(), ledger::core::api::TezosOperationTag::OPERATION_TAG_DELEGATION);
-    EXPECT_EQ(tx->getOperationIndexInTransaction(), 1);
 }
 
 TEST_F(SECP256K1TezosMakeTransaction, CreateTxAutoFill) {

--- a/core/test/tezos/tezos_account.cpp
+++ b/core/test/tezos/tezos_account.cpp
@@ -130,7 +130,7 @@ TEST_F(TezosAccount, InterpetTransactionWithCorrectUidWhenOriginatedAccount) {
       parsedTx->originatedAccountAddress = accAddress;
       account->interpretTransaction(*parsedTx, operations);
       EXPECT_EQ(operations.size(), 1);
-      EXPECT_EQ(operations[0].uid, OperationDatabaseHelper::createUid(account->getAccountUid(), "2263644+0+OPERATION_TAG_REVEAL+someUid", api::OperationType::SEND));
+      EXPECT_EQ(operations[0].uid, OperationDatabaseHelper::createUid(account->getAccountUid(), "2263644+OPERATION_TAG_REVEAL+someUid", api::OperationType::SEND));
     }
 
     // Test when received in originated account
@@ -141,7 +141,7 @@ TEST_F(TezosAccount, InterpetTransactionWithCorrectUidWhenOriginatedAccount) {
       parsedTx->originatedAccountAddress = accAddress;
       account->interpretTransaction(*parsedTx, operations);
       EXPECT_EQ(operations.size(), 2);
-      EXPECT_EQ(operations[1].uid, OperationDatabaseHelper::createUid(account->getAccountUid(), "2263645+1+OPERATION_TAG_TRANSACTION+someUid", api::OperationType::RECEIVE));
+      EXPECT_EQ(operations[1].uid, OperationDatabaseHelper::createUid(account->getAccountUid(), "2263645+OPERATION_TAG_TRANSACTION+someUid", api::OperationType::RECEIVE));
     }
 }
 
@@ -156,7 +156,7 @@ TEST_F(TezosAccount, InterpetTransactionWithCorrectUidWithoutOriginatedAccount) 
       parsedTx->sender = accAddress;
       account->interpretTransaction(*parsedTx, operations);
       EXPECT_EQ(operations.size(), 1);
-      EXPECT_EQ(operations[0].uid, OperationDatabaseHelper::createUid(account->getAccountUid(), "2263644+0+OPERATION_TAG_REVEAL", api::OperationType::SEND));
+      EXPECT_EQ(operations[0].uid, OperationDatabaseHelper::createUid(account->getAccountUid(), "2263644+OPERATION_TAG_REVEAL", api::OperationType::SEND));
     }
 
     // Test when received in account
@@ -165,7 +165,7 @@ TEST_F(TezosAccount, InterpetTransactionWithCorrectUidWithoutOriginatedAccount) 
       parsedTx->receiver = accAddress;
       account->interpretTransaction(*parsedTx, operations);
       EXPECT_EQ(operations.size(), 2);
-      EXPECT_EQ(operations[1].uid, OperationDatabaseHelper::createUid(account->getAccountUid(), "2263645+1+OPERATION_TAG_TRANSACTION", api::OperationType::RECEIVE));
+      EXPECT_EQ(operations[1].uid, OperationDatabaseHelper::createUid(account->getAccountUid(), "2263645+OPERATION_TAG_TRANSACTION", api::OperationType::RECEIVE));
     }
 }
 
@@ -191,14 +191,14 @@ TEST_F(TezosAccountWithFixedPoolName, ComputeOperationUidWithValidTransaction) {
     {
       auto txTest = std::make_shared<TezosLikeTransactionApi>(*tx);
       txTest->setSender(accAddress);
-      EXPECT_EQ(account->computeOperationUid(txTest), "7ce5bfdcb02056ffe84412ab15504cda6bd02ac38ce211826cfd1a9b6b236184");
+      EXPECT_EQ(account->computeOperationUid(txTest), "5bd2461f4fb753689ad05bce533808d72cbf11403d3e1b8d3fd7a7589205ff1f");
     }
 
     // when receiver
     {
       auto txTest = std::make_shared<TezosLikeTransactionApi>(*tx);
       txTest->setReceiver(accAddress);
-      EXPECT_EQ(account->computeOperationUid(txTest), "01f1f96874f5ea39ad4eec831d4291b249b95f2ebc4672884124ebc0f47a260e");
+      EXPECT_EQ(account->computeOperationUid(txTest), "931b61f6786f39430c105372352d47c487ed4f4ba58d1cd7f11627bb6ae68ca9");
     }
 
 }


### PR DESCRIPTION
An update of tzindex caused some breaking changes in Tezos node API. The following changes handle the breaking change in identifying batch operations. We implemented an operation uid based on `counter + txOpIndex` where `txOpIndex` is the index of the operation in the batch. This information is not directly available anymore. We decided to remove it from the computation of the operation uid.  

## Changes
* Remove `index` from Tezos operations
* Remove `txOpIndex` from the Tezos operation uid computation
* Bump patch version to `4.1.11`