### PR TITLE
Fix ripple explorer (de)serialization issues

### DIFF
--- a/core/src/wallet/ripple/explorers/NodeRippleLikeBlockchainExplorer.cpp
+++ b/core/src/wallet/ripple/explorers/NodeRippleLikeBlockchainExplorer.cpp
@@ -215,7 +215,8 @@ namespace ledger {
             bodyRequest.pushParameter("account", addresses[0]);
             bodyRequest.pushParameterBool("forward", true);
             if (fromBlockHash.hasValue() && _paginationMarker.empty()) {
-                bodyRequest.pushParameter("ledger_index_min", fromBlockHash.getValue());
+                BigInt blockHash{fromBlockHash.getValue()};
+                bodyRequest.pushParameter("ledger_index_min", blockHash.toUint64());
             }
 
             // handle transaction pagination in the case we have a pagination marker, which happens

--- a/core/src/wallet/ripple/explorers/NodeRippleLikeBlockchainExplorer.h
+++ b/core/src/wallet/ripple/explorers/NodeRippleLikeBlockchainExplorer.h
@@ -86,6 +86,16 @@ namespace ledger {
                 return *this;
             };
 
+            NodeRippleLikeBodyRequest &pushParameter(const std::string &key, uint64_t value) {
+                rapidjson::Document::AllocatorType &allocator = _document.GetAllocator();
+                rapidjson::Value vKeyParam(rapidjson::kStringType);
+                vKeyParam.SetString(key.c_str(), static_cast<rapidjson::SizeType>(key.length()), allocator);
+                rapidjson::Value vParam(rapidjson::kNumberType);
+                vParam.SetUint64(value);
+                _params.AddMember(vKeyParam, vParam, allocator);
+                return *this;
+            };
+
             NodeRippleLikeBodyRequest &pushParameterBool(const std::string &key, bool value) {
                 // TODO: C++17 group all 3 pushParameter in a single one with a if constexpr ()
                 rapidjson::Document::AllocatorType &allocator = _document.GetAllocator();

--- a/core/src/wallet/ripple/explorers/api/RippleLikeTransactionParser.cpp
+++ b/core/src/wallet/ripple/explorers/api/RippleLikeTransactionParser.cpp
@@ -161,7 +161,7 @@ namespace ledger {
                     _transaction->sender = value;
                 } else if (_lastKey == "Destination") {
                     _transaction->receiver = value;
-                } else if (_lastKey == "Amount") {
+                } else if (_lastKey == "Amount" || _lastKey == "DeliveredAmount") {
                     BigInt valueBigInt  = BigInt::fromString(value);
                     _transaction->value = valueBigInt;
                 } else if (_lastKey == "Fee") {


### PR DESCRIPTION
Fixes [VSD-2389](https://ledgerhq.atlassian.net/browse/VSD-2389) and [VSD-2405](https://ledgerhq.atlassian.net/browse/VSD-2405)

Changes: 
- `ledger_index_min` is now returned as a integer object and not a string-integer ; the synchronization fails at fetching the account transactions. Fix: change `ledger_index_min` type from string to unsigned int64 
- `Amount` attribute is missing for `AccountDelete` tx type. Fix: parse `DeliveredAmount`, which is there for this tx type instead. 

Note: I would not suggest to use `delivered_amount` which seems always returned because I don't know how the parsing would go for other tx types, e.g. if `delivered_amount` is always matching `Amount` (even if I suppose they will be always equal). 

Results:
sync successful, no error at sync, correct amount saved in db
![image](https://github.com/LedgerHQ/lib-ledger-core/assets/91121759/64aa6597-c0f4-489d-93f6-0a5e114901f2)


[VSD-2389]: https://ledgerhq.atlassian.net/browse/VSD-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VSD-2405]: https://ledgerhq.atlassian.net/browse/VSD-2405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