### PR TITLE
VG-9372 Fix sql session tracer

### DIFF
--- a/core/lib/soci/core/connection-pool.cpp
+++ b/core/lib/soci/core/connection-pool.cpp
@@ -45,10 +45,10 @@ struct connection_pool::connection_pool_impl
 
 connection_pool::connection_pool(std::size_t size)
 {
-  connection_pool(size, std::make_shared<session_tracer>());
+  connection_pool(size, std::make_shared<session_span_factory>());
 }
 
-connection_pool::connection_pool(std::size_t size, std::shared_ptr<session_tracer> tracer)
+connection_pool::connection_pool(std::size_t size, std::shared_ptr<session_span_factory> tracer)
 {
     if (size == 0)
     {

--- a/core/lib/soci/core/connection-pool.cpp
+++ b/core/lib/soci/core/connection-pool.cpp
@@ -44,9 +44,8 @@ struct connection_pool::connection_pool_impl
 };
 
 connection_pool::connection_pool(std::size_t size)
-{
-  connection_pool(size, std::make_shared<session_span_factory>());
-}
+: connection_pool(size, std::make_shared<session_span_factory>())
+{}
 
 connection_pool::connection_pool(std::size_t size, std::shared_ptr<session_span_factory> tracer)
 {

--- a/core/lib/soci/core/connection-pool.h
+++ b/core/lib/soci/core/connection-pool.h
@@ -17,13 +17,13 @@ namespace soci
 {
 
 class session;
-class session_tracer;
+class session_span_factory;
 
 class SOCI_DECL connection_pool
 {
 public:
     explicit connection_pool(std::size_t size);
-    explicit connection_pool(std::size_t size, std::shared_ptr<session_tracer> tracer);
+    explicit connection_pool(std::size_t size, std::shared_ptr<session_span_factory> tracer);
     ~connection_pool();
 
     session & at(std::size_t pos);

--- a/core/lib/soci/core/session.cpp
+++ b/core/lib/soci/core/session.cpp
@@ -32,7 +32,7 @@ void ensureConnected(session_backend * backEnd)
 
 } // namespace anonymous
 
-session::session(std::shared_ptr<session_tracer> tracer)
+session::session(std::shared_ptr<session_span_factory> tracer)
     : once(this), prepare(this), logStream_(NULL),
       tracer_(tracer), uppercaseColumnNames_(false),
       backEnd_(NULL), isFromPool_(false), pool_(NULL)

--- a/core/lib/soci/core/session.h
+++ b/core/lib/soci/core/session.h
@@ -37,8 +37,8 @@ class blob_backend;
 class connection_pool;
 
 struct session_tracer {
-    virtual void startSpan(std::string &) {};
-    virtual void finishSpan() {};
+    virtual int startSpan(std::string &) { return 0; };
+    virtual void finishSpan(int) {};
     virtual ~session_tracer() = default;
 };
 

--- a/core/lib/soci/core/session.h
+++ b/core/lib/soci/core/session.h
@@ -36,10 +36,13 @@ class blob_backend;
 
 class connection_pool;
 
-struct session_tracer {
-    virtual int startSpan(std::string &) { return 0; };
-    virtual void finishSpan(int) {};
-    virtual ~session_tracer() = default;
+struct sessions_span {
+  virtual ~sessions_span() = default;
+};
+
+struct session_span_factory {
+    virtual std::unique_ptr<sessions_span> create(std::string &) { return 0; };
+    virtual ~session_span_factory() = default;
 };
 
 class SOCI_DECL session
@@ -49,7 +52,7 @@ private:
     void set_query_transformation_(std::unique_ptr<details::query_transformation_function> qtf);
 
 public:
-    session(std::shared_ptr<session_tracer> tracer = std::make_shared<session_tracer>());
+    session(std::shared_ptr<session_span_factory> tracer = std::make_shared<session_span_factory>());
     explicit session(connection_parameters const & parameters);
     session(backend_factory const & factory, std::string const & connectString);
     session(std::string const & backendName, std::string const & connectString);
@@ -134,8 +137,8 @@ public:
     // and try again; the default implementation assumes no timeout
     bool isAlive() const;
 
-    void set_tracer(std::unique_ptr<session_tracer> tracer) { tracer_ = std::move(tracer); }
-    std::shared_ptr<session_tracer> get_tracer() { return tracer_; }
+    void set_tracer(std::unique_ptr<session_span_factory> tracer) { tracer_ = std::move(tracer); }
+    std::shared_ptr<session_span_factory> get_tracer() { return tracer_; }
 
 private:
     session(session const &);
@@ -147,7 +150,7 @@ private:
     std::ostream * logStream_;
     std::string lastQuery_;
 
-    std::shared_ptr<session_tracer> tracer_ = std::make_shared<session_tracer>();
+    std::shared_ptr<session_span_factory> tracer_ = std::make_shared<session_span_factory>();
 
     connection_parameters lastConnectParameters_;
 

--- a/core/lib/soci/core/statement.cpp
+++ b/core/lib/soci/core/statement.cpp
@@ -248,7 +248,7 @@ void statement_impl::undefine_and_bind()
 
 bool statement_impl::execute(bool withDataExchange)
 {
-    session_.get_tracer()->startSpan(query_);
+    auto span = session_.get_tracer()->startSpan(query_);
     initialFetchSize_ = intos_size();
 
     if (intos_.empty() == false && initialFetchSize_ == 0)
@@ -335,7 +335,7 @@ bool statement_impl::execute(bool withDataExchange)
     post_use(gotData);
 
     session_.set_got_data(gotData);
-    session_.get_tracer()->finishSpan();
+    session_.get_tracer()->finishSpan(span);
     return gotData;
 }
 

--- a/core/lib/soci/core/statement.cpp
+++ b/core/lib/soci/core/statement.cpp
@@ -248,7 +248,7 @@ void statement_impl::undefine_and_bind()
 
 bool statement_impl::execute(bool withDataExchange)
 {
-    const auto spanId = session_.get_tracer()->startSpan(query_);
+    const auto spanId = session_.get_tracer()->create(query_);
     initialFetchSize_ = intos_size();
 
     if (intos_.empty() == false && initialFetchSize_ == 0)
@@ -335,7 +335,6 @@ bool statement_impl::execute(bool withDataExchange)
     post_use(gotData);
 
     session_.set_got_data(gotData);
-    session_.get_tracer()->finishSpan(spanId);
     return gotData;
 }
 

--- a/core/lib/soci/core/statement.cpp
+++ b/core/lib/soci/core/statement.cpp
@@ -248,7 +248,7 @@ void statement_impl::undefine_and_bind()
 
 bool statement_impl::execute(bool withDataExchange)
 {
-    auto span = session_.get_tracer()->startSpan(query_);
+    const auto spanId = session_.get_tracer()->startSpan(query_);
     initialFetchSize_ = intos_size();
 
     if (intos_.empty() == false && initialFetchSize_ == 0)
@@ -335,7 +335,7 @@ bool statement_impl::execute(bool withDataExchange)
     post_use(gotData);
 
     session_.set_got_data(gotData);
-    session_.get_tracer()->finishSpan(span);
+    session_.get_tracer()->finishSpan(spanId);
     return gotData;
 }
 

--- a/core/lib/soci/core/statement.cpp
+++ b/core/lib/soci/core/statement.cpp
@@ -248,7 +248,7 @@ void statement_impl::undefine_and_bind()
 
 bool statement_impl::execute(bool withDataExchange)
 {
-    const auto spanId = session_.get_tracer()->create(query_);
+    const auto span = session_.get_tracer()->create(query_);
     initialFetchSize_ = intos_size();
 
     if (intos_.empty() == false && initialFetchSize_ == 0)

--- a/core/src/database/DatabaseSessionPool.cpp
+++ b/core/src/database/DatabaseSessionPool.cpp
@@ -54,6 +54,10 @@ namespace ledger {
                 ~SessionSpan() override {
                     _span->close();
                 };
+                SessionSpan(SessionSpan &)                  = delete;
+                SessionSpan(SessionSpan &&)                 = delete;
+                SessionSpan &operator=(const SessionSpan &) = delete;
+                SessionSpan &operator=(SessionSpan &&)      = delete;
 
               private:
                 std::shared_ptr<api::Span> _span;

--- a/core/src/database/DatabaseSessionPool.cpp
+++ b/core/src/database/DatabaseSessionPool.cpp
@@ -41,44 +41,41 @@
 namespace ledger {
     namespace core {
         namespace impl {
-            class SessionTracer : public soci::session_tracer {
+            class SessionSpan : public soci::sessions_span {
               public:
-                ~SessionTracer() override                       = default;
-                SessionTracer(const SessionTracer &)            = delete;
-                SessionTracer(SessionTracer &&)                 = delete;
-                SessionTracer &operator=(SessionTracer &&)      = delete;
-                SessionTracer &operator=(const SessionTracer &) = delete;
+                SessionSpan(const std::string &string, const std::shared_ptr<api::CoreTracer> &tracer) {
+                    _span = tracer->startSpan(string);
+                    _span->setTagStr("db.statement", string);
+                    _span->setTagStr("sql.query", string);
+                    _span->setTagStr("db.system", "postgresql");
+                    _span->setTagStr("span.type", "sql");
+                    _span->setTagStr("service", "postgresql");
+                }
+                ~SessionSpan() override {
+                    _span->close();
+                };
 
-                explicit SessionTracer(std::shared_ptr<api::CoreTracer> tracer) : _tracer(std::move(tracer)) {
+              private:
+                std::shared_ptr<api::Span> _span;
+            };
+
+            class SessionSpanFactory : public soci::session_span_factory {
+              public:
+                ~SessionSpanFactory() override                            = default;
+                SessionSpanFactory(const SessionSpanFactory &)            = delete;
+                SessionSpanFactory(SessionSpanFactory &&)                 = delete;
+                SessionSpanFactory &operator=(SessionSpanFactory &&)      = delete;
+                SessionSpanFactory &operator=(const SessionSpanFactory &) = delete;
+
+                explicit SessionSpanFactory(std::shared_ptr<api::CoreTracer> tracer) : _tracer(std::move(tracer)) {
                 }
 
-                int startSpan(std::string &string) override {
-                    const std::lock_guard<std::mutex> lock(_mutex);
-                    auto span = _tracer->startSpan(string);
-                    span->setTagStr("db.statement", string);
-                    span->setTagStr("sql.query", string);
-                    span->setTagStr("db.system", "postgresql");
-                    span->setTagStr("span.type", "sql");
-                    span->setTagStr("service", "postgresql");
-                    int id = _globalIndex++;
-                    _traces.insert(std::make_pair(id, span));
-                    return id;
-                }
-
-                void finishSpan(int traceId) override {
-                    const std::lock_guard<std::mutex> lock(_mutex);
-                    if (_traces.find(traceId) == _traces.end()) {
-                        throw std::runtime_error("Unknown session trace id");
-                    }
-                    _traces.at(traceId)->close();
-                    _traces.erase(traceId);
+                std::unique_ptr<soci::sessions_span> create(std::string &string) override {
+                    return std::make_unique<SessionSpan>(string, _tracer);
                 }
 
               private:
-                std::atomic<int> _globalIndex{};
-                std::map<int, std::shared_ptr<api::Span>> _traces;
                 std::shared_ptr<api::CoreTracer> _tracer;
-                std::mutex _mutex{};
             };
         } // namespace impl
 
@@ -88,8 +85,8 @@ namespace ledger {
             const std::shared_ptr<api::CoreTracer> &tracer,
             const std::shared_ptr<spdlog::logger> &logger,
             const std::string &dbName,
-            const std::string &password) : _pool(static_cast<size_t>(backend->getConnectionPoolSize()), std::make_shared<impl::SessionTracer>((tracer))),
-                                           _readonlyPool(static_cast<size_t>(backend->getReadonlyConnectionPoolSize()), std::make_shared<impl::SessionTracer>((tracer))),
+            const std::string &password) : _pool(static_cast<size_t>(backend->getConnectionPoolSize()), std::make_shared<impl::SessionSpanFactory>((tracer))),
+                                           _readonlyPool(static_cast<size_t>(backend->getReadonlyConnectionPoolSize()), std::make_shared<impl::SessionSpanFactory>((tracer))),
                                            _backend(backend),
                                            _buffer("SQL", logger) {
             std::cout << "DatabaseSessionPool::DatabaseSessionPool" << std::endl;


### PR DESCRIPTION
Due to concurrency on SessionTracer we had a core dump crash on runtime

This PR adds the ability to have multiple spans at a time in the same SessionTracer, and adds thread-safety on it