### PR TITLE
Fix fee calculation for OptimizeSize UTXO picking strategy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,9 @@ clang_tidy("-checks=-*,clang-analyzer-*,-clang-analyzer-cplusplus*,cppcoreguidel
 include_what_you_use()  # add cmake conf option IWYU=ON to activate
 
 # The project version number.
-set(VERSION_MAJOR   4    CACHE STRING "Project major version number.")
-set(VERSION_MINOR   4    CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   3    CACHE STRING "Project patch version number.")
+set(VERSION_MAJOR   0    CACHE STRING "Project major version number.")
+set(VERSION_MINOR   0    CACHE STRING "Project minor version number.")
+set(VERSION_PATCH   0    CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,9 @@ clang_tidy("-checks=-*,clang-analyzer-*,-clang-analyzer-cplusplus*,cppcoreguidel
 include_what_you_use()  # add cmake conf option IWYU=ON to activate
 
 # The project version number.
-set(VERSION_MAJOR   0    CACHE STRING "Project major version number.")
-set(VERSION_MINOR   0    CACHE STRING "Project minor version number.")
-set(VERSION_PATCH   0    CACHE STRING "Project patch version number.")
+set(VERSION_MAJOR   4    CACHE STRING "Project major version number.")
+set(VERSION_MINOR   4    CACHE STRING "Project minor version number.")
+set(VERSION_PATCH   4    CACHE STRING "Project patch version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY build)

--- a/core/idl/wallet/bitcoin/bitcoin_like_wallet.djinni
+++ b/core/idl/wallet/bitcoin/bitcoin_like_wallet.djinni
@@ -230,8 +230,6 @@ BitcoinLikePickingStrategy = enum {
     deep_outputs_first;
     optimize_size;
     merge_outputs;
-    highest_first_limit_utxo;
-    limit_utxo;
 }
 
 BitcoinLikeTransactionBuilder = interface +c {

--- a/core/src/api/BitcoinLikePickingStrategy.cpp
+++ b/core/src/api/BitcoinLikePickingStrategy.cpp
@@ -11,17 +11,13 @@ std::string to_string(const BitcoinLikePickingStrategy& bitcoinLikePickingStrate
         case BitcoinLikePickingStrategy::DEEP_OUTPUTS_FIRST: return "DEEP_OUTPUTS_FIRST";
         case BitcoinLikePickingStrategy::OPTIMIZE_SIZE: return "OPTIMIZE_SIZE";
         case BitcoinLikePickingStrategy::MERGE_OUTPUTS: return "MERGE_OUTPUTS";
-        case BitcoinLikePickingStrategy::HIGHEST_FIRST_LIMIT_UTXO: return "HIGHEST_FIRST_LIMIT_UTXO";
-        case BitcoinLikePickingStrategy::LIMIT_UTXO: return "LIMIT_UTXO";
     };
 };
 template <>
 BitcoinLikePickingStrategy from_string(const std::string& bitcoinLikePickingStrategy) {
     if (bitcoinLikePickingStrategy == "DEEP_OUTPUTS_FIRST") return BitcoinLikePickingStrategy::DEEP_OUTPUTS_FIRST;
     else if (bitcoinLikePickingStrategy == "OPTIMIZE_SIZE") return BitcoinLikePickingStrategy::OPTIMIZE_SIZE;
-    else if (bitcoinLikePickingStrategy == "MERGE_OUTPUTS") return BitcoinLikePickingStrategy::MERGE_OUTPUTS;
-    else if (bitcoinLikePickingStrategy == "HIGHEST_FIRST_LIMIT_UTXO") return BitcoinLikePickingStrategy::HIGHEST_FIRST_LIMIT_UTXO;
-    else return BitcoinLikePickingStrategy::LIMIT_UTXO;
+    else return BitcoinLikePickingStrategy::MERGE_OUTPUTS;
 };
 
 std::ostream &operator<<(std::ostream &os, const BitcoinLikePickingStrategy &o)
@@ -30,8 +26,6 @@ std::ostream &operator<<(std::ostream &os, const BitcoinLikePickingStrategy &o)
         case BitcoinLikePickingStrategy::DEEP_OUTPUTS_FIRST:  return os << "DEEP_OUTPUTS_FIRST";
         case BitcoinLikePickingStrategy::OPTIMIZE_SIZE:  return os << "OPTIMIZE_SIZE";
         case BitcoinLikePickingStrategy::MERGE_OUTPUTS:  return os << "MERGE_OUTPUTS";
-        case BitcoinLikePickingStrategy::HIGHEST_FIRST_LIMIT_UTXO:  return os << "HIGHEST_FIRST_LIMIT_UTXO";
-        case BitcoinLikePickingStrategy::LIMIT_UTXO:  return os << "LIMIT_UTXO";
     }
 }
 

--- a/core/src/api/BitcoinLikePickingStrategy.hpp
+++ b/core/src/api/BitcoinLikePickingStrategy.hpp
@@ -21,8 +21,6 @@ enum class BitcoinLikePickingStrategy : int {
     DEEP_OUTPUTS_FIRST,
     OPTIMIZE_SIZE,
     MERGE_OUTPUTS,
-    HIGHEST_FIRST_LIMIT_UTXO,
-    LIMIT_UTXO,
 };
 LIBCORE_EXPORT  std::string to_string(const BitcoinLikePickingStrategy& bitcoinLikePickingStrategy);
 LIBCORE_EXPORT  std::ostream &operator<<(std::ostream &os, const BitcoinLikePickingStrategy &o);

--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
@@ -569,15 +569,6 @@ namespace ledger {
                         sum = sum + utxo.value;
                     }
                 } break;
-                case api::BitcoinLikePickingStrategy::HIGHEST_FIRST_LIMIT_UTXO:
-                case api::BitcoinLikePickingStrategy::LIMIT_UTXO: {
-                    std::sort(utxos.begin(), utxos.end(), [](auto &lhs, auto &rhs) {
-                        return lhs.value.toInt64() > rhs.value.toInt64();
-                    });
-                    for (int i = 0; i < utxos.size() && i < maxUtxos.value_or(0); ++i) {
-                        sum = sum + utxos[i].value;
-                    }
-                } break;
                 default: {
                     throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "unknown strategy");
                 }

