### PR TITLE
Fix explorer query to get only confirmed txs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include_what_you_use()  # add cmake conf option IWYU=ON to activate
 # The project version number.
 set(VERSION_MAJOR   4    CACHE STRING "Project major version number.")
 set(VERSION_MINOR   3    CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   1    CACHE STRING "Project patch version number.")
+set(VERSION_PATCH   2    CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/core/src/wallet/common/explorers/AbstractLedgerApiBlockchainExplorer.h
+++ b/core/src/wallet/common/explorers/AbstractLedgerApiBlockchainExplorer.h
@@ -79,7 +79,7 @@ namespace ledger {
                 } else {
                     params = params + "?";
                 }
-                params = params + "batch_size=" + std::to_string(batch_size);
+                params = params + "batch_size=" + std::to_string(batch_size) + "&confirmedOnly=true";
                 return params;
             }
 


### PR DESCRIPTION
To avoid parsing errors on transactions with `block: null` 