### PR TITLE
Add some index for transaction listing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include_what_you_use()  # add cmake conf option IWYU=ON to activate
 # The project version number.
 set(VERSION_MAJOR   4    CACHE STRING "Project major version number.")
 set(VERSION_MINOR   1    CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   13   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   14   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/core/src/database/DatabaseSessionPool.hpp
+++ b/core/src/database/DatabaseSessionPool.hpp
@@ -61,7 +61,7 @@ namespace ledger {
                 const std::string &password = ""
             );
 
-            static const int CURRENT_DATABASE_SCHEME_VERSION = 28;
+            static const int CURRENT_DATABASE_SCHEME_VERSION = 29;
 
             void performDatabaseMigration();
             void performDatabaseRollback();

--- a/core/src/database/migrations.cpp
+++ b/core/src/database/migrations.cpp
@@ -1205,5 +1205,28 @@ namespace ledger {
             sql << "DROP INDEX bitcoin_operations_transaction_uid_index ;";
         }
 
+        template<>
+        void migrate<29>(soci::session &sql, api::DatabaseBackendType type) {
+          sql << "CREATE INDEX blocks_height_index ON blocks(height);";
+          sql << "CREATE INDEX algorand_transactions_hash_index ON algorand_transactions(hash);";
+          sql << "CREATE INDEX bitcoin_transactions_hash_index ON bitcoin_transactions(hash);";
+          sql << "CREATE INDEX cosmos_transactions_hash_index ON cosmos_transactions(hash);";
+          sql << "CREATE INDEX ethereum_transactions_hash_index ON ethereum_transactions(hash);";
+          sql << "CREATE INDEX ripple_transactions_hash_index ON ripple_transactions(hash);";
+          sql << "CREATE INDEX stellar_transactions_hash_index ON stellar_transactions(hash);";
+          sql << "CREATE INDEX tezos_transactions_hash_index ON tezos_transactions(hash);";
+        }
+
+        template<>
+        void rollback<29>(soci::session &sql, api::DatabaseBackendType type) {
+          sql << "DROP INDEX blocks_height_index ;";
+          sql << "DROP INDEX algorand_transactions_hash_index ;";
+          sql << "DROP INDEX bitcoin_transactions_hash_index ;";
+          sql << "DROP INDEX cosmos_transactions_hash_index ;";
+          sql << "DROP INDEX ethereum_transactions_hash_index ;";
+          sql << "DROP INDEX ripple_transactions_hash_index ;";
+          sql << "DROP INDEX stellar_transactions_hash_index ;";
+          sql << "DROP INDEX tezos_transactions_hash_index ;";
+        }
     }
 }

--- a/core/src/database/migrations.hpp
+++ b/core/src/database/migrations.hpp
@@ -215,6 +215,9 @@ namespace ledger {
         template <> void migrate<28>(soci::session& sql, api::DatabaseBackendType type);
         template <> void rollback<28>(soci::session& sql, api::DatabaseBackendType type);
 
+        // add indexes for db performance optimization
+        template <> void migrate<29>(soci::session& sql, api::DatabaseBackendType type);
+        template <> void rollback<29>(soci::session& sql, api::DatabaseBackendType type);
     }
 }
 


### PR DESCRIPTION
Improve performances when getting operations (`GET /pools/pool_name/wallets/wallet_name/accounts/acc_idx/operations?batch=300&full_op=1`) for big accounts