### PR TITLE
Rollback to pg 13 on macos

### DIFF
--- a/.circleci/build_lib.sh
+++ b/.circleci/build_lib.sh
@@ -10,7 +10,7 @@ unamestr=`uname`
 export ARCH=$2
 export CMAKE=cmake
 export PATH=$PATH:~/cmake_folder/bin
-export PG_INCLUDE_DIR=`[[ "$unamestr" = "Darwin" ]] && echo -n "/usr/local/opt/postgresql/include" || echo -n "/usr/include/postgresql"`
+export PG_INCLUDE_DIR=`[[ "$unamestr" = "Darwin" ]] && echo -n "/usr/local/opt/postgresql@13/include" || echo -n "/usr/include/postgresql"`
 
 echo "Use $PG_INCLUDE_DIR for PGSQL"
 

--- a/.circleci/setup_macos.sh
+++ b/.circleci/setup_macos.sh
@@ -33,8 +33,8 @@ brew install --build-from-source cmake
 
 echo "========> Install PostgreSQL"
 # Install with verbose otherwise the setup may timeout the CI because it doesn't log.
-brew install --verbose postgresql
-export CPLUS_INCLUDE_PATH="/usr/local/Cellar/postgresql/12.3_4/include:$CPLUS_INCLUDE_PATH"
+brew install --verbose postgresql@13
+brew link --overwrite postgresql@13
 
 
 echo "========> Install Sqlite"


### PR DESCRIPTION
Since yesterday, all builds on macos on circleci seems to fail because cmake can't find PostgreSQL

It seems to be related to update on brew package 14.5: https://github.com/Homebrew/homebrew-core/commit/8060df9169055ee1fb9d1d69fd149c3922e864ba

I propose to rollback to postgres 13 which works fine for now