### PR TITLE
Fix tezos count query

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include_what_you_use()  # add cmake conf option IWYU=ON to activate
 # The project version number.
 set(VERSION_MAJOR   4    CACHE STRING "Project major version number.")
 set(VERSION_MINOR   1    CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   14   CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   15   CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/core/src/wallet/tezos/TezosLikeAccount.h
+++ b/core/src/wallet/tezos/TezosLikeAccount.h
@@ -59,7 +59,16 @@ namespace ledger {
 
             };
         protected:
-            virtual soci::rowset<soci::row> performExecute(soci::session &sql) {
+            soci::rowset<soci::row> performCount(soci::session &sql) override {
+              return _builder.select("o.type, count(*)")
+                  .from("operations").to("o")
+                  .outerJoin("blocks AS b", "o.block_uid = b.uid")
+                  .outerJoin("tezos_originated_operations AS orig_op", "o.uid = orig_op.uid")
+                  .groupBy("o.type")
+                  .execute(sql);
+            }
+
+            soci::rowset<soci::row> performExecute(soci::session &sql) override {
                 return _builder.select("o.account_uid, o.uid, o.wallet_uid, o.type, o.date, o.senders, o.recipients,"
                                                "o.amount, o.fees, o.currency_name, o.trust, b.hash, b.height, b.time, orig_op.uid"
                         )

--- a/core/src/wallet/tezos/delegation/TezosLikeOriginatedAccount.h
+++ b/core/src/wallet/tezos/delegation/TezosLikeOriginatedAccount.h
@@ -53,7 +53,16 @@ namespace ledger {
 
             };
         protected:
-            virtual soci::rowset<soci::row> performExecute(soci::session &sql) {
+            soci::rowset<soci::row> performCount(soci::session &sql) override {
+              return _builder.select("o.type, count(*)")
+                  .from("operations").to("o")
+                  .outerJoin("blocks AS b", "o.block_uid = b.uid")
+                  .outerJoin("tezos_originated_operations AS orig_op", "o.uid = orig_op.uid")
+                  .groupBy("o.type")
+                  .execute(sql);
+            }
+
+            soci::rowset<soci::row> performExecute(soci::session &sql) override {
                 return _builder.select("o.account_uid, o.uid, o.wallet_uid, o.type, o.date, o.senders, o.recipients,"
                                                "o.amount, o.fees, o.currency_name, o.trust, b.hash, b.height, b.time, orig_op.uid"
                         )


### PR DESCRIPTION
In `TezosLikeAccount::queryOperations()`, the TezosOperationQuery is built with a head filter based on the outer join with `tezos_originated_operations`, thus the generic performCount() request cannot be executed. As for `performExecute`, we need to override `performCount`

Should fix https://github.com/LedgerHQ/ledger-wallet-daemon/pull/476