### PR TITLE
Ripple: fix destinationTag set to 1

### DIFF
--- a/core/src/wallet/ripple/api_impl/RippleLikeTransactionApi.cpp
+++ b/core/src/wallet/ripple/api_impl/RippleLikeTransactionApi.cpp
@@ -201,7 +201,14 @@ namespace ledger {
                 //1 byte Destination tag:   Type Code = 2, Field Code = 14
                 writer.writeByte(0x2E);
                 //4 bytes Destination tag
-                writer.writeBeValue<uint32_t>(static_cast<const uint32_t>(_destinationTag.getValue()));
+                const int64_t& destinationTagValue = _destinationTag.getValue();
+                if(destinationTagValue  > static_cast<int64_t>(std::numeric_limits<uint32_t>::max()) ||
+                     destinationTagValue  < static_cast<int64_t>(std::numeric_limits<uint32_t>::min()))
+                {
+                    throw make_exception(api::ErrorCode::RUNTIME_ERROR,
+                                     "RippleLikeTransactionApi::serialize: destinationTag value does not fit in uint32");
+                }
+                writer.writeBeValue<uint32_t>(static_cast<const uint32_t>(destinationTagValue));
             }
 
             //2 bytes LastLedgerSequence Field ID:   Type Code = 2, Field Code = 27
@@ -361,7 +368,7 @@ namespace ledger {
             return *this;
         }
 
-        RippleLikeTransactionApi &RippleLikeTransactionApi::setDestinationTag(uint32_t tag) {
+        RippleLikeTransactionApi &RippleLikeTransactionApi::setDestinationTag(int64_t tag) {
             _destinationTag = tag;
             return *this;
         }

--- a/core/src/wallet/ripple/api_impl/RippleLikeTransactionApi.h
+++ b/core/src/wallet/ripple/api_impl/RippleLikeTransactionApi.h
@@ -68,7 +68,7 @@ namespace ledger {
             RippleLikeTransactionApi & setReceiver(const std::shared_ptr<api::RippleLikeAddress> &receiver);
             RippleLikeTransactionApi & setSigningPubKey(const std::vector<uint8_t> &pubKey);
             RippleLikeTransactionApi & setHash(const std::string &hash);
-            RippleLikeTransactionApi & setDestinationTag(uint32_t tag);
+            RippleLikeTransactionApi & setDestinationTag(int64_t tag);
             std::vector<api::RippleLikeMemo> getMemos() override;
             void addMemo(api::RippleLikeMemo const& memo) override;
             std::experimental::optional<int64_t> getDestinationTag() override;

--- a/core/src/wallet/ripple/database/RippleLikeOperationDatabaseHelper.cpp
+++ b/core/src/wallet/ripple/database/RippleLikeOperationDatabaseHelper.cpp
@@ -54,7 +54,7 @@ namespace {
         std::vector<std::string> fees;
         std::vector<uint64_t> confirmations;
         std::vector<BigInt> sequence;
-        std::vector<Option<uint64_t>> tag;
+        std::vector<Option<int64_t>> tag;
         std::vector<int32_t> status;
 
         void update(const std::string& txUid, const Option<std::string>& bUid,

--- a/core/src/wallet/ripple/database/RippleLikeTransactionDatabaseHelper.cpp
+++ b/core/src/wallet/ripple/database/RippleLikeTransactionDatabaseHelper.cpp
@@ -95,7 +95,7 @@ namespace ledger {
 
             tx.sequence = BigInt(static_cast<unsigned long long>(get_number<uint64_t>(row, 14)));
             if (row.get_indicator(15) != i_null) {
-                tx.destinationTag = get_number<uint64_t>(row, 15);
+                tx.destinationTag = get_number<int64_t>(row, 15);
             }
 
             if (row.get_indicator(16) != i_null) {

--- a/core/src/wallet/ripple/explorers/RippleLikeBlockchainExplorer.h
+++ b/core/src/wallet/ripple/explorers/RippleLikeBlockchainExplorer.h
@@ -62,7 +62,7 @@ namespace ledger {
             std::string sender;
             Option<Block> block;
             uint64_t confirmations;
-            Option<uint64_t> destinationTag;
+            Option<int64_t> destinationTag;
             std::vector<api::RippleLikeMemo> memos;
             int32_t status;
 

--- a/core/src/wallet/ripple/explorers/api/RippleLikeTransactionParser.cpp
+++ b/core/src/wallet/ripple/explorers/api/RippleLikeTransactionParser.cpp
@@ -140,7 +140,7 @@ namespace ledger {
                     block.hash = number;
                     _transaction->block = block;
                 } else if (_lastKey == "DestinationTag") {
-                  _transaction->destinationTag = Option<uint64_t>(value.toUint64());
+                  _transaction->destinationTag = Option<uint64_t>(value.toInt64());
                 } else if (_lastKey == "date" && currentObject != "transaction") {
                   _transaction->receivedAt = xrp_utils::toTimePoint<std::chrono::system_clock>(value.toUint64());
                   if (_transaction->block.hasValue()) {

--- a/core/src/wallet/ripple/transaction_builders/RippleLikeTransactionBuilder.cpp
+++ b/core/src/wallet/ripple/transaction_builders/RippleLikeTransactionBuilder.cpp
@@ -173,7 +173,7 @@ namespace ledger {
                 //1 byte Destination tag:   Type Code = 2, Field Code = 14
                 reader.readNextByte();
                 auto bigIntTag = BigInt::fromHex(hex::toString(reader.read(4)));
-                tx->setDestinationTag(static_cast<const uint32_t>(bigIntTag.toUint64()));
+                tx->setDestinationTag(bigIntTag.toInt64());
             }
 
             //2 bytes LastLedgerSequence Field ID:   Type Code = 2, Field Code = 27

--- a/core/test/integration/synchronization/ripple_synchronization.cpp
+++ b/core/test/integration/synchronization/ripple_synchronization.cpp
@@ -201,7 +201,7 @@ TEST_F(RippleLikeWalletSynchronization, VaultAccountSynchronization) {
             std::dynamic_pointer_cast<OperationQuery>(account->queryOperations()->complete())->execute());
     std::cout << "Ops: " << ops.size() << std::endl;
 
-    uint32_t destinationTag = 0;
+    int64_t destinationTag = 0;
     for (auto const& op : ops) {
         auto xrpOp = op->asRippleLikeOperation();
 


### PR DESCRIPTION
## Changes
- uniformization of int64 type for destinationTag (cannot use unsigned because of djinni which does not allow it)
