### PR TITLE
Add Release workflow

### DIFF
--- a/.github/workflows/nix_release_builds.yml
+++ b/.github/workflows/nix_release_builds.yml
@@ -16,10 +16,15 @@ on:
       - develop
     tags:
       - '*'
+  workflow_run:
+    workflows: ["Release libcore"]
+    types:
+      - completed
 jobs:
   libcore_version:
     name: Compute libcore version
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != "workflow_run" || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       lib_version: ${{ steps.lib_version.outputs.lib_version }}
       deploy_dynlibs: ${{ steps.lib_version.outputs.deploy_dynlibs }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: "Release libcore"
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version"
+        required: true
+        type: string
+      releaseNote:
+        description: "Should create a Release"
+        required: true
+        type: boolean
+        default: true
+jobs:
+  Release:
+    runs-on: ubuntu-22.04
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+      RELEASE_NOTE: ${{ github.event.inputs.releaseNote }}
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - name: Set version number
+      run: |
+        ./tools/set_version.sh $VERSION
+        head -n47 CMakeLists.txt | tail -n3
+        git add CMakeLists.txt
+        git config --global user.name "${GITHUB_ACTOR}"
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git commit -m "Set version to $VERSION"
+        git tag -a $VERSION -m "Version $VERSION"
+        git push -u origin HEAD --tags
+    - name: Create release
+      uses: actions/github-script@v5
+      if: env.RELEASE_NOTE == 'true'
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
+        script: |
+          try {
+            await github.rest.repos.createRelease({
+              draft: false,
+              generate_release_notes: true,
+              name: process.env.RELEASE_TAG,
+              owner: context.repo.owner,
+              prerelease: false,
+              repo: context.repo.repo,
+              tag_name: process.env.VERSION,
+            });
+          } catch (error) {
+            core.setFailed(error.message);
+          }

--- a/tools/set_version.sh
+++ b/tools/set_version.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+
+#
+# Function that parses semantic versioning striings of
+# the form:
+#   MAJOR.MINOR.PATCH([+-].*)?
+#
+# Source: https://gist.github.com/jlinoff/9211310b738e83c4a2bbe14876cd2e55
+#
+# Parse the major, minor and patch versions
+# out.
+# You use it like this:
+#    semver="3.4.5+xyz"
+#    a=($(parse_semver "$semver"))
+#    major=${a[0]}
+#    minor=${a[1]}
+#    patch=${a[2]}
+#    printf "%-32s %4d %4d %4d\n" "$semver" $major $minor $patch
+function parse_semver() {
+    local token="$1"
+    local major=0
+    local minor=0
+    local patch=0
+
+    if egrep '^[0-9]+\.[0-9]+\.[0-9]+' <<<"$token" >/dev/null 2>&1 ; then
+        # It has the correct syntax.
+        local n=${token//[!0-9]/ }
+        local a=(${n//\./ })
+        major=${a[0]}
+        minor=${a[1]}
+        patch=${a[2]}
+    fi
+
+    echo "$major $minor $patch"
+}
+
+version=($(parse_semver $1))
+major=${version[0]}
+minor=${version[1]}
+patch=${version[2]}
+
+echo "major" $major
+echo "minor" $minor
+echo "patch" $patch
+
+sed -i -E 's/(VERSION_MAJOR *)([0-9]+)/\1'$major'/' CMakeLists.txt
+sed -i -E 's/(VERSION_MINOR *)([0-9]+)/\1'$minor'/' CMakeLists.txt
+sed -i -E 's/(VERSION_PATCH *)([0-9]+)/\1'$patch'/' CMakeLists.txt


### PR DESCRIPTION
This is a manual workflow to be run from github action page (manual run will be available once PR is merged to `main`)

* Set given version in CMakeLists.txt
* Commit CMakeLists.txt
* Add tag to commit
* Create release note (can be manully disabled)

Here is example of Release generated by this workflow: https://github.com/LedgerHQ/lib-ledger-core/releases/tag/4.3.4-testReleaseWorkflow I will delete it as soon as we validate this PR