### PR TITLE
Production-like build on dev PC

### DIFF
--- a/.circleci/copy_artifacts.sh
+++ b/.circleci/copy_artifacts.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 unamestr=$(uname)
 TARGET=$1

--- a/.circleci/publish_jar.sh
+++ b/.circleci/publish_jar.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 BIN_DIR=~/lib-ledger-core-artifacts
 JAR_BUILD_DIR=build-jar

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Core library which will be used by Ledger applications.
     - [Nix build](#nix-build)
     - [Non nix builds](#non-nix-builds)
     - [Build library with PostgreSQL](#build-library-with-postgresql)
+    - [Build production-like version of the library](#build-production-like-version-of-the-library)
   - [Documentation](#documentation)
   - [Binding to node.js](#binding-to-nodejs)
     - [Using the node module](#using-the-node-module)
@@ -222,6 +223,14 @@ if you want to run only one specific unit test. (e.g. the test case `BitcoinLike
 ```
 ./core/test/integration/build/ledger-core-integration-tests "--gtest_filter=BitcoinLikeWalletSynchronization.MediumXpubSynchronization"
 ```
+## Build production-like version of the library
+
+To build the production-like version of the library use script `tools/prod-like-build.sh`. This script requires
+Docker. It starts from building Docker image with required versions of the dependencies. Next it starts the
+Docker container with that image and the `lib-ledger-core` source code from the current directory. The resulting
+`ledger-lib-core.jar` will be copied from the container to the `artifacts` sub-directory of the current directory.
+By default the `Release` versions of the `lib-ledger-core` is created. To specify the required build type add
+it to the command line: `./tools/prod-like-build.sh Debug`.
 
 ## Documentation
 

--- a/tools/prod-like-build-inner.sh
+++ b/tools/prod-like-build-inner.sh
@@ -7,17 +7,23 @@ then
   BUILD_TYPE=$1
 fi
 
-cd ~
-git clone --recursive https://github.com/LedgerHQ/lib-ledger-core.git
+cp -r ~/lib-ledger-core-ro ~/lib-ledger-core
+rm -rf ~/lib-ledger-core/djinni/src/target/ || echo "Dir \"djinni/src/target/\" doesn't exists (that's ok)."
+
 export CORE_SSL_1_1=arch_ssl_1_1
+
 mkdir -p ~/lib-ledger-core-artifacts
 cd ~/lib-ledger-core
+
 .circleci/build_lib.sh target_jni $BUILD_TYPE
+
 export LIB_VERSION=`.circleci/export_lib_version.sh`
+
 . .circleci/copy_artifacts.sh target_jni
 
 . tools/generate_interfaces.sh
 
+# We don't try to build for MacOS here
 mkdir -p ~/lib-ledger-core-artifacts/macos/jni
 touch ~/lib-ledger-core-artifacts/macos/jni/libledger-core_jni.dylib
 

--- a/tools/prod-like-build-inner.sh
+++ b/tools/prod-like-build-inner.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+BUILD_TYPE=Release
+if [ ! -z "$1" ];
+then
+  BUILD_TYPE=$1
+fi
+
+cd ~
+git clone --recursive https://github.com/LedgerHQ/lib-ledger-core.git
+export CORE_SSL_1_1=arch_ssl_1_1
+mkdir -p ~/lib-ledger-core-artifacts
+cd ~/lib-ledger-core
+.circleci/build_lib.sh target_jni $BUILD_TYPE
+export LIB_VERSION=`.circleci/export_lib_version.sh`
+. .circleci/copy_artifacts.sh target_jni
+
+. tools/generate_interfaces.sh
+
+mkdir -p ~/lib-ledger-core-artifacts/macos/jni
+touch ~/lib-ledger-core-artifacts/macos/jni/libledger-core_jni.dylib
+
+CIRCLE_TAG=mytag .circleci/publish_jar.sh
+
+cp /root/lib-ledger-core-artifacts/ledger-lib-core.jar /hostdir/
+

--- a/tools/prod-like-build.sh
+++ b/tools/prod-like-build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+BUILD_TYPE=$1
+
 if [ ! -d lib-ledger-core-build-env ]
 then
   git clone git@github.com:LedgerHQ/lib-ledger-core-build-env.git
@@ -9,14 +11,16 @@ else
   git pull
   cd ..
 fi
-cp tools/prod-like-build-inner.sh lib-ledger-core-build-env/scripts/
+
 cd lib-ledger-core-build-env
-git checkout update-installation
 docker build -t lib-ledger-core-build-env:latest .
 cd ..
+
 mkdir -p artifacts
 docker run \
     --mount type=bind,source="$(pwd)"/artifacts,target=/hostdir \
+    --mount type=bind,source="$(pwd)"/tools,target=/root/tools \
+    --mount type=bind,source="$(pwd)",target=/root/lib-ledger-core-ro,readonly \
     lib-ledger-core-build-env:latest \
-    /scripts/prod-like-build-inner.sh Debug
+    /root/tools/prod-like-build-inner.sh ${BUILD_TYPE}
 

--- a/tools/prod-like-build.sh
+++ b/tools/prod-like-build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+if [ ! -d lib-ledger-core-build-env ]
+then
+  git clone git@github.com:LedgerHQ/lib-ledger-core-build-env.git
+else
+  cd lib-ledger-core-build-env
+  git pull
+  cd ..
+fi
+cp tools/prod-like-build-inner.sh lib-ledger-core-build-env/scripts/
+cd lib-ledger-core-build-env
+git checkout update-installation
+docker build -t lib-ledger-core-build-env:latest .
+cd ..
+mkdir -p artifacts
+docker run \
+    --mount type=bind,source="$(pwd)"/artifacts,target=/hostdir \
+    lib-ledger-core-build-env:latest \
+    /scripts/prod-like-build-inner.sh Debug
+


### PR DESCRIPTION
* builds Docker container from `LedgerHQ/lib-ledger-core-build-env`
* uses CircleCI scripts to build `ledger-lib-core.jar`

Attn: default paths to jre libraries are different in prod and on typical dev machine. `LD_LIBRARY_PATH` must be modified accordingly to run WD:

```
LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server sbt "run -http.port=:9200 -admin.port=:0"
```

This PR depends on https://github.com/LedgerHQ/lib-ledger-core-build-env/pull/9