--- a/core/src/wallet/bitcoin/scripts/BitcoinLikeScript.cpp
+++ b/core/src/wallet/bitcoin/scripts/BitcoinLikeScript.cpp
@@ -39,6 +39,7 @@
 #include <math/bech32/Bech32Factory.h>
 #include <utils/hex.h>
 #include <wallet/bitcoin/networks.hpp>
+#include <wallet/currencies.hpp>
 
 namespace ledger {
     namespace core {
@@ -128,6 +129,11 @@ namespace ledger {
             if (a->isP2WPKH() || a->isP2WSH()) {
                 script << btccore::OP_0 << a->getHash160();
             } else if (a->isP2TR()) {
+                if (currency.name != currencies::BITCOIN.name &&
+                    currency.name != currencies::BITCOIN_TESTNET.name &&
+                    currency.name != currencies::BITCOIN_REGTEST.name) {
+                    throw make_exception(api::ErrorCode::UNSUPPORTED_OPERATION, "Can't generate script from Taproot address ({}) in currency {}", address, currency.name);
+                }
                 script << btccore::OP_1 << a->getHash160();
             } else if (a->isP2PKH()) {
                 script << btccore::OP_DUP << btccore::OP_HASH160 << a->getHash160() << btccore::OP_EQUALVERIFY

--- a/core/src/wallet/bitcoin/scripts/BitcoinLikeScript.cpp
+++ b/core/src/wallet/bitcoin/scripts/BitcoinLikeScript.cpp
@@ -127,6 +127,8 @@ namespace ledger {
             BitcoinLikeScript script;
             if (a->isP2WPKH() || a->isP2WSH()) {
                 script << btccore::OP_0 << a->getHash160();
+            } else if (a->isP2TR()) {
+                script << btccore::OP_1 << a->getHash160();
             } else if (a->isP2PKH()) {
                 script << btccore::OP_DUP << btccore::OP_HASH160 << a->getHash160() << btccore::OP_EQUALVERIFY
                        << btccore::OP_CHECKSIG;

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.cpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.cpp
@@ -570,7 +570,7 @@ namespace ledger {
                 buddy->logger->debug("Add coinLowestLarger to coin selection");
                 out.push_back(coinLowestLarger.getValue());
 
-                buddy->changeAmount = BigInt(coinLowestLarger.getValue().value.toLong() - signedUTXOCost - (int64_t)(amountWithFixedFees + changeOutputSize * buddy->request.feePerByte->toInt64()));
+                buddy->changeAmount = BigInt(coinLowestLarger.getValue().value.toLong() - signedUTXOCost - static_cast<int64_t>(amountWithFixedFees + changeOutputSize * buddy->request.feePerByte->toInt64()));
             } else { // Pick bestValues
                 buddy->logger->debug("Push all vUTXOs");
                 out                 = tmpOut;

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.cpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.cpp
@@ -74,10 +74,6 @@ namespace ledger {
                             return filterWithOptimizeSize(buddy, utxos, amount, getCurrency());
                         case api::BitcoinLikePickingStrategy::MERGE_OUTPUTS:
                             return filterWithMergeOutputs(buddy, utxos, amount, getCurrency());
-                        case api::BitcoinLikePickingStrategy::HIGHEST_FIRST_LIMIT_UTXO:
-                            return filterWithHighestFirstLimitUtxo(buddy, utxos, amount, getCurrency(), picker.maxUtxo);
-                        case api::BitcoinLikePickingStrategy::LIMIT_UTXO:
-                            return filterWithLimitUtxo(buddy, utxos, amount, getCurrency(), picker.maxUtxo);
                         }
 
                         throw make_exception(api::ErrorCode::ILLEGAL_ARGUMENT, "Unknown UTXO picking strategy.");
@@ -596,121 +592,6 @@ namespace ledger {
             return filterWithSort(buddy, utxos, aggregatedAmount, currency, [](auto &lhs, auto &rhs) {
                 return lhs.value.toLong() < rhs.value.toLong();
             });
-        }
-
-        std::vector<BitcoinLikeUtxo> BitcoinLikeStrategyUtxoPicker::filterWithHighestFirstLimitUtxo(
-            const std::shared_ptr<BitcoinLikeUtxoPicker::Buddy> &buddy,
-            std::vector<BitcoinLikeUtxo> utxos,
-            const BigInt &aggregatedAmount,
-            const api::Currency &currency,
-            const optional<int32_t> &maxUtxo) {
-            buddy->logger->debug("Start filterWithHighestFirstLimitUtxo");
-            if (!maxUtxo) {
-                throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Missed max_utxo parameter.");
-            }
-
-            BigInt collected = aggregatedAmount;
-
-            auto pickedUtxos = std::vector<BitcoinLikeUtxo>{};
-
-            pickedUtxos.reserve(utxos.size());
-            std::sort(utxos.begin(), utxos.end(), [](auto &lhs, auto &rhs) {
-                return lhs.value.toLong() > rhs.value.toLong();
-            });
-
-            bool enough = false;
-            for (auto const &u : utxos) {
-                collected = collected + *u.value.value();
-                pickedUtxos.push_back(u);
-                if (pickedUtxos.size() > maxUtxo.value()) {
-                    throw make_exception(api::ErrorCode::NOT_ENOUGH_FUNDS, "Cannot gather enough funds: max_utxo reached");
-                }
-
-                buddy->logger->debug("Collected: {} Needed: {}", collected.toString(), buddy->outputAmount.toString());
-
-                auto const computeOutputAmount = pickedUtxos.size() == utxos.size();
-                if (hasEnough(buddy, collected, pickedUtxos.size(), currency, computeOutputAmount)) {
-                    enough = true;
-                    break;
-                }
-            }
-
-            if (!enough && !buddy->request.wipe) {
-                throw make_exception(api::ErrorCode::NOT_ENOUGH_FUNDS, "Cannot gather enough funds.");
-            }
-
-            buddy->logger->debug("Require {} inputs to complete the transaction with {} for {}", pickedUtxos.size(), collected.toString(), buddy->outputAmount.toString());
-
-            pickedUtxos.shrink_to_fit();
-
-            return pickedUtxos;
-        }
-
-        std::vector<BitcoinLikeUtxo> BitcoinLikeStrategyUtxoPicker::filterWithLimitUtxo(
-            const std::shared_ptr<BitcoinLikeUtxoPicker::Buddy> &buddy,
-            std::vector<BitcoinLikeUtxo> utxos,
-            const BigInt &aggregatedAmount,
-            const api::Currency &currency,
-            const optional<int32_t> &maxUtxo) {
-            buddy->logger->debug("Start filterWithLimitUtxo");
-            if (!maxUtxo) {
-                throw make_exception(api::ErrorCode::INVALID_ARGUMENT, "Missed max_utxo parameter.");
-            }
-
-            // sort utxos by value (DESC)
-            std::sort(utxos.begin(), utxos.end(), [](auto &lhs, auto &rhs) {
-                return lhs.value.toLong() > rhs.value.toLong();
-            });
-
-            struct BatchData {
-                int pos       = 0;
-                int size      = 0;
-                BigInt value  = BigInt::ZERO;
-                BigInt output = BigInt::ZERO;
-                BigInt change = BigInt::ZERO;
-            } bestBatch;
-
-            auto currentBatch = std::vector<BitcoinLikeUtxo>{};
-            for (int pos = 0; pos < utxos.size(); pos += currentBatch.size()) { // iterate over batches : currentBatch.size is the size of the previous batch
-                bool enough = false;
-                buddy->logger->debug("starting a new batch: position: {}", pos);
-                currentBatch.clear();
-                BigInt collected = aggregatedAmount;
-                for (int i = pos; (i < pos + maxUtxo.value()) && (i < utxos.size()); ++i) { // iterate over utxos of batch: cannot exceed maxUtxo elements by batch
-                    collected = collected + *utxos[i].value.value();
-                    currentBatch.push_back(utxos[i]);
-
-                    buddy->logger->debug("Collected: {} Needed: {}", collected.toString(), buddy->outputAmount.toString());
-
-                    auto const computeOutputAmount = currentBatch.size() == utxos.size();
-                    if (hasEnough(buddy, collected, currentBatch.size(), currency, computeOutputAmount)) {
-                        enough = true;
-                        buddy->logger->debug("Enough funds for batch: position: {}, size: {} ", pos, currentBatch.size());
-                        if (collected < bestBatch.value || bestBatch.value == BigInt::ZERO) {
-                            bestBatch = {pos, static_cast<int>(currentBatch.size()), collected, buddy->outputAmount, buddy->changeAmount};
-                        }
-                        break;
-                    }
-                }
-
-                if (!enough) { // if the current batch is not enough, it will be the same for the remaining batches as utxos are sorted
-                    break;
-                }
-            }
-
-            if (bestBatch.size == 0) {
-                throw make_exception(api::ErrorCode::NOT_ENOUGH_FUNDS, "Cannot gather enough funds.");
-            }
-            buddy->outputAmount = bestBatch.output;
-            buddy->changeAmount = bestBatch.change;
-
-            std::vector<BitcoinLikeUtxo> pickedUtxos(
-                utxos.begin() + bestBatch.pos,
-                utxos.begin() + bestBatch.pos + bestBatch.size);
-
-            buddy->logger->debug("Require {} inputs to complete the transaction with {} for {}", pickedUtxos.size(), bestBatch.value.toString(), buddy->outputAmount.toString());
-
-            return pickedUtxos;
         }
 
         std::vector<BitcoinLikeUtxo> BitcoinLikeStrategyUtxoPicker::filterWithSort(

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.cpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.cpp
@@ -576,7 +576,7 @@ namespace ledger {
                 out                 = tmpOut;
                 // Set amount of change
                 // Change amount = amountWithFixedFees + fees for 1 additional output (change)
-                buddy->changeAmount = BigInt(bestValue - (int64_t)(amountWithFixedFees + changeOutputSize * buddy->request.feePerByte->toInt64()));
+                buddy->changeAmount = BigInt(bestValue - static_cast<int64_t>(amountWithFixedFees + changeOutputSize * buddy->request.feePerByte->toInt64()));
             }
 
             if (buddy->changeAmount.toInt64() < minimumChange) {

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.cpp
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.cpp
@@ -456,13 +456,13 @@ namespace ledger {
             // We take the dust as a reference plus the cost of spending this change
 
             const int64_t dustAmount_fixedAndOutputPart = BitcoinLikeTransactionApi::computeDustAmount(currency,
-                                                                                                       (fixedSize.Max + targetOutputsSize));
+                                                                                                       (fixedSize.Max + narrowing_cast<int32_t>(targetOutputsSize)));
 
             const int64_t dustAmount_OneInputPart       = BitcoinLikeTransactionApi::computeDustAmount(currency,
                                                                                                        signedUTXOSize);
 
             const int64_t dustAmountWithOneInput        = BitcoinLikeTransactionApi::computeDustAmount(currency,
-                                                                                                       fixedSize.Max + targetOutputsSize + signedUTXOSize + signedUTXOSize);
+                                                                                                       fixedSize.Max + narrowing_cast<int32_t>(targetOutputsSize + signedUTXOSize + signedUTXOSize));
 
             const int64_t minimumChangeWithOneInput     = dustAmountWithOneInput + signedUTXOCost;
 

--- a/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.h
+++ b/core/src/wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.h
@@ -67,18 +67,6 @@ namespace ledger {
                                                                     const std::vector<BitcoinLikeUtxo> &utxo,
                                                                     const BigInt &aggregatedAmount,
                                                                     const api::Currency &currrency);
-            static std::vector<BitcoinLikeUtxo> filterWithHighestFirstLimitUtxo(
-                const std::shared_ptr<BitcoinLikeUtxoPicker::Buddy> &buddy,
-                std::vector<BitcoinLikeUtxo> utxos,
-                const BigInt &aggregatedAmount,
-                const api::Currency &currency,
-                const optional<int32_t> &maxUtxo);
-            static std::vector<BitcoinLikeUtxo> filterWithLimitUtxo(
-                const std::shared_ptr<BitcoinLikeUtxoPicker::Buddy> &buddy,
-                std::vector<BitcoinLikeUtxo> utxos,
-                const BigInt &aggregatedAmount,
-                const api::Currency &currency,
-                const optional<int32_t> &maxUtxo);
             static bool hasEnough(const std::shared_ptr<Buddy> &buddy,
                                   const BigInt &aggregatedAmount,
                                   int inputCount,

--- a/core/test/bitcoin/bitcoin_utxo_picket_tests.cpp
+++ b/core/test/bitcoin/bitcoin_utxo_picket_tests.cpp
@@ -7,6 +7,9 @@
 #include <wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.h>
 #include <wallet/common/Amount.h>
 #include <wallet/currencies.hpp>
+#include <wallet/bitcoin/scripts/BitcoinLikeScript.h>
+#include <wallet/bitcoin/api_impl/BitcoinLikeScriptApi.h>
+#include <wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h>
 
 using namespace ledger::core;
 
@@ -38,12 +41,6 @@ class MockKeychain : public BitcoinLikeKeychain {
     MOCK_CONST_METHOD0(getObservableRangeSize, int32_t());
     MOCK_CONST_METHOD1(contains, bool(const std::string &address));
     MOCK_CONST_METHOD0(getOutputSizeAsSignedTxInput, int32_t());
-};
-
-class MockBitcoinLikeScript : public api::BitcoinLikeScript {
-  public:
-    MOCK_METHOD0(head, std::shared_ptr<api::BitcoinLikeScriptChunk>());
-    MOCK_METHOD0(toString, std::string());
 };
 
 class MockBitcoinLikeOutput : public api::BitcoinLikeOutput {
@@ -95,18 +92,20 @@ std::vector<BitcoinLikeUtxo> createUtxos(const std::vector<int64_t> &values) {
     return utxos;
 }
 
-std::shared_ptr<BitcoinLikeUtxoPicker::Buddy> createBuddy(int64_t feesPerByte, int64_t outputAmount, const api::Currency &currency) {
+std::shared_ptr<BitcoinLikeUtxoPicker::Buddy> createBuddy(int64_t feesPerByte, int64_t outputAmount, const api::Currency &currency, const std::string keychainEngine = api::KeychainEngines::BIP32_P2PKH, const std::string address = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4") {
     BitcoinLikeTransactionBuildRequest r(std::make_shared<BigInt>(0));
     r.wipe       = false;
     r.feePerByte = std::make_shared<BigInt>(feesPerByte);
-    r.outputs.push_back(std::make_tuple(std::make_shared<BigInt>(outputAmount), std::make_shared<MockBitcoinLikeScript>()));
+    ledger::core::BitcoinLikeScript outputScript = ledger::core::BitcoinLikeScript::fromAddress(address, currency);
+    r.outputs.push_back(std::make_tuple(std::make_shared<BigInt>(outputAmount), std::make_shared<BitcoinLikeScriptApi>(outputScript)));
     r.utxoPicker = BitcoinUtxoPickerParams{api::BitcoinLikePickingStrategy::OPTIMIZE_SIZE, 0, optional<int32_t>()};
 
     BitcoinLikeGetUtxoFunction g;
     BitcoinLikeGetTxFunction tx;
     std::shared_ptr<BitcoinLikeBlockchainExplorer> e;
     auto config = std::make_shared<ledger::core::DynamicObject>();
-    config->putString(api::Configuration::KEYCHAIN_ENGINE, api::KeychainEngines::BIP32_P2PKH);
+    config->putString(api::Configuration::KEYCHAIN_ENGINE, keychainEngine);
+    config->putBoolean(api::Configuration::ALLOW_P2TR, true);
     std::shared_ptr<Preferences> preferences;
     std::shared_ptr<MockKeychain> k          = std::make_shared<MockKeychain>(config, currency, 0, preferences);
     static std::shared_ptr<spdlog::logger> l = spdlog::null_logger_mt("null_sink");
@@ -184,4 +183,59 @@ TEST(OptimizeSize, ApproximationShouldTookEnough) {
     EXPECT_GE(transactionFees, minimumRequiredFees);
     if (buddy->changeAmount.toInt64() != 0)
         EXPECT_GE(buddy->changeAmount.toInt64(), inputSizeInBytes * feesPerByte);
+}
+
+void feeIsEnoughFor(const std::string address, const int64_t targetOutputSizeInBytes) {
+    const api::Currency currency             = currencies::BITCOIN_TESTNET;
+    const int64_t feesPerByte                = 1;
+    const int64_t inputSizeInBytes           = 68; // we are spending P2WPKH input
+
+    const int64_t emtyTransactionSizeInBytes = 10;
+    int64_t outputAmount                     = 50000000;
+    std::vector<int64_t> inputAmounts{100000000};
+
+    auto buddy               = createBuddy(feesPerByte, outputAmount, currency, api::KeychainEngines::BIP173_P2WPKH, address);
+
+    const int64_t changeOutputSizeInBytes = 8 + 1 + 1 + 1 + 20;
+    const int64_t allOutputsSizeInBytes = targetOutputSizeInBytes + changeOutputSizeInBytes;
+
+    auto utxos               = createUtxos(inputAmounts);
+    auto pickedUtxos         = BitcoinLikeStrategyUtxoPicker::filterWithOptimizeSize(buddy, utxos, BigInt(-1), currency);
+    int64_t totalInputsValue = 0;
+    for (auto utxo : pickedUtxos) {
+        totalInputsValue += utxo.value.toLong();
+    }
+    int64_t transactionFees     = totalInputsValue - buddy->changeAmount.toInt64() - outputAmount;
+    int64_t minimumRequiredFees = (emtyTransactionSizeInBytes + allOutputsSizeInBytes + inputSizeInBytes * pickedUtxos.size()) * feesPerByte;
+
+    EXPECT_GE(transactionFees, minimumRequiredFees);
+    if (buddy->changeAmount.toInt64() != 0)
+        EXPECT_GE(buddy->changeAmount.toInt64(), inputSizeInBytes * feesPerByte);
+}
+
+TEST(OptimizeSize, FeeIsEnoughForP2WPKH) {
+    const std::string address = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"; // P2WPKH
+
+    const int64_t targetOutputSizeInBytes = 8 + 1 + 1 + 1 + 20;
+    // amount + script length + witness version + hash size + hash
+
+    feeIsEnoughFor(address, targetOutputSizeInBytes);
+}
+
+TEST(OptimizeSize, FeeIsEnoughForP2WSH) {
+    const std::string address = "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7"; // P2WSH
+
+    const int64_t targetOutputSizeInBytes = 8 + 1 + 1 + 1 + 32;
+    // amount + script length + witness version + hash size + hash
+
+    feeIsEnoughFor(address, targetOutputSizeInBytes);
+}
+
+TEST(OptimizeSize, FeeIsEnoughForP2TR) {
+    const std::string address = "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c"; // P2TR
+
+    const int64_t targetOutputSizeInBytes = 8 + 1 + 1 + 1 + 32;
+    // amount + script length + witness version + hash size + hash
+
+    feeIsEnoughFor(address, targetOutputSizeInBytes);
 }

--- a/core/test/bitcoin/bitcoin_utxo_picket_tests.cpp
+++ b/core/test/bitcoin/bitcoin_utxo_picket_tests.cpp
@@ -185,9 +185,8 @@ TEST(OptimizeSize, ApproximationShouldTookEnough) {
         EXPECT_GE(buddy->changeAmount.toInt64(), inputSizeInBytes * feesPerByte);
 }
 
-void feeIsEnoughFor(const std::string address, const int64_t targetOutputSizeInBytes) {
+void feeIsEnoughFor(const std::string address, const int64_t targetOutputSizeInBytes, const int64_t feesPerByte) {
     const api::Currency currency             = currencies::BITCOIN_TESTNET;
-    const int64_t feesPerByte                = 1;
     const int64_t inputSizeInBytes           = 68; // we are spending P2WPKH input
 
     const int64_t emtyTransactionSizeInBytes = 10;
@@ -208,6 +207,9 @@ void feeIsEnoughFor(const std::string address, const int64_t targetOutputSizeInB
     int64_t transactionFees     = totalInputsValue - buddy->changeAmount.toInt64() - outputAmount;
     int64_t minimumRequiredFees = (emtyTransactionSizeInBytes + allOutputsSizeInBytes + inputSizeInBytes * pickedUtxos.size()) * feesPerByte;
 
+    std::cerr << "transactionFees     == " << transactionFees << std::endl;
+    std::cerr << "minimumRequiredFees == " << minimumRequiredFees << std::endl;
+
     EXPECT_GE(transactionFees, minimumRequiredFees);
     if (buddy->changeAmount.toInt64() != 0)
         EXPECT_GE(buddy->changeAmount.toInt64(), inputSizeInBytes * feesPerByte);
@@ -219,7 +221,8 @@ TEST(OptimizeSize, FeeIsEnoughForP2WPKH) {
     const int64_t targetOutputSizeInBytes = 8 + 1 + 1 + 1 + 20;
     // amount + script length + witness version + hash size + hash
 
-    feeIsEnoughFor(address, targetOutputSizeInBytes);
+    for (int64_t feesPerByte = 1; feesPerByte < 1000000; feesPerByte *= 10)
+        feeIsEnoughFor(address, targetOutputSizeInBytes, feesPerByte);
 }
 
 TEST(OptimizeSize, FeeIsEnoughForP2WSH) {
@@ -228,7 +231,8 @@ TEST(OptimizeSize, FeeIsEnoughForP2WSH) {
     const int64_t targetOutputSizeInBytes = 8 + 1 + 1 + 1 + 32;
     // amount + script length + witness version + hash size + hash
 
-    feeIsEnoughFor(address, targetOutputSizeInBytes);
+    for (int64_t feesPerByte = 1; feesPerByte < 1000000; feesPerByte *= 10)
+        feeIsEnoughFor(address, targetOutputSizeInBytes, feesPerByte);
 }
 
 TEST(OptimizeSize, FeeIsEnoughForP2TR) {
@@ -237,5 +241,6 @@ TEST(OptimizeSize, FeeIsEnoughForP2TR) {
     const int64_t targetOutputSizeInBytes = 8 + 1 + 1 + 1 + 32;
     // amount + script length + witness version + hash size + hash
 
-    feeIsEnoughFor(address, targetOutputSizeInBytes);
+    for (int64_t feesPerByte = 1; feesPerByte < 1000000; feesPerByte *= 10)
+        feeIsEnoughFor(address, targetOutputSizeInBytes, feesPerByte);
 }

--- a/core/test/bitcoin/bitcoin_utxo_picket_tests.cpp
+++ b/core/test/bitcoin/bitcoin_utxo_picket_tests.cpp
@@ -4,12 +4,12 @@
 #include <gtest/gtest.h>
 #include <ledger/core/api/Networks.hpp>
 #include <spdlog/sinks/null_sink.h>
+#include <wallet/bitcoin/api_impl/BitcoinLikeScriptApi.h>
+#include <wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h>
+#include <wallet/bitcoin/scripts/BitcoinLikeScript.h>
 #include <wallet/bitcoin/transaction_builders/BitcoinLikeStrategyUtxoPicker.h>
 #include <wallet/common/Amount.h>
 #include <wallet/currencies.hpp>
-#include <wallet/bitcoin/scripts/BitcoinLikeScript.h>
-#include <wallet/bitcoin/api_impl/BitcoinLikeScriptApi.h>
-#include <wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.h>
 
 using namespace ledger::core;
 
@@ -94,8 +94,8 @@ std::vector<BitcoinLikeUtxo> createUtxos(const std::vector<int64_t> &values) {
 
 std::shared_ptr<BitcoinLikeUtxoPicker::Buddy> createBuddy(int64_t feesPerByte, int64_t outputAmount, const api::Currency &currency, const std::string keychainEngine = api::KeychainEngines::BIP32_P2PKH, const std::string address = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4") {
     BitcoinLikeTransactionBuildRequest r(std::make_shared<BigInt>(0));
-    r.wipe       = false;
-    r.feePerByte = std::make_shared<BigInt>(feesPerByte);
+    r.wipe                                       = false;
+    r.feePerByte                                 = std::make_shared<BigInt>(feesPerByte);
     ledger::core::BitcoinLikeScript outputScript = ledger::core::BitcoinLikeScript::fromAddress(address, currency);
     r.outputs.push_back(std::make_tuple(std::make_shared<BigInt>(outputAmount), std::make_shared<BitcoinLikeScriptApi>(outputScript)));
     r.utxoPicker = BitcoinUtxoPickerParams{api::BitcoinLikePickingStrategy::OPTIMIZE_SIZE, 0, optional<int32_t>()};
@@ -194,14 +194,14 @@ void feeIsEnoughFor(const std::string address, const int64_t targetOutputSizeInB
     int64_t outputAmount                     = 50000000;
     std::vector<int64_t> inputAmounts{100000000};
 
-    auto buddy               = createBuddy(feesPerByte, outputAmount, currency, api::KeychainEngines::BIP173_P2WPKH, address);
+    auto buddy                            = createBuddy(feesPerByte, outputAmount, currency, api::KeychainEngines::BIP173_P2WPKH, address);
 
     const int64_t changeOutputSizeInBytes = 8 + 1 + 1 + 1 + 20;
-    const int64_t allOutputsSizeInBytes = targetOutputSizeInBytes + changeOutputSizeInBytes;
+    const int64_t allOutputsSizeInBytes   = targetOutputSizeInBytes + changeOutputSizeInBytes;
 
-    auto utxos               = createUtxos(inputAmounts);
-    auto pickedUtxos         = BitcoinLikeStrategyUtxoPicker::filterWithOptimizeSize(buddy, utxos, BigInt(-1), currency);
-    int64_t totalInputsValue = 0;
+    auto utxos                            = createUtxos(inputAmounts);
+    auto pickedUtxos                      = BitcoinLikeStrategyUtxoPicker::filterWithOptimizeSize(buddy, utxos, BigInt(-1), currency);
+    int64_t totalInputsValue              = 0;
     for (auto utxo : pickedUtxos) {
         totalInputsValue += utxo.value.toLong();
     }
@@ -214,7 +214,7 @@ void feeIsEnoughFor(const std::string address, const int64_t targetOutputSizeInB
 }
 
 TEST(OptimizeSize, FeeIsEnoughForP2WPKH) {
-    const std::string address = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"; // P2WPKH
+    const std::string address             = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"; // P2WPKH
 
     const int64_t targetOutputSizeInBytes = 8 + 1 + 1 + 1 + 20;
     // amount + script length + witness version + hash size + hash
@@ -223,7 +223,7 @@ TEST(OptimizeSize, FeeIsEnoughForP2WPKH) {
 }
 
 TEST(OptimizeSize, FeeIsEnoughForP2WSH) {
-    const std::string address = "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7"; // P2WSH
+    const std::string address             = "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7"; // P2WSH
 
     const int64_t targetOutputSizeInBytes = 8 + 1 + 1 + 1 + 32;
     // amount + script length + witness version + hash size + hash
@@ -232,7 +232,7 @@ TEST(OptimizeSize, FeeIsEnoughForP2WSH) {
 }
 
 TEST(OptimizeSize, FeeIsEnoughForP2TR) {
-    const std::string address = "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c"; // P2TR
+    const std::string address             = "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c"; // P2TR
 
     const int64_t targetOutputSizeInBytes = 8 + 1 + 1 + 1 + 32;
     // amount + script length + witness version + hash size + hash

--- a/core/test/integration/transactions/coin_selection_P2PKH.cpp
+++ b/core/test/integration/transactions/coin_selection_P2PKH.cpp
@@ -104,68 +104,6 @@ TEST_F(CoinSelectionP2PKH, PickMultipleUTXO) {
     EXPECT_EQ(tx->getOutputs().at(0)->getValue()->toLong(), 70000000);
 }
 
-TEST_F(CoinSelectionP2PKH, HighestFirstEnough) {
-    auto builder = tx_builder();
-    builder->sendToAddress(api::Amount::fromLong(currency, 70000000), "2MvuUMAG1NFQmmM69Writ6zTsYCnQHFG9BF");
-    builder->pickInputs(api::BitcoinLikePickingStrategy::HIGHEST_FIRST_LIMIT_UTXO, 0xFFFFFFFF, optional<int32_t>(2));
-    builder->setFeesPerByte(api::Amount::fromLong(currency, 0));
-    auto f  = builder->build();
-    auto tx = uv::wait(f);
-
-    EXPECT_LE(tx->getInputs().size(), 2);
-    EXPECT_EQ(tx->getInputs().at(0)->getValue()->toLong(), 50000000);
-    EXPECT_EQ(tx->getInputs().at(1)->getValue()->toLong(), 40000000);
-
-    EXPECT_EQ(tx->getOutputs().size(), 2);
-    EXPECT_EQ(tx->getOutputs().at(0)->getValue()->toLong(), 70000000);
-}
-
-TEST_F(CoinSelectionP2PKH, HighestFirstNotEnough) {
-    auto builder = tx_builder();
-    builder->sendToAddress(api::Amount::fromLong(currency, 100000000), "2MvuUMAG1NFQmmM69Writ6zTsYCnQHFG9BF");
-    builder->pickInputs(api::BitcoinLikePickingStrategy::HIGHEST_FIRST_LIMIT_UTXO, 0xFFFFFFFF, optional<int32_t>(2));
-    builder->setFeesPerByte(api::Amount::fromLong(currency, 0));
-    auto f = builder->build();
-    EXPECT_THROW(uv::wait(f), Exception);
-}
-
-TEST_F(CoinSelectionP2PKH, LimitUtxoPickStrategy) {
-    auto build = [=](int64_t amount) {
-        auto builder = tx_builder();
-        builder->sendToAddress(api::Amount::fromLong(currency, amount), "2MvuUMAG1NFQmmM69Writ6zTsYCnQHFG9BF");
-        builder->pickInputs(api::BitcoinLikePickingStrategy::LIMIT_UTXO, 0xFFFFFFFF, optional<int32_t>(2));
-        builder->setFeesPerByte(api::Amount::fromLong(currency, 0));
-        auto f = builder->build();
-        return uv::wait(f);
-    };
-
-    { // test 1
-        auto tx = build(70000000);
-        EXPECT_LE(tx->getInputs().size(), 2);
-        EXPECT_EQ(tx->getInputs().at(0)->getValue()->toLong(), 50000000);
-        EXPECT_EQ(tx->getInputs().at(1)->getValue()->toLong(), 40000000);
-        EXPECT_EQ(tx->getOutputs().size(), 2);
-        EXPECT_EQ(tx->getOutputs().at(0)->getValue()->toLong(), 70000000);
-    }
-    { // test 2
-        auto tx = build(50000000);
-        EXPECT_LE(tx->getInputs().size(), 1);
-        EXPECT_EQ(tx->getInputs().at(0)->getValue()->toLong(), 50000000);
-        EXPECT_EQ(tx->getOutputs().size(), 1);
-        EXPECT_EQ(tx->getOutputs().at(0)->getValue()->toLong(), 50000000);
-    }
-    { // test 3
-        EXPECT_THROW(build(100000000), Exception);
-    }
-    { // test 4
-        auto tx = build(10000000);
-        EXPECT_LE(tx->getInputs().size(), 1);
-        EXPECT_EQ(tx->getInputs().at(0)->getValue()->toLong(), 10000000);
-        EXPECT_EQ(tx->getOutputs().size(), 1);
-        EXPECT_EQ(tx->getOutputs().at(0)->getValue()->toLong(), 10000000);
-    }
-}
-
 TEST_F(CoinSelectionP2PKH, maxSpendable) {
     auto balance = uv::wait(account->getBalance());
     EXPECT_EQ(balance->toLong(), uv::wait(
@@ -177,15 +115,6 @@ TEST_F(CoinSelectionP2PKH, maxSpendable) {
     EXPECT_EQ(balance->toLong(), uv::wait(
                                      account->getMaxSpendable(api::BitcoinLikePickingStrategy::MERGE_OUTPUTS, optional<int32_t>()))
                                      ->toLong());
-    EXPECT_EQ(120000000, uv::wait(
-                             account->getMaxSpendable(api::BitcoinLikePickingStrategy::HIGHEST_FIRST_LIMIT_UTXO, optional<int32_t>(3)))
-                             ->toLong());
-    EXPECT_EQ(120000000, uv::wait(
-                             account->getMaxSpendable(api::BitcoinLikePickingStrategy::LIMIT_UTXO, optional<int32_t>(3)))
-                             ->toLong());
-    EXPECT_EQ(150000000, uv::wait(
-                             account->getMaxSpendable(api::BitcoinLikePickingStrategy::LIMIT_UTXO, optional<int32_t>(7)))
-                             ->toLong());
 }
 
 TEST_F(CoinSelectionP2PKH, PickAllUTXO) {


### PR DESCRIPTION
This PR is intended to solve VG-10452.

* FeeIsEnoughFor{P2WPKH, P2WSH, P2TR} tests
* Fix for fee calculation in `OptimizeSize` strategy
* `highest_first_limit_utxo` and `limit_utxo` strategies are removed because aren't used by WD
